### PR TITLE
Add a magic __call populator

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Loader.php
+++ b/src/Nelmio/Alice/Fixtures/Loader.php
@@ -435,6 +435,7 @@ class Loader
             new Populator\Methods\ArrayDirect($typeHintChecker),
             new Populator\Methods\Direct($typeHintChecker),
             new Populator\Methods\Property(),
+            new Populator\Methods\MagicCall(),
         );
     }
 }

--- a/src/Nelmio/Alice/Instances/Populator/Methods/MagicCall.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/MagicCall.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Methods;
+
+use Nelmio\Alice\Fixtures\Fixture;
+
+class MagicCall implements MethodInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function canSet(Fixture $fixture, $object, $property, $value)
+    {
+        return method_exists($object, '__call');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set(Fixture $fixture, $object, $property, $value)
+    {
+        $setter = $this->setterFor($property);
+        $object->{$setter}($value);
+    }
+
+    /**
+     * return the name of the setter for a given property
+     *
+     * @param  string $property
+     * @return string
+     */
+    private function setterFor($property)
+    {
+        return "set{$property}";
+    }
+}

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\support\extensions;
 class LoaderTest extends \PHPUnit_Framework_TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
+    const MAGIC_USER = 'Nelmio\Alice\support\models\MagicUser';
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
 
@@ -174,6 +175,20 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $group = $res['a'];
 
         $this->assertEquals('group', $group->getSortName());
+    }
+
+    public function testLoadAssignsDataToMagicCall()
+    {
+        $res = $this->loadData(array(
+            self::MAGIC_USER => array(
+                'a' => array(
+                    'username' => 'bob'
+                ),
+            ),
+        ));
+        $user = $res['a'];
+
+        $this->assertEquals('bob set by __call', $user->getUsername());
     }
 
     public function testLoadAddsReferencesToAdders()

--- a/tests/Nelmio/Alice/support/models/MagicUser.php
+++ b/tests/Nelmio/Alice/support/models/MagicUser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Nelmio\Alice\support\models;
+
+class MagicUser
+{
+    public function __call($method, $args)
+    {
+        if (0 === strpos($method, 'set')) {
+            $property = lcfirst(substr($method, 3));
+            $this->$property = $args[0] . ' set by __call';
+            return;
+        }
+
+        if (0 === strpos($method, 'get')) {
+            $property = lcfirst(substr($method, 3));
+            return $this->$property;
+        }
+    }
+}


### PR DESCRIPTION
 If the __call magic method is present we assume that this magic method handle the setting. 

This feature will be also added on 1.x branch: https://github.com/nelmio/alice/pull/154
