### PR TITLE
Allow PHP fixtures to include files as well

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -78,4 +78,41 @@ abstract class Base implements MethodInterface
             return call_user_func_array([$faker, 'fake'], func_get_args());
         };
     }
+
+    /**
+     * @param  array  $data
+     * @param  string $filename
+     * @return mixed
+     */
+    protected function processIncludes($data, $filename)
+    {
+        if (isset($data['include'])) {
+            foreach ($data['include'] as $include) {
+                $includeFile = dirname($filename) . DIRECTORY_SEPARATOR . $include;
+                $includeData = $this->parse($includeFile);
+                $data = $this->mergeIncludeData($data, $includeData);
+            }
+        }
+
+        unset($data['include']);
+
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     * @param array $includeData
+     */
+    protected function mergeIncludeData($data, $includeData)
+    {
+        foreach ($includeData as $class => $fixtures) {
+            if (isset($data[$class])) {
+                $data[$class] = array_merge($fixtures, $data[$class]);
+            } else {
+                $data[$class] = $fixtures;
+            }
+        }
+
+        return $data;
+    }
 }

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
@@ -58,6 +58,8 @@ class Php extends Base
             throw new UnexpectedValueException("Included file \"{$file}\" must return an array of data");
         }
 
+        $data = $this->processIncludes($data, $file);
+
         return $data;
     }
 }

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
@@ -52,41 +52,4 @@ class Yaml extends Base
 
         return $data;
     }
-
-    /**
-     * @param  array  $data
-     * @param  string $filename
-     * @return mixed
-     */
-    private function processIncludes($data, $filename)
-    {
-        if (isset($data['include'])) {
-            foreach ($data['include'] as $include) {
-                $includeFile = dirname($filename) . DIRECTORY_SEPARATOR . $include;
-                $includeData = $this->parse($includeFile);
-                $data = $this->mergeIncludeData($data, $includeData);
-            }
-        }
-
-        unset($data['include']);
-
-        return $data;
-    }
-
-    /**
-     * @param array $data
-     * @param array $includeData
-     */
-    private function mergeIncludeData($data, $includeData)
-    {
-        foreach ($includeData as $class => $fixtures) {
-            if (isset($data[$class])) {
-                $data[$class] = array_merge($fixtures, $data[$class]);
-            } else {
-                $data[$class] = $fixtures;
-            }
-        }
-
-        return $data;
-    }
 }

--- a/tests/Nelmio/Alice/Fixtures/Parser/Methods/PhpTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Methods/PhpTest.php
@@ -55,4 +55,59 @@ class PhpTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals("Included file \"{$file}\" must return an array of data", $e->getMessage());
         }
     }
+
+    public function testIncludeFiles()
+    {
+        $data = $this->parser->parse(__DIR__.'/../../../support/fixtures/include.php');
+
+        $expectedData = array(
+            'Nelmio\\Alice\\fixtures\\Product' =>
+                array(
+                    'product_base (template)' =>
+                        array(
+                            'status' => 'in_stock',
+                            'site' => '<word()>',
+                            'changed' => 'n',
+                            'locked' => '<word()>',
+                            'cancelled' => '<word()>',
+                            'canBuy' => 'y',
+                            'package' => 'n',
+                            'price' => '<randomFloat()>',
+                            'amount' => 1,
+                            'markDeleted' => '<word()>',
+                            'paid' => 'y',
+                        ),
+                    'product1' =>
+                        array(
+                            'amount' => 45,
+                            'paid' => 'n',
+                            'user' => '@user0',
+                        ),
+                    'product0' =>
+                        array(
+                            'changed' => 'y',
+                            'user' => '@user1',
+                        ),
+                ),
+            'Nelmio\\Alice\\fixtures\\Shop' =>
+                array(
+                    'shop2' =>
+                        array(
+                            'domain' => 'amazon.com',
+                        ),
+                    'shop1' =>
+                        array(
+                            'domain' => 'ebay.com',
+                        ),
+                ),
+            'Nelmio\\Alice\\fixtures\\User' =>
+                array(
+                    'user_base (template)' =>
+                        array(
+                            'email' => '<email()>',
+                        ),
+                ),
+        );
+        $this->assertEquals($expectedData, $data);
+    }
 }

--- a/tests/Nelmio/Alice/support/fixtures/include.php
+++ b/tests/Nelmio/Alice/support/fixtures/include.php
@@ -1,0 +1,23 @@
+<?php
+return array(
+  'include' => array(
+    'includes/product.php',
+    'includes/file1.php'
+  ),
+  'Nelmio\Alice\fixtures\Product' => array(
+    'product0' => array(
+      'changed' => 'y',
+      'user' => '@user1'
+    ),
+    'product1' => array(
+      'amount' => 45,
+      'paid' => 'n',
+      'user' => '@user0',
+      )
+  ),
+  'Nelmio\Alice\fixtures\Shop' => array(
+    'shop1' => array(
+      'domain' => 'ebay.com'
+    )
+  )
+);

--- a/tests/Nelmio/Alice/support/fixtures/includes/file1.php
+++ b/tests/Nelmio/Alice/support/fixtures/includes/file1.php
@@ -1,0 +1,14 @@
+<?php
+return array(
+  'include' => array(
+    'file2.php'
+  ),
+  'Nelmio\Alice\fixtures\Shop' => array(
+    'shop1' => array(
+      'domain' => '<word()>'
+    ),
+    'shop2' => array(
+      'domain' => 'amazon.com'
+    )
+  )
+);

--- a/tests/Nelmio/Alice/support/fixtures/includes/file2.php
+++ b/tests/Nelmio/Alice/support/fixtures/includes/file2.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+  'Nelmio\Alice\fixtures\User' => array(
+    'user_base (template)' => array(
+      'email' =>  '<email()>'
+    ),
+  )
+);

--- a/tests/Nelmio/Alice/support/fixtures/includes/product.php
+++ b/tests/Nelmio/Alice/support/fixtures/includes/product.php
@@ -1,0 +1,18 @@
+<?php
+return array(
+  'Nelmio\Alice\fixtures\Product' => array(
+    'product_base (template)' => array(
+      'status' => 'in_stock',
+      'site' => '<word()>',
+      'changed' => 'n',
+      'locked' => '<word()>',
+      'cancelled' => '<word()>',
+      'canBuy' => 'y',
+      'package' => 'n',
+      'price' => '<randomFloat()>',
+      'amount' => '1',
+      'markDeleted' => '<word()>',
+      'paid' => 'y',
+    )
+  )
+);


### PR DESCRIPTION
As in the 1.x branch, the include functions are moved from YAML to Base.

IMO parse should be a `TemplateMethod` that calls `processIncludes()` and that provides hooks for manipulating data from the file, but I can't do it right now.
