### PR TITLE
Extend keys with enums

### DIFF
--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -544,6 +544,24 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(self::USER, $this->loader->getReference('user10'));
     }
 
+    public function testLoadCreatesEnumsOfObjects()
+    {
+        $res = $this->loadData(array(
+            self::USER => array(
+                'user_{alice, bob}' => array(
+                    'username' => '<current()>',
+                    'email'    => '<current()>@gmail.com'
+                ),
+            ),
+        ));
+
+        $this->assertCount(2, $res);
+        $this->assertInstanceOf(self::USER, $this->loader->getReference('user_alice'));
+        $this->assertEquals('alice', $this->loader->getReference('user_alice')->username);
+        $this->assertInstanceOf(self::USER, $this->loader->getReference('user_bob'));
+        $this->assertEquals('bob', $this->loader->getReference('user_bob')->username);
+    }
+
     /**
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage Cannot use <current()> out of fixtures ranges


### PR DESCRIPTION
The goal is to shorten repeative definitions like

``` yaml
My\App\Entity\Currency:
    currency_eur:
        isoCode: eur
    currency_usd:
        isoCode: usd
    currency_chf:
        isoCode: chf
    currency_dkk:
        isoCode: dkk
```

... with some enum functionality in keys

``` yaml
My\App\Entity\Currency:
    currency_{eur,usd,chf,dkk}:
        isoCode: <current()>
```

... that keeps syntax declarative.

Maybe the syntax I used is not good, we need to discuss about it.
