### PR TITLE
fixture is not extending template if range set as string items

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -172,6 +172,15 @@ class Base implements LoaderInterface
                         $curSpec = $spec;
                         $curName = str_replace($match[0], $item, $name);
                         list($curName, $instanceFlags) = $this->parseFlags($curName);
+                        if (!empty($instanceFlags)) {
+                            // Reverse flag order: check templates from last to first, so that last one wins
+                            foreach (array_reverse(array_keys($instanceFlags)) as $flag) {
+                                if (preg_match('#^extends\s*(.+)$#', $flag, $match2)) {
+                                    $template = $this->getTemplate($match2[1]);
+                                    $curSpec = array_merge($template, $curSpec);
+                                }
+                            }
+                        }
                         $this->currentValue = $item;
                         $instances[$curName] = array($this->createInstance($class, $curName, $curSpec), $class, $curName, $curSpec, $classFlags, $instanceFlags, $item);
                         $this->currentValue = null;


### PR DESCRIPTION
example:

```
User:
    user (template):
        firstName: <firstName()>

    user_{first, second, third} (extends user):
        lastName: <lastName()>
```

in result `user_first`, `user_second`, `user_third` will not get first name set.
