### PR TITLE
Use preg_grep to match collection instances by mask

### DIFF
--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -134,12 +134,12 @@ class Collection
             return [];
         }
 
-        $availableObjects = [];
-        foreach ($this->instances as $name => $instance) {
-            if (preg_match('{^'.str_replace('*', '.+', $mask).'$}', $name)) {
-                $availableObjects[] = $name;
-            }
-        }
+        $availableObjects = array_values(
+            preg_grep(
+                '{^'.str_replace('*', '.+', $mask).'$}',
+                array_keys($this->instances)
+            )
+        );
 
         if (!$availableObjects) {
             throw new \UnexpectedValueException('Instance mask "'.$mask.'" did not match any existing instance, make sure the object is created after its references');


### PR DESCRIPTION
*preg_grep* is much more faster alternative than iterating collection and applying *preg_match* on every instance array key.
I've used this script to random method performance  - https://gist.github.com/munkie/1d06214d8eaa2af349c1
Performance boost was upto 3-4x times with 1000 and 10000 items counts.



 