### PR TITLE
Add support for forward references

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,21 @@ Since an exception will no longer be thrown on unmet references, you
 will need to call `getIncompleteInstances()` at the end of your
 fixture loading run to see if you have any such fixtures.
 
-#### Persisting of incomplete object trees ####
+### Deferred Referencing ###
+
+If a fixture references a property of a fixture defined in the same
+file, instantiation of that object will be deferred until the referred
+to object has been persisted. (The assumption is that the data you are
+trying to reference is some sort of entity id).
+
+After the first persist you could then run `Base::load()` to process
+the incomplete instances to fill in the blanks and then you can
+persist them again.
+
+If you require a more stringent definition of what fields qualify you
+may override `Base::refersToPersistedId($reference, $property, $data)`
+
+#### Persisting of Incomplete Object Trees ####
 
 When using this feature you might get an error such as:
 

--- a/src/Nelmio/Alice/Loader/MissingReferenceException.php
+++ b/src/Nelmio/Alice/Loader/MissingReferenceException.php
@@ -2,4 +2,7 @@
 
 namespace Nelmio\Alice\Loader;
 
-class MissingReferenceException extends \UnexpectedValueException {}
+class MissingReferenceException extends \UnexpectedValueException {
+    const FORWARD = 0;
+    const DEFERRED = 1;
+}

--- a/tests/Nelmio/Alice/TestORM.php
+++ b/tests/Nelmio/Alice/TestORM.php
@@ -11,18 +11,40 @@
 
 namespace Nelmio\Alice;
 
-class TestORM implements ORMinterface
+class TestORM implements ORMInterface
 {
     protected $objects;
+    protected $currentId;
 
     public function persist(array $objects)
     {
-        $this->objects = $objects;
+        foreach ($objects as $object) {
+            $this->setObjectId($object, ++$this->currentId);
+            $this->objects[] = $object;
+        }
     }
 
     public function getObjects()
     {
         return $this->objects;
+    }
+
+    protected function getObjectId($object)
+    {
+        if (property_exists($object, 'id')) {
+            return $object->id;
+        } elseif (methodExists($object, 'getId')) {
+            return $object->getId();
+        }
+    }
+
+    protected function setObjectId($object, $id)
+    {
+        if (property_exists($object, 'id')) {
+            $object->id = $id;
+        } elseif (methodExists($object, 'setId')) {
+            $object->setId($id);
+        }
     }
 
     /**
@@ -32,6 +54,12 @@ class TestORM implements ORMinterface
      */
     public function find($class, $id)
     {
+        foreach ($this->objects as $object) {
+            if ($this->getObjectId($object) == $id) {
+                return $object;
+            }
+        }
+
         return null;
     }
 }

--- a/tests/Nelmio/Alice/fixtures/Category.php
+++ b/tests/Nelmio/Alice/fixtures/Category.php
@@ -4,11 +4,13 @@ namespace Nelmio\Alice\fixtures;
 
 class Category
 {
+    public $id;
     public $description;
     public $lastTopic;
 
-    public function __construct($description = null, $lastTopic = null)
+    public function __construct($id = null, $description = null, $lastTopic = null)
     {
+        $this->id = $id;
         $this->description = $description;
         $this->lastTopic = $lastTopic;
     }

--- a/tests/Nelmio/Alice/fixtures/Topic.php
+++ b/tests/Nelmio/Alice/fixtures/Topic.php
@@ -4,12 +4,16 @@ namespace Nelmio\Alice\fixtures;
 
 class Topic
 {
+    public $id;
     public $subject;
+    public $parentTopicId;
     public $parentCategory;
 
-    public function __construct($subject = null, $parentCategory = null)
+    public function __construct($id = null, $subject = null, $parentTopicId = null, $parentCategory = null)
     {
+        $this->id = $id;
         $this->subject = $subject;
+        $this->parentTopicId = $parentTopicId;
         $this->parentCategory = $parentCategory;
     }
 }


### PR DESCRIPTION
Fixture definitions with unmet references can now be cached and added to
subsequent load operations.  This allows bidrectional references in
separate files, as well as any other situation in which there is no
well-defined linear order to load the fixture files in.

In order to not change the current default behavior from what people are
used to a flag set by `enableForwardReferences()` has been added.

Since with this on the loader no longer throws an exception on an unmet
reference, a new method `getIncompleteInstances()` has been introduced.
This can be called at the end of a fixture loading run to get
information on those fixtures that were never completed.
