### PR TITLE
Add $fake() closure for nested faker calls, fixes #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ Nelmio\Entity\User:
 As you see in the last line, you can also pass arguments to those just as if
 you were calling a function.
 
+To pass Faker Data to another Faker provider, you can use the `$fake()` closure
+within faker calls. For example use `$fake('firstName', 'de_DE')` or
+`$fake('numberBetween', null, 1, 200)` to call Faker. Pass the provider to call
+followed by the locale (or null) and then the arguments to the provider.
+
+In plain PHP fixtures the `$fake` closure is also available.
+
 #### Localized Fake Data ####
 
 Faker can create localized data for adresses, phone numbers and so on. You can

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,6 @@
+# Breaking changes between Alice 1.x and 2.0
+
+In php fixtures, and nested faker blocks in yml fixtures, using `$this->fake()`
+or `$loader->fake()` is no longer supported.
+
+A closure is provided so you can now use the shorter `$fake()` instead.

--- a/src/Nelmio/Alice/Fixtures/Loader.php
+++ b/src/Nelmio/Alice/Fixtures/Loader.php
@@ -324,6 +324,14 @@ class Loader
     }
 
     /**
+     * @return Processor\Methods\Faker
+     */
+    public function getFakerProcessorMethod()
+    {
+        return $this->fakerProcessorMethod;
+    }
+
+    /**
      * returns a list of all the default providers faker processing
      *
      * @return array

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\Alice\Fixtures\Parser\Methods;
 
+use Nelmio\Alice\Fixtures\Loader;
+
 abstract class Base implements MethodInterface
 {
     /**
@@ -56,11 +58,24 @@ abstract class Base implements MethodInterface
         $context = $this->context;
 
         ob_start();
-        $includeWrapper = function () use ($file, $context) {
+        $fake = $this->createFakerClosure();
+        $includeWrapper = function () use ($file, $context, $fake) {
             return include $file;
         };
         $data = $includeWrapper();
 
         return ob_get_clean();
+    }
+
+    protected function createFakerClosure()
+    {
+        if (!$this->context instanceof Loader) {
+            return;
+        }
+        $faker = $this->context->getFakerProcessorMethod();
+
+        return function () use ($faker) {
+            return call_user_func_array(array($faker, 'fake'), func_get_args());
+        };
     }
 }

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
@@ -14,7 +14,7 @@ namespace Nelmio\Alice\Fixtures\Parser\Methods;
 use UnexpectedValueException;
 
 /**
- * Each fixture has access to $context->fake() to generate data.
+ * Each fixture has access to $fake() to generate data.
  *
  * The array format must follow this example:
  *
@@ -43,7 +43,8 @@ class Php extends Base
     public function parse($file)
     {
         $context = $this->context;
-        $includeWrapper = function () use ($file, $context) {
+        $fake = $this->createFakerClosure();
+        $includeWrapper = function () use ($file, $context, $fake) {
             ob_start();
             $res = include $file;
             ob_end_clean();

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -158,17 +158,27 @@ class Faker implements MethodInterface
         $locale = var_export($matches['locale'], true);
         $name = var_export($matches['name'], true);
 
+        // enable calls to $fake() to call faker from within faker calls
+        $that = $this;
+        $fake = function () use ($that) {
+            return call_user_func_array(array($that, 'fake'), func_get_args());
+        };
+
         return eval('return $this->fake(' . $name . ', ' . $locale . ', ' . $args . ');');
     }
 
     /**
-     * returns a fake value
+     * Returns a fake value
+     *
+     * This is made public so it is accessible by the $fake() callback in replacePlaceholder
+     * and the callback in Parser\Method\Base::createFakerClosure
      *
      * @param  string $formatter
      * @param  string $locale
+     * @private
      * @return mixed
      */
-    private function fake($formatter, $locale = null)
+    public function fake($formatter, $locale = null)
     {
         $args = array_slice(func_get_args(), 2);
 

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1415,6 +1415,20 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(self::CONTACT, $res['contact']);
         $this->assertEquals('magicValue set by magic setter', $res['contact']->magicProp);
     }
+
+    public function testCallFakerFromFakerCall()
+    {
+        $loader = new Loader('en_US', array(new FakerProvider));
+
+        $res = $loader->load(__DIR__.'/../support/fixtures/nested_faker.php');
+
+        foreach (array('user1', 'user2') as $userKey) {
+            $user = $res[$userKey];
+            $this->assertInstanceOf(self::USER, $user, $userKey.' should match');
+            $this->assertEquals('JOHN DOE', $user->username, $userKey.' should match');
+            $this->assertEquals('JOHN DOE', $user->fullname, $userKey.' should match');
+        }
+    }
 }
 
 class FakerProvider
@@ -1432,5 +1446,10 @@ class FakerProvider
     public function noop($str)
     {
         return $str;
+    }
+
+    public function upperCaseProvider($arg)
+    {
+        return strtoupper($arg);
     }
 }

--- a/tests/Nelmio/Alice/support/fixtures/nested_faker.php
+++ b/tests/Nelmio/Alice/support/fixtures/nested_faker.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+    'Nelmio\Alice\support\models\User' => array(
+        'user1' => array(
+            'username' => '<identity($fake("upperCaseProvider", null, "John Doe"))>',
+            'fullname' => '<upperCaseProvider("John Doe")>',
+        ),
+        'user2' => array(
+            'username' => $fake('identity', null, $fake('upperCaseProvider', null, 'John Doe')),
+            'fullname' => $fake('upperCaseProvider', null, 'John Doe'),
+        ),
+    ),
+);


### PR DESCRIPTION
This was already sort of possible but undocumented. I cleaned it up and documented the new way in UPGADE as well.
