### PR TITLE
Add ProcessableInterface::getMatches

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -115,7 +115,7 @@ class Faker implements MethodInterface
     {
         $fakerRegex = '<(?:(?<locale>[a-z]+(?:_[a-z]+)?):)?(?<name>[a-z0-9_]+?)?\((?<args>(?:[^)]*|\)(?!>))*)\)>';
         if ($processable->valueMatches('#^'.$fakerRegex.'$#i')) {
-            return $this->replacePlaceholder($processable->matches, $variables);
+            return $this->replacePlaceholder($processable->getMatches(), $variables);
         } else {
             // format placeholders inline
             return preg_replace_callback('#'.$fakerRegex.'#i', function ($matches) use ($variables) {

--- a/src/Nelmio/Alice/Instances/Processor/Processable.php
+++ b/src/Nelmio/Alice/Instances/Processor/Processable.php
@@ -61,4 +61,12 @@ class Processable implements ProcessableInterface
 
         return null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMatches()
+    {
+        return $this->matches;
+    }
 }

--- a/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
+++ b/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
@@ -33,4 +33,11 @@ interface ProcessableInterface
      * @return string
      */
     public function getMatch($name);
+
+    /**
+     * return all matches
+     *
+     * @return array|string[]
+     */
+    public function getMatches();
 }

--- a/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
+++ b/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
@@ -37,7 +37,7 @@ interface ProcessableInterface
     /**
      * return all matches
      *
-     * @return array|string[]
+     * @return string[]
      */
     public function getMatches();
 }


### PR DESCRIPTION
_Faker::process_ method expects $processable to be _ProcessableInterface_, but uses not-existing property _matches_. To solve this issue i've added getMatches method to ProcessableInterface interface.