### PR TITLE
renamed `Nelmio\Alice\ORM\Doctrine` => `Nelmio\Alice\Persister\Doctrine`

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Psr\Log\LoggerInterface;
+use Nelmio\Alice\Persister\Doctrine as DoctrinePersister;
 
 class Fixtures
 {
@@ -62,7 +63,7 @@ class Fixtures
         $options = array_merge($this->defaultOptions, $options);
 
         if ($this->container instanceof ObjectManager) {
-            $persister = new ORM\Doctrine($this->container);
+            $persister = new DoctrinePersister($this->container);
         } else {
             throw new \InvalidArgumentException('Unknown container type '.get_class($this->container));
         }
@@ -97,7 +98,7 @@ class Fixtures
                 throw new \RuntimeException('Logger must be callable or an instance of Psr\Log\LoggerInterface.');
             }
 
-            $loader->setORM($persister);
+            $loader->setPersister($persister);
             $set = $loader->load($file);
 
             if (!$options['persist_once']) {

--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -12,7 +12,7 @@
 namespace Nelmio\Alice\Loader;
 
 use Psr\Log\LoggerInterface;
-use Nelmio\Alice\ORMInterface;
+use Nelmio\Alice\PersisterInterface;
 use Nelmio\Alice\LoaderInterface;
 use Nelmio\Alice\Fixtures\Builder;
 use Nelmio\Alice\Fixtures\Fixture;
@@ -76,7 +76,7 @@ class Base implements LoaderInterface
     protected $populator;
 
     /**
-     * @var ORMInterface
+     * @var PersisterInterface
      */
     protected $manager;
 
@@ -302,14 +302,14 @@ class Base implements LoaderInterface
     }
 
     /**
-     * public interface to set the ORM interface
+     * public interface to set the Persister interface
      *
-     * @param ORMInterface $manager
+     * @param PersisterInterface $manager
      */
-    public function setORM(ORMInterface $manager)
+    public function setPersister(PersisterInterface $manager)
     {
         $this->manager = $manager;
-        $this->typeHintChecker->setORM($manager);
+        $this->typeHintChecker->setPersister($manager);
     }
 
     /**

--- a/src/Nelmio/Alice/Persister/Doctrine.php
+++ b/src/Nelmio/Alice/Persister/Doctrine.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Nelmio\Alice\ORM;
+namespace Nelmio\Alice\Persister;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Nelmio\Alice\ORMInterface;
+use Nelmio\Alice\PersisterInterface;
 
 /**
  * The Doctrine persists the fixtures into an ObjectManager
  */
-class Doctrine implements ORMInterface
+class Doctrine implements PersisterInterface
 {
     protected $om;
     protected $flush;

--- a/src/Nelmio/Alice/PersisterInterface.php
+++ b/src/Nelmio/Alice/PersisterInterface.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\Alice;
 
-interface ORMInterface
+interface PersisterInterface
 {
     /**
      * Loads a fixture file

--- a/src/Nelmio/Alice/Util/TypeHintChecker.php
+++ b/src/Nelmio/Alice/Util/TypeHintChecker.php
@@ -11,21 +11,21 @@
 
 namespace Nelmio\Alice\Util;
 
-use Nelmio\Alice\ORMInterface;
+use Nelmio\Alice\PersisterInterface;
 
 class TypeHintChecker
 {
     /**
-     * ORMInterface
+     * PersisterInterface
      */
     protected $manager;
 
     /**
-     * public interface to set the ORM interface
+     * public interface to set the Persister interface
      *
-     * @param ORMInterface $manager
+     * @param PersisterInterface $manager
      */
-    public function setORM(ORMInterface $manager)
+    public function setPersister(PersisterInterface $manager)
     {
         $this->manager = $manager;
     }
@@ -70,7 +70,7 @@ class TypeHintChecker
 
         if ($hintedClass) {
             if (!$this->manager) {
-                throw new \LogicException('To reference objects by id you must first set a Nelmio\Alice\ORMInterface object on this instance');
+                throw new \LogicException('To reference objects by id you must first set a Nelmio\Alice\PersisterInterface object on this instance');
             }
             $value = $this->manager->find($hintedClass, $value);
         }

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -19,7 +19,7 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
 
-    public function testLoadLoadsYamlFilesAndDoctrineORM()
+    public function testLoadLoadsYamlFilesAndDoctrinePersister()
     {
         $om = $this->getDoctrineManagerMock(14);
         $objects = Fixtures::load(__DIR__.'/support/fixtures/complete.yml', $om, array('providers' => array($this)));

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\Alice\Loader;
 
-use Nelmio\Alice\TestORM;
+use Nelmio\Alice\TestPersister;
 use Nelmio\Alice\support\models\User;
 use Nelmio\Alice\support\extensions;
 
@@ -21,7 +21,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
 
-    protected $orm;
+    protected $persister;
 
     /**
      * @var \Nelmio\Alice\Loader\Base
@@ -32,7 +32,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $loader = $this->createLoader($options);
 
-        return $loader->load($data, $this->orm);
+        return $loader->load($data, $this->persister);
     }
 
     protected function createLoader(array $options = array())
@@ -43,7 +43,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         );
         $options = array_merge($defaults, $options);
 
-        $this->orm = new TestORM;
+        $this->persister = new TestPersister;
 
         return $this->loader = new Base($options['locale'], $options['providers']);
     }

--- a/tests/Nelmio/Alice/TestPersister.php
+++ b/tests/Nelmio/Alice/TestPersister.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\Alice;
 
-class TestORM implements ORMinterface
+class TestPersister implements PersisterInterface
 {
     protected $objects;
 


### PR DESCRIPTION
Same as #119 but on top of new 2.0 version.

As far as MongoDB fixtures can be runned on stock Alice without any changes of code (I have used this numerous times, and it looks like PHPCR fixtures can be applied as well) there is confusing namespace `Nelmio\Alice\ORM\Doctrine`. `ORM` part of namespace redundant there.

Or let's just rename `Nelmio\Alice\ORM\Doctrine` to something more common, like `Nelmio\Alice\Persister\Doctrine`
