### PR TITLE
Allow Fixtures::persist() orverride

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -119,7 +119,7 @@ class Fixtures
         $this->processors[] = $processor;
     }
 
-    private function persist($persister, $objects)
+    public function persist($persister, $objects)
     {
         foreach ($this->processors as $proc) {
             foreach ($objects as $obj) {


### PR DESCRIPTION
Sorry for opening a new PR. I did some mistake with my previous fork...

Here is my issue:

> In some case, I do not want to persist some objetcs.
> 
> The only way I found to avoid object persistance is to override persist() method, but it's impossible because this method is private.
> 
> Make it protected would solve this issue.

@tyx suggested :

> You can avoid to persist entity like this My\Fully\Qualified (local)
> 
> See https://github.com/nelmio/alice#value-objects

Well, yes `(local)` option avoid entity persistance. But, with this option, the `load` method won't return those objects. And I need those objects to perform persistance on all or some of them.

I tryed to find a solution using a processor. But it seems impossible to avoid persistance by this way.
