### PR TITLE
Remove dev tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:
@@ -9,22 +11,17 @@ php:
 
 matrix:
   include:
-    # Test against LTS releases
     - php: 5.5
       env: SYMFONY_VERSION='2.3.*'
     - php: 5.5
       env: SYMFONY_VERSION='2.7.*'
-    # Test against dev dependencies
     - php: 5.6
-      env: DEPS=dev
+      env: SYMFONY_VERSION='2.8.*'
     - php: 5.6
-      env: SYMFONY_VERSION='2.8.*@dev'
-    - php: 5.6
-      env: DEPS=dev SYMFONY_VERSION='3.0.*'
+      env: SYMFONY_VERSION='3.0.*'
 
 before_install:
   - composer self-update
-  - if [ "$DEPS" = 'dev' ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
 
 before_script:


### PR DESCRIPTION
As Symfony 2.8 and 3.0 now have stable releases we can test against stable releases rather than the dev versions.