### PR TITLE
Add ability to specify a custom setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To use it in Symfony2 you may want to use the [hautelook/alice-bundle](https://g
   - [Variables](#variables)
   - [Value Objects](#value-objects)
   - [Custom Faker Data Providers](#custom-faker-data-providers)
+  - [Custom Setter](#custom-setter)
   - [Complete Sample](#complete-sample)
 
 ## Usage ##
@@ -493,6 +494,26 @@ there are two ways to solve the problem:
    ```
 
    That way you can now use `name: <groupName()>` to generate specific group names.
+
+### Custom Setter ###
+
+In case, you want to specify a custom function that will be used to set all the values,
+you can specify a `__set` value:
+
+```yaml
+Nelmio\Data\Geopoint:
+    geo1:
+        __set: customSetter
+        foo: bar
+```
+
+When the objects are populated, the `customSetter` function will be called, with the first parameter
+being the `key`, the second one being the `value` (so similar to the magic PHP setter). In the above
+example, the following call will be made on the instance when populating:
+
+```php
+$geopoint->customSetter('foo', 'bar');
+```
 
 ### Complete Sample ###
 

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -852,6 +852,43 @@ class BaseTest extends \PHPUnit_Framework_TestCase
             $this->loader->getReference('contact2')->getUser()
         );
     }
+
+    public function testCustomSetFunction()
+    {
+        $this->loadData(
+            array(
+                self::USER => array(
+                    'user' => array(
+                        'username' => 'foo',
+                        'fullname' => 'foo bar',
+                        '__set' => 'customSetter'
+                    )
+                )
+            )
+        );
+
+        $this->assertEquals('foo set by custom setter', $this->loader->getReference('user')->username);
+        $this->assertEquals('foo bar set by custom setter', $this->loader->getReference('user')->fullname);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Setter customNonexistantSetter not found in object
+     */
+    public function testCustomNonexistantSetFunction()
+    {
+        $this->loadData(
+            array(
+                self::USER => array(
+                    'user' => array(
+                        'username' => 'foo',
+                        'fullname' => 'foo bar',
+                        '__set' => 'customNonexistantSetter'
+                    )
+                )
+            )
+        );
+    }
 }
 
 class FakerProvider

--- a/tests/Nelmio/Alice/fixtures/User.php
+++ b/tests/Nelmio/Alice/fixtures/User.php
@@ -27,4 +27,9 @@ class User
     {
         $this->username = $arg;
     }
+
+    public function customSetter($key, $value)
+    {
+        $this->$key = $value . ' set by custom setter';
+    }
 }


### PR DESCRIPTION
I need the ability to specify a custom setter function to populate the object, as I am dealing with an external model that has a custom setter (`setField($key, $value, ...)`)
