### PR TITLE
Add parameters in fixtures files

### DIFF
--- a/src/Nelmio/Alice/Fixtures/ParameterBag.php
+++ b/src/Nelmio/Alice/Fixtures/ParameterBag.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Fixtures;
+
+class ParameterBag
+{
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @param array $parameters
+     */
+    public function __construct(array $parameters = array())
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->parameters);
+    }
+
+    /**
+     * @param string $key
+     * @return mixed|null
+     */
+    public function get($key)
+    {
+        return $this->has($key) ? $this->parameters[$key] : null;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     */
+    public function set($key, $value)
+    {
+        $this->parameters[$key] = $value;
+    }
+} 

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Fixtures\Parser\Methods;
 
+use Nelmio\Alice\Fixtures\Loader;
 use Symfony\Component\Yaml\Yaml as YamlParser;
 use UnexpectedValueException;
 
@@ -49,6 +50,7 @@ class Yaml extends Base
         }
 
         $data = $this->processIncludes($data, $file);
+        $data = $this->processParameters($data);
 
         return $data;
     }
@@ -69,6 +71,24 @@ class Yaml extends Base
         }
 
         unset($data['include']);
+
+        return $data;
+    }
+
+    /**
+     * @param $data
+     * @return mixed
+     */
+    private function processParameters($data)
+    {
+        if (isset($data['parameters']) && $this->context instanceof Loader) {
+            $parameterBag = $this->context->getParameterBag();
+            foreach ($data['parameters'] as $name => $value) {
+                $parameterBag->set($name, $value);
+            }
+        }
+
+        unset($data['parameters']);
 
         return $data;
     }

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Processor\Methods;
+
+use Nelmio\Alice\Instances\Processor\Processor;
+use Nelmio\Alice\Instances\Processor\ProcessableInterface;
+
+class Parameterized implements MethodInterface
+{
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * sets the processor to handle recursive calls
+     *
+     * @param Processor $processor
+     */
+    public function setProcessor(Processor $processor)
+    {
+        $this->processor = $processor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canProcess(ProcessableInterface $processable)
+    {
+        return is_string($processable->getValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ProcessableInterface $processable, array $variables)
+    {
+        $value = $processable->getValue();
+        $parameterBag = $this->processor->getParameterBag();
+
+        return preg_replace_callback('#<\{([a-z0-9_\.-]+)\}>#i', function ($matches) use ($parameterBag) {
+            $key = $matches[1];
+            if (!$parameterBag->has($key)) {
+                throw new \UnexpectedValueException(sprintf(
+                    'Parameter "%s" was not found',
+                    $key
+                ));
+            }
+
+            return $parameterBag->get($key);
+        }, $value);
+    }
+
+}

--- a/src/Nelmio/Alice/Instances/Processor/Processor.php
+++ b/src/Nelmio/Alice/Instances/Processor/Processor.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Instances\Processor;
 
 use InvalidArgumentException;
 use Nelmio\Alice\Instances\Collection;
+use Nelmio\Alice\Fixtures\ParameterBag;
 use Nelmio\Alice\Instances\Processor\Methods\MethodInterface;
 use Nelmio\Alice\Util\SetterInjector;
 
@@ -33,8 +34,20 @@ class Processor
      */
     private $valueForCurrent;
 
-    public function __construct(Collection $objects, array $methods)
+    /**
+     * @var \Nelmio\Alice\Fixtures\ParameterBag
+     */
+    protected $parameterBag;
+
+    /**
+     * @param Collection $objects
+     * @param array $methods
+     * @param ParameterBag $parameterBag
+     */
+    public function __construct(Collection $objects, array $methods, ParameterBag $parameterBag)
     {
+        $this->parameterBag = $parameterBag;
+
         foreach ($methods as $method) {
             if (!($method instanceof MethodInterface)) {
                 throw new InvalidArgumentException("All methods passed into Processor must implement MethodInterface.");
@@ -90,5 +103,13 @@ class Processor
         }
 
         return $value;
+    }
+
+    /**
+     * @return ParameterBag
+     */
+    public function getParameterBag()
+    {
+        return $this->parameterBag;
     }
 }

--- a/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
@@ -94,7 +94,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
                         ],
                     'shop1' =>
                         [
-                            'domain' => 'ebay.com',
+                            'domain' => '<{ebay_domain_name}>',
                         ],
                 ],
             'Nelmio\\Alice\\fixtures\\User' =>

--- a/tests/Nelmio/Alice/Instances/Populator/PopulatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Populator/PopulatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Instances\Populator;
 
+use Nelmio\Alice\Fixtures\ParameterBag;
 use Nelmio\Alice\Instances\Collection;
 use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\Instances\Processor\Processor;
@@ -35,7 +36,7 @@ class PopulatorTest extends \PHPUnit_Framework_TestCase
         $objects = isset($options['objects']) ? $options['objects'] : new Collection;
         $defaults = [
             'objects' => $objects,
-            'processor' => new Processor($objects, []),
+            'processor' => new Processor($objects, [], new ParameterBag()),
             'methods' => []
         ];
         $options = array_merge($defaults, $options);

--- a/tests/Nelmio/Alice/Instances/Processor/ProcessorTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/ProcessorTest.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Instances\Processor;
 
 use Nelmio\Alice\Instances\Collection;
+use Nelmio\Alice\Fixtures\ParameterBag;
 use Nelmio\Alice\support\extensions\CustomProcessor;
 
 class ProcessorTest extends \PHPUnit_Framework_TestCase
@@ -34,7 +35,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         ];
         $options = array_merge($defaults, $options);
 
-        return $this->processor = new Processor($this->objects = $options['objects'], $options['methods']);
+        return $this->processor = new Processor($this->objects = $options['objects'], $options['methods'], new ParameterBag());
     }
 
     /**
@@ -43,7 +44,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnlyMethodInterfacesCanBeUsedToInstantiateTheProcessor()
     {
-        $builder = new Processor(new Collection, ['CustomProcessor']);
+        $builder = new Processor(new Collection, ['CustomProcessor'], new ParameterBag());
     }
 
     public function testAddProcessor()

--- a/tests/Nelmio/Alice/support/fixtures/include.yml
+++ b/tests/Nelmio/Alice/support/fixtures/include.yml
@@ -2,6 +2,9 @@ include:
   - includes/product.yml
   - includes/file1.yml
 
+parameters:
+  ebay_domain_name: ebay.us
+
 Nelmio\Alice\fixtures\Product:
   product0:
     changed: y
@@ -13,4 +16,4 @@ Nelmio\Alice\fixtures\Product:
 
 Nelmio\Alice\fixtures\Shop:
   shop1:
-    domain: ebay.com
+    domain: <{ebay_domain_name}>


### PR DESCRIPTION
This pull request add a new feature: it allows to set parameters in fixtures files that will be replaced by there values by a new processor method.

A use case can be the following:

``` yml
parameters:
    medias_directory: /my/medias/path

Application\Sonata\MediaBundle\Entity\Media:
    media0:
        binaryContent: %medias_directory%/picture1.jpg

    media1:
        binaryContent: %medias_directory%/picture2.jpg
```
