### PR TITLE
Allow arrays parameters

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
@@ -50,7 +50,11 @@ class Parameterized implements MethodInterface
                 ));
             }
 
-            return $this->parameters->get($key);
+            if (is_array($value = $this->parameters->get($key))) {
+                return var_export($value, true);
+            }
+
+            return $value;
         }, $value);
     }
 }

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1502,6 +1502,38 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('user_alice', $user1->username);
     }
 
+    public function testArrayParametersAreReplaced()
+    {
+        $res = $this->loadData([
+            self::USER => [
+                'user{1..5}' => [
+                    'username' => '<randomElement(<{usernames}>)>',
+                ],
+            ],
+        ], [
+            'parameters' => [
+                'usernames' => $usernames = ['Alice', 'Bob', 'Ogi'],
+            ]
+        ]);
+
+        $this->assertCount(5, $res);
+        foreach ($this->loader->getReferences() as $user) {
+            $this->assertInstanceOf(self::USER, $user);
+            $this->assertContains($user->username, $usernames);
+        }
+    }
+
+    public function testYamlArrayParametersAreProperlyInterpreted()
+    {
+        $res = $this->createLoader()->load(__DIR__ . '/../support/fixtures/array_parameters.yml');
+
+        $this->assertCount(5, $res);
+        foreach ($this->loader->getReferences() as $user) {
+            $this->assertInstanceOf(self::USER, $user);
+            $this->assertContains($user->username, ['Alice', 'Bob', 'Ogi']);
+        }
+    }
+
     public function testBackslashes()
     {
         $loader = new Loader();

--- a/tests/Nelmio/Alice/support/fixtures/array_parameters.yml
+++ b/tests/Nelmio/Alice/support/fixtures/array_parameters.yml
@@ -1,0 +1,6 @@
+parameters:
+    usernames: ['Alice', 'Bob', 'Ogi']
+
+Nelmio\Alice\support\models\User:
+    user{1..5}:
+        username: <randomElement(<{usernames}>)>


### PR DESCRIPTION
This allow to have array parameters. For instance:

```php
#fixtures.yml
parameters:
    usernames: ['Alice', 'Bob', 'Ryan']

Nelmio\Entity\User:
    user{1..50}:
        username: <randomElement(<{usernames}>)>
````

and associative arrays:
```php
parameters: 
    config: { host: localhost, port: 4567 }
```

Without this change, you'll get an `Array to string conversion` error:

However, note that it is already doable by enforcing the yaml array to be interpreted as a string:
```php
parameters:
    usernames: "['Alice', 'Bob', 'Ryan']"
```