### PR TITLE
Allow persisting only once if multiple files are loaded

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -29,6 +29,7 @@ class Fixtures
      *                                - seed: a seed to make sure faker generates data consistently across
      *                                  runs, set to null to disable
      *                                - logger: a callable or Psr\Log\LoggerInterface object that will receive progress information
+     *                                - persist_once: only persist objects once if multiple files are passsed
      */
     public static function load($files, $container, array $options = array())
     {
@@ -37,6 +38,7 @@ class Fixtures
             'providers' => array(),
             'seed' => 1,
             'logger' => null,
+            'persist_once' => false,
         );
         $options = array_merge($defaults, $options);
 
@@ -74,9 +76,16 @@ class Fixtures
 
             $loader->setORM($persister);
             $set = $loader->load($file);
-            $persister->persist($set);
+
+            if (!$options['persist_once']) {
+                $persister->persist($set);
+            }
 
             $objects = array_merge($objects, $set);
+        }
+
+        if ($options['persist_once']) {
+            $persister->persist($objects);
         }
 
         return $objects;

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -282,6 +282,24 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testMakesOnlyOneFlushWithPersistOnce()
+    {
+        $om = $this->getDoctrineManagerMock(14);
+        $objects = Fixtures::load(
+            array(
+                __DIR__.'/fixtures/part_1.yml',
+                __DIR__.'/fixtures/part_2.yml',
+            ),
+            $om,
+            array(
+                'providers' => array($this),
+                'persist_once' => true
+            )
+        );
+
+        $this->assertCount(14, $objects);
+    }
+
     protected function getDoctrineManagerMock($objects = null)
     {
         $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');

--- a/tests/Nelmio/Alice/fixtures/part_1.yml
+++ b/tests/Nelmio/Alice/fixtures/part_1.yml
@@ -1,0 +1,13 @@
+Nelmio\Alice\fixtures\User:
+    user0:
+        username: johnny
+        fullname: John Smith
+        birthDate: 1980-10-10
+        email: <email()>
+        favoriteNumber: 42
+    user{1..10}:
+        username: <username()>
+        fullname: <firstName()> <lastName()>
+        birthDate: 80%? <date> : 0000-00-00
+        email: <email()>
+        favoriteNumber: 40%? <randomNumber(1, 99)>

--- a/tests/Nelmio/Alice/fixtures/part_2.yml
+++ b/tests/Nelmio/Alice/fixtures/part_2.yml
@@ -1,0 +1,15 @@
+Nelmio\Alice\fixtures\Contact:
+    contact0:
+        __construct: [@user0]
+
+Nelmio\Alice\fixtures\Group:
+    group{0...1}:
+        name: <company()>
+        members: 20%? 3x @user*
+        owner: @user<current()>
+    group1:
+        name: <company()>
+        members: 3x @user*
+        owner: 1
+        contactPerson: @contact*->user
+        contactPersonName: <contactName($contactPerson)>


### PR DESCRIPTION
Activating this option allows setting references between multiple files and flushing only once.
