### PR TITLE
Allow fixtures/persist() override

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -119,7 +119,7 @@ class Fixtures
         $this->processors[] = $processor;
     }
 
-    private function persist($persister, $objects)
+    protected function persist($persister, $objects)
     {
         foreach ($this->processors as $proc) {
             foreach ($objects as $obj) {


### PR DESCRIPTION
In some case, I do not want to persist some objetcs.

The only way I found to avoid object persistance is to override `persist()` method, but it's impossible because this method is private.

Make it protected would solve this issue.
