### PR TITLE
Make sure a setter is public before invoking it

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -344,7 +344,13 @@ class Base implements LoaderInterface
                 $variables[$key] = $generatedVal;
             } elseif (method_exists($instance, 'set'.$key)) {
                 $generatedVal = $this->checkTypeHints($instance, 'set'.$key, $generatedVal);
-                $instance->{'set'.$key}($generatedVal);
+                if(!is_callable(array($instance, 'set'.$key))) {
+                    $refl = new \ReflectionMethod($instance, 'set'.$key);
+                    $refl->setAccessible(true);
+                    $refl->invoke($instance, $generatedVal);
+                } else {
+                    $instance->{'set'.$key}($generatedVal);
+                }
                 $variables[$key] = $generatedVal;
             } elseif (property_exists($instance, $key)) {
                 $refl = new \ReflectionProperty($instance, $key);

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -131,6 +131,20 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('group', $group->getName());
     }
 
+    public function testLoadAssignsDataToNonPublicSetters()
+    {
+        $res = $this->loadData(array(
+            self::GROUP => array(
+                'a' => array(
+                    'sortName' => 'group'
+                ),
+            ),
+        ));
+
+        $group = $res[0];
+        $this->assertEquals('group', $group->getSortName());
+    }
+
     public function testLoadAddsReferencesToAdders()
     {
         $res = $this->loadData(array(

--- a/tests/Nelmio/Alice/fixtures/Group.php
+++ b/tests/Nelmio/Alice/fixtures/Group.php
@@ -5,6 +5,7 @@ namespace Nelmio\Alice\fixtures;
 class Group
 {
     private $name;
+    private $sortName;
     private $owner;
     private $members = array();
     private $creationDate;
@@ -21,6 +22,15 @@ class Group
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function getSortName()
+    {
+        return $this->sortName;
+    }
+
+    protected function setSortName($sortName) {
+        $this->sortName = $sortName;
     }
 
     public function getOwner()


### PR DESCRIPTION
`method_exists()` doesn't say whether the method is callable in the current scope, so if a setter is `protected`/`private` it'll be called and a fatal error is raised.

This PR changes it to match the property test by making sure it's accessible first.

(The other option is to make it `method_exists($instance, 'set'.$key) && is_callable(array($instance, 'set'.$key))`, but this method allows Alice to pick up the typehinting - though you could do some reflection in the property setting block.)
