### PR TITLE
Handle unique fields

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -125,11 +125,11 @@ class Base implements LoaderInterface
                     }
                     for ($i = $from; $i <= $to; $i++) {
                         $this->currentRangeId = $i;
-                        $objects[] = $this->createObject($class, str_replace($match[0], $i, $name), $spec, $name);
+                        $objects[] = $this->createObject($class, str_replace($match[0], $i, $name), $spec);
                     }
                     $this->currentRangeId = null;
                 } else {
-                    $objects[] = $this->createObject($class, $name, $spec, $name);
+                    $objects[] = $this->createObject($class, $name, $spec);
                 }
             }
         }
@@ -215,7 +215,7 @@ class Base implements LoaderInterface
         return $this->generators[$locale];
     }
 
-    private function createObject($class, $name, $data, $objectDescription)
+    private function createObject($class, $name, $data)
     {
         $obj = $this->createInstance($class, $name, $data);
 
@@ -242,14 +242,14 @@ class Base implements LoaderInterface
                 } else {
                     $valHash = "";
                 }
-            } while ($unique && --$i > 0 && isset($this->uniqueValues[$objectDescription . $key][$valHash]));
+            } while ($unique && --$i > 0 && isset($this->uniqueValues[$class . $key][$valHash]));
 
-            if ($unique && isset($this->uniqueValues[$objectDescription . $key][$valHash])) {
-                throw new \RuntimeException("Couldn't generate random unique value for $class: $objectDescription->$key in $uniqueTriesLimit tries.");
+            if ($unique && isset($this->uniqueValues[$class . $key][$valHash])) {
+                throw new \RuntimeException("Couldn't generate random unique value for $class: $key in $uniqueTriesLimit tries.");
             }
 
             if ($unique) {
-                $this->uniqueValues[$objectDescription . $key][$valHash] = true;
+                $this->uniqueValues[$class . $key][$valHash] = true;
             }
 
             // add relations if available

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -714,6 +714,25 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($usernames, array_unique($usernames));
     }
 
+    public function testGeneratedValuesAreUniqueAcrossAClass()
+    {
+        $loader = new Base('en_US', array(new FakerProvider));
+        $res = $loader->load(array(
+            self::USER => array(
+                'user{0..4}' => array(
+                    'username' => '<randomNumber()>!'
+                ),
+                'user{5..9}' => array(
+                    'username' => '<randomNumber()>!'
+                )
+            )
+        ));
+
+        $usernames = array_map(function (User $u) { return $u->username; }, $res);
+
+        $this->assertEquals($usernames, array_unique($usernames));
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
Hi, I implemented it in the way I proposed because there's problem with unique:func() syntax: this unique keyword can be parsed as a part of expression but we can have a several of expressions for one field (e.g. <func1()><func2()>, or even worse: it can be ternary condition).
I couldn't come up with better syntax, so I left it as it was...
