### PR TITLE
Fix incorrect docblock var and return types

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -159,7 +159,7 @@ class Fixtures
         $this->processors[] = $processor;
     }
 
-    protected function persist($persister, $objects)
+    protected function persist(PersisterInterface $persister, $objects)
     {
         foreach ($this->processors as $proc) {
             foreach ($objects as $obj) {

--- a/src/Nelmio/Alice/Fixtures/Builder/Builder.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Builder.php
@@ -13,12 +13,13 @@ namespace Nelmio\Alice\Fixtures\Builder;
 
 use InvalidArgumentException;
 use Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface;
+use Nelmio\Alice\Fixtures\Fixture;
 
 class Builder
 {
     /**
-     * @var array
-     **/
+     * @var MethodInterface[]
+     */
     protected $methods;
 
     /**
@@ -26,6 +27,9 @@ class Builder
      */
     protected $templates;
 
+    /**
+     * @param MethodInterface[] $methods
+     */
     public function __construct(array $methods)
     {
         foreach ($methods as $method) {
@@ -51,7 +55,10 @@ class Builder
     /**
      * builds a single fixture from a "raw" definition
      *
-     * @param array $rawData
+     * @param  string    $class
+     * @param  string    $name
+     * @param  array     $spec
+     * @return Fixture[]
      */
     public function build($class, $name, array $spec)
     {

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/MethodInterface.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/MethodInterface.php
@@ -11,23 +11,25 @@
 
 namespace Nelmio\Alice\Fixtures\Builder\Methods;
 
+use Nelmio\Alice\Fixtures\Fixture;
+
 interface MethodInterface
 {
     /**
      * tests whether this class can build an fixture with the given name
      *
-     * @param  string  $name
-     * @return boolean
+     * @param  string $name
+     * @return bool
      */
     public function canBuild($name);
 
     /**
      * builds an fixture from the given class, name, and spec
      *
-     * @param  string $class
-     * @param  string $name
-     * @param  array  $spec
-     * @return array
+     * @param  string    $class
+     * @param  string    $name
+     * @param  array     $spec
+     * @return Fixture[]
      */
     public function build($class, $name, array $spec);
 }

--- a/src/Nelmio/Alice/Fixtures/Fixture.php
+++ b/src/Nelmio/Alice/Fixtures/Fixture.php
@@ -31,7 +31,7 @@ class Fixture
     protected $spec;
 
     /**
-     * @var array
+     * @var PropertyDefinition[]
      */
     protected $properties;
 
@@ -164,11 +164,16 @@ class Fixture
     /**
      * returns the list of properties with the complex properties (__construct, __set, etc) filtered out
      *
-     * @return array
+     * @return PropertyDefinition[]
      */
     public function getProperties()
     {
-        return array_filter($this->properties, function ($property) { return $property->isBasic(); });
+        return array_filter(
+            $this->properties,
+            function (PropertyDefinition $property) {
+                return $property->isBasic();
+            }
+        );
     }
 
     /**
@@ -184,7 +189,8 @@ class Fixture
     /**
      * returns true if this fixture has the given class flag
      *
-     * @return boolean
+     * @param  string $flag
+     * @return bool
      */
     public function hasClassFlag($flag)
     {
@@ -204,7 +210,8 @@ class Fixture
     /**
      * returns true if this fixture has the given name flag
      *
-     * @return boolean
+     * @param  string $flag
+     * @return bool
      */
     public function hasNameFlag($flag)
     {
@@ -266,7 +273,7 @@ class Fixture
     /**
      * returns the name of the method to use as the custom setter
      *
-     * @return string
+     * @return PropertyDefinition
      */
     public function getCustomSetter()
     {
@@ -287,7 +294,8 @@ class Fixture
     /**
      * returns the value of a property that has been registered as set
      *
-     * @return mixed $value
+     * @param  string $property
+     * @return mixed
      */
     public function getPropertyValue($property)
     {
@@ -315,8 +323,9 @@ class Fixture
     /**
      * creates and adds a PropertyDefinition to the fixture with the given name and value
      *
-     * @param string $name
-     * @param mixed  $value
+     * @param  string             $name
+     * @param  mixed              $value
+     * @return PropertyDefinition
      */
     protected function addProperty($name, $value)
     {

--- a/src/Nelmio/Alice/Fixtures/Loader.php
+++ b/src/Nelmio/Alice/Fixtures/Loader.php
@@ -11,16 +11,15 @@
 
 namespace Nelmio\Alice\Fixtures;
 
-use Nelmio\Alice\Instances\Processor\Methods\Faker;
-use Nelmio\Alice\Fixtures\ParameterBag;
-use Psr\Log\LoggerInterface;
-use Nelmio\Alice\PersisterInterface;
 use Nelmio\Alice\Instances\Collection;
 use Nelmio\Alice\Instances\Instantiator;
 use Nelmio\Alice\Instances\Populator;
 use Nelmio\Alice\Instances\Processor;
+use Nelmio\Alice\Instances\Processor\Methods\Faker;
 use Nelmio\Alice\Instances\Processor\Providers\IdentityProvider;
+use Nelmio\Alice\PersisterInterface;
 use Nelmio\Alice\Util\TypeHintChecker;
+use Psr\Log\LoggerInterface;
 
 /**
  * Loads fixtures from an array or file
@@ -38,12 +37,17 @@ class Loader
     protected $typeHintChecker;
 
     /**
-     * @var Parser
+     * @var Processor\Processor
+     */
+    protected $processor;
+
+    /**
+     * @var Parser\Parser
      **/
     protected $parser;
 
     /**
-     * @var Builder
+     * @var Builder\Builder
      */
     protected $builder;
 
@@ -53,12 +57,12 @@ class Loader
     protected $fakerProcessorMethod;
 
     /**
-     * @var Instantiator
+     * @var Instantiator\Instantiator
      */
     protected $instantiator;
 
     /**
-     * @var Populator
+     * @var Populator\Populator
      */
     protected $populator;
 
@@ -68,7 +72,7 @@ class Loader
     protected $manager;
 
     /**
-     * @var \Nelmio\Alice\Fixtures\ParameterBag
+     * @var ParameterBag
      */
     protected $parameterBag;
 
@@ -125,7 +129,8 @@ class Loader
     /**
      * Loads a fixture file
      *
-     * @param string|array $dataOrFilename data array or filename
+     * @param  string|array $dataOrFilename data array or filename
+     * @return object[]
      */
     public function load($dataOrFilename)
     {
@@ -157,7 +162,7 @@ class Loader
     /**
      * Returns all references created by the loader
      *
-     * @return array[object]
+     * @return object[]
      */
     public function getReferences()
     {
@@ -181,12 +186,14 @@ class Loader
     }
 
     /**
-     * @param array $references
+     * References are objects which the loader is aware of while loading fixtures.
+     *
+     * @param object[] $references Array of object where the key is the name of the reference
      */
-    public function setReferences(array $objects)
+    public function setReferences(array $references)
     {
         $this->objects->clear();
-        foreach ($objects as $name => $object) {
+        foreach ($references as $name => $object) {
             $this->objects->set($name, $object);
         }
     }
@@ -244,8 +251,8 @@ class Loader
     /**
      * parses a file at the given filename
      *
-     * @param string filename
-     * @return array data
+     * @param  string $filename
+     * @return array  data
      */
     protected function parseFile($filename)
     {
@@ -255,8 +262,8 @@ class Loader
     /**
      * builds a collection of fixtures
      *
-     * @param  array $rawData
-     * @return array
+     * @param  array     $rawData
+     * @return Fixture[]
      */
     protected function buildFixtures(array $rawData)
     {
@@ -275,7 +282,7 @@ class Loader
     /**
      * creates an empty instance for each fixture, and adds it to our object collection
      *
-     * @param array $fixtures
+     * @param Fixture[] $fixtures
      */
     protected function instantiateFixtures(array $fixtures)
     {
@@ -290,8 +297,8 @@ class Loader
     /**
      * hydrates each instance described by fixtures and returns the final non-local list
      *
-     * @param  array $fixtures
-     * @return array
+     * @param  Fixture[] $fixtures
+     * @return object[]  List of object created
      */
     protected function populateObjects(array $fixtures)
     {

--- a/src/Nelmio/Alice/Fixtures/ParameterBag.php
+++ b/src/Nelmio/Alice/Fixtures/ParameterBag.php
@@ -45,7 +45,8 @@ class ParameterBag
     }
 
     /**
-     * @param mixed $value
+     * @param string $key
+     * @param mixed  $value
      */
     public function set($key, $value)
     {

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -67,6 +67,9 @@ abstract class Base implements MethodInterface
         return ob_get_clean();
     }
 
+    /**
+     * @return \Closure|void
+     */
     protected function createFakerClosure()
     {
         if (!$this->context instanceof Loader) {
@@ -100,8 +103,8 @@ abstract class Base implements MethodInterface
     }
 
     /**
-     * @param array $data
-     * @param array $includeData
+     * @param  array $data
+     * @param  array $includeData
      * @return array
      */
     protected function mergeIncludeData($data, $includeData)

--- a/src/Nelmio/Alice/Fixtures/Parser/Parser.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Parser.php
@@ -19,10 +19,15 @@ use Nelmio\Alice\Fixtures\Parser\Methods\MethodInterface;
 class Parser
 {
     /**
-     * @var array
-     **/
+     * @var MethodInterface[]
+     */
     private $parsers = [];
 
+    /**
+     * Parser constructor.
+     *
+     * @param MethodInterface[] $parsers
+     */
     public function __construct(array $parsers)
     {
         foreach ($parsers as $parser) {

--- a/src/Nelmio/Alice/Instances/Instantiator/Instantiator.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Instantiator.php
@@ -18,10 +18,13 @@ use Nelmio\Alice\Instances\Instantiator\Methods\MethodInterface;
 class Instantiator
 {
     /**
-     * @var array
+     * @var MethodInterface[]
      **/
     protected $methods;
 
+    /**
+     * @param MethodInterface[] $methods
+     */
     public function __construct(array $methods)
     {
         foreach ($methods as $method) {

--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/MethodInterface.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/MethodInterface.php
@@ -18,16 +18,16 @@ interface MethodInterface
     /**
      * returns true if this method can instantiate the object described in the fixture
      *
-     * @param Fixture
-     * @return boolean
+     * @param  Fixture $fixture
+     * @return bool
      */
     public function canInstantiate(Fixture $fixture);
 
     /**
      * returns an empty instance of the class the fixture describes
      *
-     * @param Fixture
-     * @return mixed
+     * @param  Fixture $fixture
+     * @return object
      */
     public function instantiate(Fixture $fixture);
 }

--- a/src/Nelmio/Alice/Instances/Populator/Methods/ArrayAdd.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/ArrayAdd.php
@@ -52,8 +52,9 @@ class ArrayAdd implements MethodInterface
     /**
      * finds the method used to append values to the named property
      *
-     * @param mixed  $object
-     * @param string $property
+     * @param  mixed  $object
+     * @param  string $property
+     * @return string Method name or null if adder method not detected
      */
     private function findAdderMethod($object, $property)
     {

--- a/src/Nelmio/Alice/Instances/Populator/Populator.php
+++ b/src/Nelmio/Alice/Instances/Populator/Populator.php
@@ -31,10 +31,20 @@ class Populator
     protected $processor;
 
     /**
+     * @var Methods\MethodInterface[]
+     */
+    protected $setters;
+
+    /**
      * @var array
      */
     private $uniqueValues = [];
 
+    /**
+     * @param Collection        $objects
+     * @param Processor         $processor
+     * @param MethodInterface[] $setters
+     */
     public function __construct(Collection $objects, Processor $processor, array $setters)
     {
         foreach ($setters as $setter) {

--- a/src/Nelmio/Alice/Instances/Processor/Methods/ArrayValue.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/ArrayValue.php
@@ -24,7 +24,7 @@ class ArrayValue implements MethodInterface
     /**
      * sets the processor to handle recursive calls
      *
-     * @param Processor
+     * @param Processor $processor
      */
     public function setProcessor(Processor $processor)
     {
@@ -44,6 +44,7 @@ class ArrayValue implements MethodInterface
      */
     public function process(ProcessableInterface $processable, array $variables)
     {
+        /* @var array $values */
         $values = $processable->getValue();
         foreach ($values as $key => $value) {
             $values[$key] = $this->processor->process($value, $variables);

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Conditional.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Conditional.php
@@ -24,7 +24,7 @@ class Conditional implements MethodInterface
     /**
      * sets the processor to handle recursive calls
      *
-     * @param Processor
+     * @param Processor $processor
      */
     public function setProcessor(Processor $processor)
     {
@@ -58,8 +58,8 @@ class Conditional implements MethodInterface
     /**
      * compares the threshold to a randomly generated value to determine whether
      *
-     * @param ProcessableInterface $processable
-     * @return
+     * @param  ProcessableInterface $processable
+     * @return bool
      */
     private function shouldReturnTrue(ProcessableInterface $processable)
     {

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Instances\Processor\Methods;
 
 use Nelmio\Alice\Instances\Collection;
 use Nelmio\Alice\Instances\Processor\ProcessableInterface;
+use Faker\Factory;
 
 class Faker implements MethodInterface
 {
@@ -221,7 +222,7 @@ class Faker implements MethodInterface
         $locale = $locale ?: $this->defaultLocale;
 
         if (!isset($this->generators[$locale])) {
-            $generator = \Faker\Factory::create($locale);
+            $generator = Factory::create($locale);
             foreach ($this->providers as $provider) {
                 $generator->addProvider($provider);
             }

--- a/src/Nelmio/Alice/Instances/Processor/Methods/MethodInterface.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/MethodInterface.php
@@ -18,15 +18,15 @@ interface MethodInterface
     /**
      * returns true if this method can process the given value persister
      *
-     * @param ProcessableInterface
-     * @return boolean
+     * @param  ProcessableInterface $processable
+     * @return bool
      */
     public function canProcess(ProcessableInterface $processable);
 
     /**
      * returns the processed value
      *
-     * @param ProcessableInterface
+     * @param ProcessableInterface $processable
      * @param array
      * @return mixed
      */

--- a/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
+++ b/src/Nelmio/Alice/Instances/Processor/ProcessableInterface.php
@@ -14,8 +14,8 @@ namespace Nelmio\Alice\Instances\Processor;
 interface ProcessableInterface
 {
     /**
-     * @return string
-     **/
+     * @return mixed
+     */
     public function getValue();
 
     /**

--- a/src/Nelmio/Alice/PersisterInterface.php
+++ b/src/Nelmio/Alice/PersisterInterface.php
@@ -16,7 +16,7 @@ interface PersisterInterface
     /**
      * Loads a fixture file
      *
-     * @param array[object] $objects instance to persist in the DB
+     * @param object[] $objects instance to persist in the DB
      */
     public function persist(array $objects);
 
@@ -25,7 +25,7 @@ interface PersisterInterface
      *
      * @param  string $class
      * @param  int    $id
-     * @return mixed
+     * @return object
      */
     public function find($class, $id);
 }

--- a/src/Nelmio/Alice/Util/TypeHintChecker.php
+++ b/src/Nelmio/Alice/Util/TypeHintChecker.php
@@ -16,7 +16,7 @@ use Nelmio\Alice\PersisterInterface;
 class TypeHintChecker
 {
     /**
-     * PersisterInterface
+     * @var PersisterInterface
      */
     protected $manager;
 

--- a/tests/Nelmio/Alice/support/models/NamedConstructorClass.php
+++ b/tests/Nelmio/Alice/support/models/NamedConstructorClass.php
@@ -4,15 +4,15 @@ namespace Nelmio\Alice\support\models;
 
 class NamedConstructorClass
 {
-   public $lambda;
+    public $lambda;
 
-   private function __construct($lambda)
-   {
-       $this->lambda = $lambda;
-   }
+    private function __construct($lambda)
+    {
+        $this->lambda = $lambda;
+    }
 
-   public static function withLambda($lambda)
-   {
-       return new self($lambda);
-   }
+    public static function withLambda($lambda)
+    {
+        return new self($lambda);
+    }
 }


### PR DESCRIPTION
This PR fixes:
* Incorrect @var and @return docblock tags types
* Adds missing type hints
* Fixes some incorrect comparisons (ie: preg_match returns integer while interface requires return type to be bool)