### PR TITLE
support for private constructors

### DIFF
--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
@@ -20,7 +20,9 @@ class ReflectionWithoutConstructor implements MethodInterface
      */
     public function canInstantiate(Fixture $fixture)
     {
-        return !$fixture->shouldUseConstructor() && !version_compare(PHP_VERSION, '5.4', '<');
+        $reflConstruct = new \ReflectionMethod($fixture->getClass(), '__construct');
+
+        return !$reflConstruct->isPublic() || (!$fixture->shouldUseConstructor() && !version_compare(PHP_VERSION, '5.4', '<'));
     }
 
     /**

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Fixtures;
 
+use Nelmio\Alice\support\models\PrivateConstructorClass;
 use Nelmio\Alice\TestPersister;
 use Nelmio\Alice\support\models\User;
 use Nelmio\Alice\support\extensions;
@@ -97,6 +98,14 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         } catch (\UnexpectedValueException $e) {
             $this->assertEquals("{$file} cannot be parsed - no parser exists that can handle it.", $e->getMessage());
         }
+    }
+
+    public function testCreatePrivateConstructorInstance()
+    {
+        $loader = new Loader('en_US', [new FakerProvider]);
+
+        $res = $loader->load($file = __DIR__.'/../support/fixtures/private_constructs.yml');
+        $this->assertTrue($res['test1'] instanceof PrivateConstructorClass);
     }
 
     public function testLoadInvalidFile()

--- a/tests/Nelmio/Alice/support/fixtures/private_constructs.yml
+++ b/tests/Nelmio/Alice/support/fixtures/private_constructs.yml
@@ -1,0 +1,4 @@
+Nelmio\Alice\support\models\PrivateConstructorClass:
+    test1:
+      alpha: "A"
+      beta: "B"

--- a/tests/Nelmio/Alice/support/models/PrivateConstructorClass.php
+++ b/tests/Nelmio/Alice/support/models/PrivateConstructorClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nelmio\Alice\support\models;
+
+class PrivateConstructorClass
+{
+    public $alpha;
+
+    public $beta;
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
If entity has a private constructor without arguments create instance without constructor, if it has mandatory arguments throws an exception if explicit construct has been called. Tests covering those cases included, rectified some typos related to faker library too.