### PR TITLE
Added missing `clear()` method in `Collection`

### DIFF
--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -86,6 +86,14 @@ class Collection
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function clear()
+    {
+        $this->_instances = array();
+    }
+
+    /**
      * returns an object, or a property on that object if $property is not null
      *
      * @param  string $name


### PR DESCRIPTION
There's a missing `clear` method in `Collection` object [called in `Base` loader](https://github.com/nelmio/alice/blob/master/src/Nelmio/Alice/Loader/Base.php#L174).

This pull request add it and make the library usable.
