### PR TITLE
Fix container exception

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/MethodInterface.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/MethodInterface.php
@@ -16,7 +16,7 @@ use Nelmio\Alice\Instances\Processor\ProcessableInterface;
 interface MethodInterface
 {
     /**
-     * returns true if this method can process the given value container
+     * returns true if this method can process the given value persister
      *
      * @param ProcessableInterface
      * @return boolean

--- a/src/Nelmio/Alice/Instances/Processor/Processor.php
+++ b/src/Nelmio/Alice/Instances/Processor/Processor.php
@@ -66,7 +66,7 @@ class Processor
     /**
      * processes a given value to return a value that can be set on the actual instance
      *
-     * @param  mixed  $valueOrProcessable - the original value (or value container) to be converted
+     * @param  mixed  $valueOrProcessable - the original value (or value persister) to be converted
      * @param  array  $variables
      * @param  string $valueForCurrent    - in the event a fixture will need to support <current()>, this value must be passed in at the top of the process loop
      * @return mixed

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -99,20 +99,7 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
                 'seed'      => 1,
                 'providers' => [
                     'Nelmio\Alice\FooProvider'
-                ],
-                'fixtures' => [
-                    self::USER => [
-                        'user1' => [
-                            'username' => 'johnny',
-                            'favoriteNumber' => 42,
-                        ],
-                    ],
-                    self::GROUP => [
-                        'group1' => [
-                            'owner' => 1
-                        ],
-                    ],
-                ],
+                ]
             ],
             // check various combinations of options (non-exhaustive)
             [
@@ -144,22 +131,6 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
             [
                 'locale'    => 'ru_RU',
                 'seed'      => null,
-            ],
-            [
-                'locale'    => 'de_DE',
-                'fixtures' => [
-                    self::USER => [
-                        'user1' => [
-                            'username' => 'johnny',
-                            'favoriteNumber' => 42,
-                        ],
-                    ],
-                    self::GROUP => [
-                        'group1' => [
-                            'owner' => 1
-                        ],
-                    ],
-                ],
             ],
             [
                 'locale'    => 'de_DE',
@@ -288,9 +259,17 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
     {
         $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
 
-        $objects = Fixtures::load(__DIR__.'/support/fixtures/basic.php', $om, [
-            'logger' => 'not callable'
+        Fixtures::load(__DIR__.'/support/fixtures/basic.php', $om, [
+            'logger' => function () {}
         ]);
+
+        try {
+            Fixtures::load(__DIR__.'/support/fixtures/basic.php', $om, [
+                'logger' => 'not callable'
+            ]);
+        } catch (\RuntimeException $exception) {
+            // Expected result
+        }
     }
 
     public function testMakesOnlyOneFlushWithPersistOnce()


### PR DESCRIPTION
When using another persister than `Doctrine\Common\Persistence\ObjectManager`, we get the exception bits `\InvalidArgumentException('Unknown container type '.get_class($this->container))`. It's really weird to have that when we have a `PersisterInterface` especially if under the hook there is not other support than the `ObjectManager`.

So instead, we can require the `persister` to implement the `PersisterInterface` and for not introducing any BC break (in the interface) keep accepting the `ObjectManager` in the `::load()` method. This way, if we happen to have another persister, we can implement our own bridge.

On the way I renamed `container` to `persister` as is was already a bit unclear and now would be inconsistent.