### PR TITLE
Authorize magic __call way to populate object

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -512,6 +512,8 @@ class Base implements LoaderInterface
                 $refl->setValue($instance, $generatedVal);
 
                 $variables[$key] = $generatedVal;
+            } elseif (method_exists($instance, '__call')) {
+                $instance->{'set'.$key}($generatedVal);
             } else {
                 throw new \UnexpectedValueException('Could not determine how to assign '.$key.' to a '.$class.' object');
             }

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -17,9 +17,10 @@ use Nelmio\Alice\fixtures\User;
 
 class BaseTest extends \PHPUnit_Framework_TestCase
 {
-    const USER = 'Nelmio\Alice\fixtures\User';
-    const GROUP = 'Nelmio\Alice\fixtures\Group';
-    const CONTACT = 'Nelmio\Alice\fixtures\Contact';
+    const USER       = 'Nelmio\Alice\fixtures\User';
+    const MAGIC_USER = 'Nelmio\Alice\fixtures\MagicUser';
+    const GROUP      = 'Nelmio\Alice\fixtures\Group';
+    const CONTACT    = 'Nelmio\Alice\fixtures\Contact';
 
     protected $orm;
 
@@ -134,6 +135,20 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $group = $res['a'];
 
         $this->assertEquals('group', $group->getName());
+    }
+
+    public function testLoadAssignsDataToMagicCall()
+    {
+        $res = $this->loadData(array(
+            self::MAGIC_USER => array(
+                'a' => array(
+                    'username' => 'bob'
+                ),
+            ),
+        ));
+        $user = $res['a'];
+
+        $this->assertEquals('bob set by __call', $user->getUsername());
     }
 
     public function testLoadAssignsDataToNonPublicSetters()

--- a/tests/Nelmio/Alice/fixtures/MagicUser.php
+++ b/tests/Nelmio/Alice/fixtures/MagicUser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Nelmio\Alice\fixtures;
+
+class MagicUser
+{
+    public function __call($method, $args)
+    {
+        if (0 === strpos($method, 'set')) {
+            $property = lcfirst(substr($method, 3));
+            $this->$property = $args[0] . ' set by __call';
+            return;
+        }
+
+        if (0 === strpos($method, 'get')) {
+            $property = lcfirst(substr($method, 3));
+            return $this->$property;
+        }
+    }
+}


### PR DESCRIPTION
When populating an object, just before give up and throw the exception "Could not determine how to assign..." we did a last check: If the __call magic method is present we assume that this magic method handle the setting. 
