### PR TITLE
Fix issue when using custom setter

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -347,6 +347,7 @@ class Base implements LoaderInterface
                 }
             } elseif (isset($customSetter)) {
                 $instance->$customSetter($key, $generatedVal);
+                $variables[$key] = $generatedVal;
             } elseif (is_array($generatedVal) && method_exists($instance, $key)) {
                 foreach ($generatedVal as $num => $param) {
                     $generatedVal[$num] = $this->checkTypeHints($instance, $key, $param, $num);

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -22,6 +22,10 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     const CONTACT = 'Nelmio\Alice\fixtures\Contact';
 
     protected $orm;
+
+    /**
+     * @var \Nelmio\Alice\Loader\Base
+     */
     protected $loader;
 
     protected function loadData(array $data, array $options = array())
@@ -913,20 +917,27 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomSetFunction()
     {
-        $this->loadData(
+        $loader = $this->createLoader(
+            array(
+                'providers' => array(new FakerProvider())
+            )
+        );
+        $loader->load(
             array(
                 self::USER => array(
                     'user' => array(
                         'username' => 'foo',
                         'fullname' => 'foo bar',
-                        '__set' => 'customSetter'
+                        '__set' => 'customSetter',
+                        'test_variable' => '<noop($username)>',
                     )
                 )
             )
         );
 
-        $this->assertEquals('foo set by custom setter', $this->loader->getReference('user')->username);
-        $this->assertEquals('foo bar set by custom setter', $this->loader->getReference('user')->fullname);
+        $this->assertEquals('foo set by custom setter', $loader->getReference('user')->username);
+        $this->assertEquals('foo bar set by custom setter', $loader->getReference('user')->fullname);
+        $this->assertEquals('foo set by custom setter', $loader->getReference('user')->test_variable);
     }
 
     /**
@@ -959,5 +970,10 @@ class FakerProvider
     public function randomNumber()
     {
         return mt_rand(0, 9);
+    }
+
+    public function noop($str)
+    {
+        return $str;
     }
 }


### PR DESCRIPTION
The problem was that the generated value was not added to the internal list
of variables. Therefore references to the variable were broken.
