### PR TITLE
[RFC] added ability to use custom persisters

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -20,15 +20,16 @@ class Fixtures
     /**
      * Loads a fixture file into an object container
      *
-     * @param string|array $file      filename, glob mask (e.g. *.yml) or array of filenames to load data from, or data array
-     * @param object       $container object container
-     * @param array        $options   available options:
-     *                                - providers: an array of additional faker providers
-     *                                - locale: the faker locale
-     *                                - seed: a seed to make sure faker generates data consistently across
-     *                                  runs, set to null to disable
+     * @param string|array $file       filename, glob mask (e.g. *.yml) or array of filenames to load data from, or data array
+     * @param object       $container  object container
+     * @param array        $options    available options:
+     *                                 - providers: an array of additional faker providers
+     *                                 - locale: the faker locale
+     *                                 - seed: a seed to make sure faker generates data consistently across
+     *                                   runs, set to null to disable
+     * @param array        $persisters custom persisters
      */
-    public static function load($files, $container, array $options = array())
+    public static function load($files, $container, array $options = array(), $persisters = array())
     {
         $defaults = array(
             'locale' => 'en_US',
@@ -38,7 +39,7 @@ class Fixtures
         $options = array_merge($defaults, $options);
 
         if ($container instanceof ObjectManager) {
-            $persister = new ORM\Doctrine($container);
+            $persister = new ORM\Doctrine($container, true, $persisters);
         } else {
             throw new \InvalidArgumentException('Unknown container type '.get_class($container));
         }

--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -115,11 +115,18 @@ class Base implements LoaderInterface
                     }
                     for ($i = $from; $i <= $to; $i++) {
                         $this->currentRangeId = $i;
-                        $objects[] = $this->createObject($class, str_replace($match[0], $i, $name), $spec);
+                        $object = $this->createObject($class, str_replace($match[0], $i, $name), $spec);
                     }
                     $this->currentRangeId = null;
                 } else {
-                    $objects[] = $this->createObject($class, $name, $spec);
+                    $object = $this->createObject($class, $name, $spec);
+                }
+
+                if (isset($object)) {
+                    $objects[] = array(
+                        'object'    => $object,
+                        'persister' => isset($spec['_persister']) ? $spec['_persister'] : null
+                    );
                 }
             }
         }
@@ -210,6 +217,10 @@ class Base implements LoaderInterface
         $obj = new $class;
         $variables = array();
         foreach ($data as $key => $val) {
+            if ('_persister' === $key) {
+                continue;
+            }
+
             if (is_array($val) && '{' === key($val)) {
                 throw new \RuntimeException('Misformatted string in object '.$name.', '.$key.'\'s value should be quoted if you used yaml.');
             }

--- a/src/Nelmio/Alice/ORM/Doctrine.php
+++ b/src/Nelmio/Alice/ORM/Doctrine.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\ORM;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\ORMInterface;
+use Nelmio\Alice\PersisterInterface;
 
 /**
  * The Doctrine persists the fixtures into an ObjectManager
@@ -21,11 +22,21 @@ class Doctrine implements ORMInterface
 {
     private $om;
     private $flush;
+    private $persisters = array();
 
-    public function __construct(ObjectManager $om, $doFlush = true)
+    public function __construct(ObjectManager $om, $doFlush = true, $persisters = array())
     {
         $this->om = $om;
         $this->flush = $doFlush;
+
+        foreach ($persisters as $name => $persister) {
+            $this->addPersister($name, $persister);
+        }
+    }
+
+    public function addPersister($name, PersisterInterface $persister)
+    {
+        $this->persisters[$name] = $persister;
     }
 
     /**
@@ -34,7 +45,11 @@ class Doctrine implements ORMInterface
     public function persist(array $objects)
     {
         foreach ($objects as $object) {
-            $this->om->persist($object);
+            if (array_key_exists($object['persister'], $this->persisters)) {
+                $this->persisters[$object['persister']]->persist($object['object']);
+            } else {
+                $this->om->persist($object['object']);
+            }
         }
 
         if ($this->flush) {

--- a/src/Nelmio/Alice/PersisterInterface.php
+++ b/src/Nelmio/Alice/PersisterInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Nelmio\Alice;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface PersisterInterface
+{
+    public function persist($object);
+}


### PR DESCRIPTION
When using the FOSUserBundle, you are required to use the `UserManager` to persist users.  This causes an issue for this library.

This solution is a little hackish but I think it gets my requirement across.
### Usage

Create a custom persister class:

``` php
class UserPersister implements PersisterInterface
{
    protected $manager;

    public function __construct(UserManager $manager)
    {
        $this->manager = $manager;
    }

    public function persist($object)
    {
        $this->manager->updateUser($object);
    }
}
```

Add `_persister` key to your fixture file:

``` yaml
MyApp\UserBundle\Entity\User:
    user0:
        username: kevin
        plainPassword: pass
        email: kevinbond@gmail.com
        enabled: true
        _persister: user
```

Load fixtures:

``` php
$userManager = $container->get('fos_user.user_manager');

$userPersister = new \MyBundle\Alice\UserPersister($userManager);

// add data fixtures
\Nelmio\Alice\Fixtures::load(array(
    $fixtureDir.'/users.yml'
    ),
    $em,
    array(),
    array('user' => $userPersister)
);
```

Thoughts?
