### PR TITLE
Fixing error when the parameter is got by func_get_args

### DIFF
--- a/src/Nelmio/Alice/Util/TypeHintChecker.php
+++ b/src/Nelmio/Alice/Util/TypeHintChecker.php
@@ -50,7 +50,7 @@ class TypeHintChecker
         $reflection = new \ReflectionMethod($obj, $method);
         $params = $reflection->getParameters();
 
-        if (!$params[$pNum]->getClass()) {
+        if (!isset($params[$pNum]) || !$params[$pNum]->getClass()) {
             return $value;
         }
 


### PR DESCRIPTION
When I have:

```yml
MyNameSpace\Object (local):
    obj1:
        __construct: ['val']
```

And My Object is:

```php
<?php

namespace MyNameSpace;

class Object
{
    public function __construct()
    {
        $args = func_get_args();
        // do something
    }
}
```

I got error: Notice: Undefined offset: 0 (Symfony\Component\Debug\Exception\ContextErrorException)

With this patch this behavior will be fixed.