### PR TITLE
Remove incorrect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,14 +741,6 @@ You can add a list of processors in the load method, e.g.
 $objects = \Nelmio\Alice\Fixtures::load(__DIR__.'/fixtures.yml', $objectManager, $options, $processors);
 ```
 
-Or, you can ad them to your loader using the `addProcessor()` method, e.g.
-
-```php
-$loader = new \Nelmio\Alice\Loader\Yaml();
-$loader->addProcessor($processor);
-$objects = $loader->load(__DIR__.'/fixtures.yml');
-```
-
 ## License ##
 
 Released under the MIT License, see LICENSE.


### PR DESCRIPTION
Maybe I've missed something, but this example cannot be replicated using `Nelmio\Alice\Loader\Yaml`.
