### PR TITLE
[References] Allow to reference existing objects with non-numeric PKs

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -379,7 +379,7 @@ class Base implements LoaderInterface
             }
         }
 
-        if (is_numeric($value)) {
+        if ($hintedClass) {
             if (!$this->manager) {
                 throw new \LogicException('To reference objects by id you must first set a Nelmio\Alice\ORMInterface object on this instance');
             }


### PR DESCRIPTION
Some entities have non-numeric PK, like currency (USD,BRL..), with this fix now we can do this:

```
Acme\AcmeBundle\Entity\Payment:
    payment{1..10}:
        currency: BRL
        amount: 10
```

Thanks.
