### PR TITLE
[RFC] Make work with dataset inheritances

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -108,6 +108,22 @@ class Base implements LoaderInterface
             }
         }
 
+        // apply dataset inheritance
+        foreach ($data as $class => $datasets) {
+            foreach ($datasets as $name => $dataset) {
+                $data[$class][$name] = $this->applyDatasetInheritance($datasets, $dataset);
+            }
+        }
+        
+        // unset abstract dataset
+        foreach ($data as $class => $datasets) {
+            foreach ($datasets as $name => $dataset) {
+                if (isset($dataset["@abstract"])) {
+                    unset($data[$class][$name]);
+                }
+            }
+        }
+
         $objects = array();
 
         foreach ($data as $class => $instances) {
@@ -186,6 +202,25 @@ class Base implements LoaderInterface
         }
 
         return $this->getGenerator($locale)->format($formatter, $args);
+    }
+
+    /**
+     * Applies the inheritance of datasets
+     *
+     * @param array $datasets
+     * @param array $dataset
+     *
+     * @return array new dataset with inherited data
+     */
+    private function applyDatasetInheritance($datasets, $dataset)
+    {
+        if (isset($dataset["@inherits"])) {
+            $dataset = array_merge($this->applyDatasetInheritance($datasets, $datasets[$dataset["@inherits"]]), $dataset);
+            unset($dataset["@inherits"]);
+            unset($dataset["@abstract"]);
+        }
+
+        return $dataset;
     }
 
     /**

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -697,6 +697,45 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(self::USER, $res[0]);
         $this->assertInstanceOf('DateTime', $res[0]->birthDate);
     }
+    
+    public function testApplyDatasetInheritance()
+    {
+        $loader = new Base('en_US', array(new FakerProvider));
+        $res = $loader->load(array(
+            self::USER => array(
+                'base' => array(
+                    '@abstract' => 1, 
+                    'username' => 'curtis_norris79', 
+                    'fullname' => 'Curits Norris', 
+                    'email' => 'curtis@norris.org', 
+                    'is_admin' => false, 
+                    'is_moderator' => false
+                ), 
+                'moderator' => array(
+                    '@inherits' => 'base', 
+                    'is_moderator' => true
+                ), 
+                'admin' => array(
+                    '@inherits' => 'moderator', 
+                    'is_admin' => true
+                )
+            ) 
+        ));
+        
+        $moderator = $res[0];
+        $this->assertEquals("curtis_norris79", $moderator->username);
+        $this->assertEquals("Curits Norris", $moderator->fullname);
+        $this->assertEquals("curtis@norris.org", $moderator->email);
+        $this->assertTrue($moderator->is_moderator);
+        $this->assertFalse($moderator->is_admin);
+        
+        $admin = $res[1];
+        $this->assertEquals("curtis_norris79", $admin->username);
+        $this->assertEquals("Curits Norris", $admin->fullname);
+        $this->assertEquals("curtis@norris.org", $admin->email);
+        $this->assertTrue($admin->is_moderator);
+        $this->assertTrue($admin->is_admin);
+    }
 }
 
 class FakerProvider

--- a/tests/Nelmio/Alice/fixtures/User.php
+++ b/tests/Nelmio/Alice/fixtures/User.php
@@ -9,6 +9,8 @@ class User
     public $birthDate;
     public $email;
     public $favoriteNumber;
+    public $is_moderator;
+    public $is_admin;
 
     public function __construct($username = null, $email = null, \DateTime $birthDate = null)
     {


### PR DESCRIPTION
I think, it isn't possible yet to do a data inheritance between data sets. 

Use case: 

You have an User with complex structure and you have to do a lot of duplicates for "basic" data. The solution is to create a base user data for re-usage. The other User data can inherit the data from this base data set. 

Example: 

``` yaml
User: 
    base: 
        @abstract: true
        username: <username()>
        email: <email()>
        is_admin: 0

    admin: 
        @inherits: base
        is_admin: 1
```

What do you think?
