### PR TITLE
Add support for forward references

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -45,6 +45,11 @@ class Base implements LoaderInterface
     protected $references = array();
 
     /**
+     * @var array
+     */
+    protected $incompleteInstances = array();
+
+    /**
      * @var ORMInterface
      */
     protected $manager;
@@ -82,6 +87,11 @@ class Base implements LoaderInterface
      * @var callable|LoggerInterface
      */
     private $logger;
+
+    /**
+     * @var boolean
+     */
+    private $allowForwardReferences = false;
 
     /**
      * @param string $locale default locale to use with faker if none is
@@ -161,17 +171,30 @@ class Base implements LoaderInterface
         }
 
         // populate instances
+        $instances = array_merge($instances, $this->incompleteInstances);
+        $this->incompleteInstances = array();
         $objects = array();
+        $i = 0;
+
         foreach ($instances as $instanceData) {
             list($instance, $class, $name, $spec, $classFlags, $instanceFlags, $curValue) = $instanceData;
 
             $this->currentValue = $curValue;
-            $this->populateObject($instance, $class, $name, $spec);
-            $this->currentValue = null;
 
-            // add the object in the object store unless it's local
-            if (!isset($classFlags['local']) && !isset($instanceFlags['local'])) {
-                $objects[] = $instance;
+            try {
+                $this->populateObject($instance, $class, $name, $spec);
+                $this->currentValue = null;
+
+                // add the object in the object store unless it's local
+                if (!isset($classFlags['local']) && !isset($instanceFlags['local'])) {
+                    $objects[] = $instance;
+                }
+            } catch (MissingReferenceException $e) {
+                if (!$this->allowForwardReferences) {
+                    throw $e;
+                }
+
+                $this->incompleteInstances[] = $instanceData;
             }
         }
 
@@ -206,7 +229,7 @@ class Base implements LoaderInterface
             return $this->references[$name];
         }
 
-        throw new \UnexpectedValueException('Reference '.$name.' is not defined');
+        throw new MissingReferenceException('Reference '.$name.' is not defined');
     }
 
     /**
@@ -215,6 +238,11 @@ class Base implements LoaderInterface
     public function getReferences()
     {
         return $this->references;
+    }
+
+    public function getIncompleteInstances()
+    {
+        return $this->incompleteInstances;
     }
 
     public function fake($formatter, $locale = null, $arg = null, $arg2 = null, $arg3 = null)
@@ -537,6 +565,7 @@ class Base implements LoaderInterface
                 if (null !== $multi) {
                     throw new \UnexpectedValueException('To use multiple references you must use a mask like "'.$matches['multi'].'x @user*", otherwise you would always get only one item.');
                 }
+
                 $data = $this->getReference($matches['reference'], $property);
             }
         }
@@ -630,5 +659,10 @@ class Base implements LoaderInterface
         } elseif ($logger = $this->logger) {
             $logger($message);
         }
+    }
+
+    public function enableForwardReferences($val = true)
+    {
+        $this->allowForwardReferences = !($val === false);
     }
 }

--- a/src/Nelmio/Alice/Loader/MissingReferenceException.php
+++ b/src/Nelmio/Alice/Loader/MissingReferenceException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Nelmio\Alice\Loader;
+
+class MissingReferenceException extends \UnexpectedValueException {}

--- a/tests/Nelmio/Alice/fixtures/Category.php
+++ b/tests/Nelmio/Alice/fixtures/Category.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Nelmio\Alice\fixtures;
+
+class Category
+{
+    public $description;
+    public $lastTopic;
+
+    public function __construct($description = null, $lastTopic = null)
+    {
+        $this->description = $description;
+        $this->lastTopic = $lastTopic;
+    }
+}

--- a/tests/Nelmio/Alice/fixtures/Topic.php
+++ b/tests/Nelmio/Alice/fixtures/Topic.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Nelmio\Alice\fixtures;
+
+class Topic
+{
+    public $subject;
+    public $parentCategory;
+
+    public function __construct($subject = null, $parentCategory = null)
+    {
+        $this->subject = $subject;
+        $this->parentCategory = $parentCategory;
+    }
+}


### PR DESCRIPTION
Fixture definitions with unmet references can now be cached and added to
subsequent load operations.  This allows bidrectional references in
separate files, as well as any other situation in which there is no
well-defined linear order to load the fixture files in.

In order to not change the current default behavior from what people are
used to a flag set by `enableForwardReferences()` has been added.

Since with this on the loader no longer throws an exception on an unmet
reference, a new method `getIncompleteInstances()` has been introduced.
This can be called at the end of a fixture loading run to get
information on those fixtures that were never completed.
