### PR TITLE
Add KNPLabs/rad-fixtures-load to Symfony2 integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is installable via [Composer](https://getcomposer.org/) as [nelmio/alice](h
 
     composer require nelmio/alice
 
-To use it in Symfony2 you may want to use the [hautelook/alice-bundle](https://github.com/hautelook/AliceBundle) or [h4cc/alice-fixtures-bundle](https://github.com/h4cc/AliceFixturesBundle) package instead.
+To use it in Symfony2 you may want to use the [hautelook/alice-bundle](https://github.com/hautelook/AliceBundle), [h4cc/alice-fixtures-bundle](https://github.com/h4cc/AliceFixturesBundle) or [knplabs/rad-fixtures-load](https://github.com/KnpLabs/rad-fixtures-load) package instead.
 
 ## Table of Contents
 


### PR DESCRIPTION
Hello guys.
Just a little add to the documentation to promote my [Symfony2 integration](https://github.com/KnpLabs/rad-fixtures-load) of your awesome library.
It's a configuration-less integration, let's try !