### PR TITLE
Cache keys by mask in instance collection

### DIFF
--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -25,6 +25,17 @@ class Collection
     private $instances;
 
     /**
+     * Instance keys that match random mask
+     * [
+     *      mask => [keys matching mask],
+     *      mask2 => [keys matching mask2],
+     *      ...
+     * ]
+     * @var array
+     */
+    private $keysByMask = [];
+
+    /**
      * Initializes a new ArrayCollection.
      *
      * @param array $elements
@@ -125,6 +136,24 @@ class Collection
     }
 
     /**
+     * Get instance keys that match given mask
+     * @param string $mask
+     * @return string[]
+     */
+    protected function getKeysByMask($mask)
+    {
+        if (!isset($this->keysByMask[$mask])) {
+            $this->keysByMask[$mask] = array_values(
+                preg_grep(
+                    '{^'.str_replace('*', '.+', $mask).'$}',
+                    array_keys($this->instances)
+                )
+            );
+        }
+        return $this->keysByMask[$mask];
+    }
+
+    /**
      * returns a random object or objects from the collection, or a property on that object if $property is not null
      *
      * @param  string  $mask
@@ -138,12 +167,7 @@ class Collection
             return [];
         }
 
-        $availableObjects = array_values(
-            preg_grep(
-                '{^'.str_replace('*', '.+', $mask).'$}',
-                array_keys($this->instances)
-            )
-        );
+        $availableObjects = $this->getKeysByMask($mask);
 
         if (empty($availableObjects)) {
             throw new \UnexpectedValueException(
@@ -173,5 +197,6 @@ class Collection
     public function clear()
     {
         $this->instances = [];
+        $this->keysByMask = [];
     }
 }


### PR DESCRIPTION
This PR introduces one more performance optimization in Collection::random method

For example for following fixture:
```yaml
User:
  user{1..100}:
    name: <name()>
Group:
  group{1..100}:
    users: 5x user*
```
Collection::random method will be called 100 times and will create list of keys matching 'user*' mask 100 time and every time it will create same list of key.

I've added caching of keys matching mask, so keys list for mask will calculated only one time instead of 100. 