### PR TITLE
greatly improve performance of buildFixtures

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Loader.php
+++ b/src/Nelmio/Alice/Fixtures/Loader.php
@@ -258,11 +258,11 @@ class Loader
         foreach ($rawData as $class => $specs) {
             $this->log('Loading '.$class);
             foreach ($specs as $name => $spec) {
-                $fixtures = array_merge($fixtures, $this->builder->build($class, $name, $spec));
+                $fixtures[] = $this->builder->build($class, $name, $spec);
             }
         }
 
-        return $fixtures;
+        return call_user_func_array('array_merge', $fixtures);
     }
 
     /**


### PR DESCRIPTION
Hi Jordi,

We encountered an issue which made Alice unusable when using a large number  (>15k) of fixtures.

The performance of `array_merge` is terrible, especially in a loop.
This change defers the merge until all the fixtures are built, which greatly improves the performance.

Cheers.
