### PR TITLE
Minor typo fix

### DIFF
--- a/doc/customizing-data-generation.md
+++ b/doc/customizing-data-generation.md
@@ -109,20 +109,20 @@ use Nelmio\Alice\Fixtures;
 
 class LoadFixtureData implements FixtureInterface
 {
-   public function load(ObjectManager $om)
+   public function load(ObjectManager $manager)
    {
        // pass $this as an additional faker provider to make the "groupName"
        // method available as a data provider
-       Fixtures::load(__DIR__.'/fixtures.yml', $om, array('providers' => array($this)));
+       Fixtures::load(__DIR__.'/fixtures.yml', $manager, ['providers' => [$this]]);
    }
 
    public function groupName()
    {
-       $names = array(
+       $names = [
            'Group A',
            'Group B',
            'Group C',
-       );
+       ];
 
        return $names[array_rand($names)];
    }


### PR DESCRIPTION
* use `$manager` instead of `$om`
* use short array notation (available since PHP 5.4 and some other example in the doc was with the short array notation)