### PR TITLE
Allow builders to be added through options array

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -30,6 +30,7 @@ class Fixtures
         $defaults = [
             'locale' => 'en_US',
             'providers' => [],
+            'builders' => [],
             'seed' => 1,
             'logger' => null,
             'persist_once' => false,
@@ -175,6 +176,11 @@ class Fixtures
         $loaderKey = self::generateLoaderKey($options);
         if (!isset(self::$loaders[$loaderKey])) {
             self::$loaders[$loaderKey] = new Loader($options['locale'], $options['providers'], $options['seed']);
+            if ($options['builders']) {
+                foreach ($options['builders'] as $builder) {
+                    self::$loaders[$loaderKey]->addBuilder($builder);
+                }
+            }
         }
 
         return self::$loaders[$loaderKey];


### PR DESCRIPTION
Like `providers`, it would be neat to have `builders` configurable through the `$options` argument:

```php
$options = [
    'locale' => $locale,
    'logger' => $this->container->get('logger'),
    'providers' => [new CustomProvider()],
    'builders' => [new CustomBuilder()], // new option
];
```

I needed this to implement my own name flag (`uses...`) which allows me to update an already persisted fixture with new data:
```yaml
  # default (dutch) article
  article_hello_world_nl:
    title: Hallo wereld!
    subtitle: Dit is je eerste artikel!
    body: Wat een lekker weertje vandaag, nietwaar?

  # english version of the article (requires same object to modify only a few properties)
  article_hello_world_en (local, uses article_hello_world_nl):
    title: Hello world!
    subtitle: This is your first article!
    body: What a lovely weather today, isn't it?
    translatableLocale: en
```

This approach (updating an existing entity) is required to work with the `Translatable` doctrine extension, as described here: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/translatable.md#basic-usage-examples.

I won't go into the details of my builder as it's not really related to this change; I just hope you will be willing to merge this so others can make use of this as well.