### PR TITLE
Add support for custom method calls

### DIFF
--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -516,6 +516,21 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testLoadCallsCustomMethodWithMultipleArguments()
+    {
+        $res = $this->loadData(array(
+            self::USER => array(
+                'user' => array(
+                    '__construct' => array('alice', 'alice@example.com'),
+                ),
+            ),
+        ));
+
+        $this->assertInstanceOf(self::USER, $this->loader->getReference('user'));
+        $this->assertSame('alice', $this->loader->getReference('user')->username);
+        $this->assertSame('alice@example.com', $this->loader->getReference('user')->email);
+    }
+
     public function testConstructorCustomProviders()
     {
         $loader = new Base('en_US', array(new FakerProvider));
@@ -528,6 +543,22 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals('foo', $res[0]->username);
+    }
+
+    public function testLoadCallsCustomMethodWithMultipleArgumentsAndCustomProviders()
+    {
+        $loader = new Base('en_US', array(new FakerProvider));
+        $res = $loader->load(array(
+            self::USER => array(
+                'user' => array(
+                    '__construct' => array('<fooGenerator()>', '<fooGenerator()>@example.com'),
+                ),
+            ),
+        ));
+
+        $this->assertInstanceOf(self::USER, $res[0]);
+        $this->assertSame('foo', $res[0]->username);
+        $this->assertSame('foo@example.com', $res[0]->email);
     }
 }
 

--- a/tests/Nelmio/Alice/fixtures/User.php
+++ b/tests/Nelmio/Alice/fixtures/User.php
@@ -10,6 +10,12 @@ class User
     public $email;
     public $favoriteNumber;
 
+    public function __construct($username = null, $email = null)
+    {
+        $this->username = $username;
+        $this->email    = $email;
+    }
+
     public function getAge()
     {
         return 25;


### PR DESCRIPTION
As we are not calling constructor automatically to initialize
objects anymore, we now need a way to call it manually with
custom arguments.

It also could be extremely useful to be able to call custom
methods (not setters) with one or many custom arguments.

This commit does exactly that. It adds support for user-defined
custom methods with custom arguments. Now, if user provides full
method name instead of field as a key, Alice will call this method
with multiple arguments provided as array value.

Example:

```
App\Entity\Contact:
    user1_contact:
        __construct: [ @user1 ]
```
