### PR TITLE
Empty generators when setting references

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -234,6 +234,7 @@ class Base implements LoaderInterface
     public function setProviders(array $providers)
     {
         $this->providers = $providers;
+        $this->emptyGenerators();
     }
 
     /**
@@ -242,6 +243,11 @@ class Base implements LoaderInterface
     public function setReferences(array $references)
     {
         $this->references = $references;
+    }
+
+    private function emptyGenerators()
+    {
+        $this->generators = array();
     }
 
     /**


### PR DESCRIPTION
I noticed that there is a problem when setting providers after a generator has already been called. This gets around this problem by emptying the cached generators when new providers are set. 

Maybe we should create a 1.5.1 tag?

Thanks.
