### PR TITLE
Fix logger setting

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -133,6 +133,10 @@ class Fixtures
         foreach ($files as $file) {
             $loader = self::getLoader($options);
 
+            if (isset($options['logger'])) {
+                $loader->setLogger($options['logger']);
+            }
+
             $loader->setPersister($this->persister);
             $set = $loader->load($file);
 


### PR DESCRIPTION
Since https://github.com/nelmio/alice/commit/a2cb638c1a29d9335a46b779c5d77dbd9d7f00a6 the logger of the loader is not set from the `Fixtures` class.