### PR TITLE
Add provider when no generators

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -31,7 +31,7 @@ class Faker implements MethodInterface
     /**
      * @var \Faker\Generator[]
      */
-    private $generators;
+    private $generators = [];
 
     /**
      * Default locale to use with faker
@@ -54,7 +54,7 @@ class Faker implements MethodInterface
     /**
      * sets the object collection to handle referential calls
      *
-     * @param Collection
+     * @param Collection $objects
      */
     public function setObjects(Collection $objects)
     {

--- a/tests/Nelmio/Alice/Instances/Processor/Methods/FakerTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/Methods/FakerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Processor\Methods;
+
+use Nelmio\Alice\FooProvider;
+
+class FakerTest extends \PHPUnit_Framework_TestCase
+{
+    const USER = 'Nelmio\Alice\support\models\User';
+    const MAGIC_USER = 'Nelmio\Alice\support\models\MagicUser';
+    const GROUP = 'Nelmio\Alice\support\models\Group';
+    const CONTACT = 'Nelmio\Alice\support\models\Contact';
+
+    protected $persister;
+
+    /**
+     * @var \Nelmio\Alice\Fixtures\Loader
+     */
+    protected $loader;
+
+    public function testAddProvider()
+    {
+        $faker = new Faker([]);
+        $faker->addProvider(new FooProvider());
+    }
+}


### PR DESCRIPTION
As of now if we retrieve a fresh instance of `Nelmio\Alice\Instances\Processor\Methods\Faker` and call `::addProvider()`, [this foreach block](https://github.com/nelmio/alice/blob/master/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php#L97-L99) will throw an error as `$this->generators` is still `null`.