### PR TITLE
fix static constructor support

### DIFF
--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructor.php
@@ -38,7 +38,7 @@ class ReflectionWithConstructor implements MethodInterface
      */
     public function canInstantiate(Fixture $fixture)
     {
-        $refl = new \ReflectionMethod($fixture->getClass(), '__construct');
+        $refl = new \ReflectionMethod($fixture->getClass(), $fixture->getConstructorMethod());
 
         return $fixture->shouldUseConstructor() && $refl->getNumberOfRequiredParameters() <= count($fixture->getConstructorArgs());
     }

--- a/tests/Nelmio/Alice/Fixtures/FixtureTest.php
+++ b/tests/Nelmio/Alice/Fixtures/FixtureTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Fixtures;
 class FixtureTest extends \PHPUnit_Framework_TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
+    const STATIC_USER = 'Nelmio\Alice\support\models\StaticUser';
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
 
@@ -151,16 +152,16 @@ class FixtureTest extends \PHPUnit_Framework_TestCase
 
     public function testGetConstructorMethodWillReturnTheMethodName()
     {
-        $fixture = new Fixture(self::USER, 'user', ['__construct' => ['create' => ['1', '2', '3']]], null);
+        $fixture = new Fixture(self::STATIC_USER, 'user', ['__construct' => ['create' => ['alice@example.com']]], null);
 
         $this->assertEquals('create', $fixture->getConstructorMethod());
     }
 
     public function testGetConstructorArgsWillReturnTheArgumentsList()
     {
-        $fixture = new Fixture(self::USER, 'user', ['__construct' => ['create' => ['1', '2', '3']]], null);
+        $fixture = new Fixture(self::STATIC_USER, 'user', ['__construct' => ['create' => ['alice@example.com']]], null);
 
-        $this->assertEquals(['1', '2', '3'], $fixture->getConstructorArgs());
+        $this->assertEquals(['alice@example.com'], $fixture->getConstructorArgs());
     }
 
     public function testShouldUseConstructorWillReturnTrueIfThereIsNoConstructorInTheSpec()

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -18,6 +18,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
     const MAGIC_USER = 'Nelmio\Alice\support\models\MagicUser';
+    const STATIC_USER = 'Nelmio\Alice\support\models\StaticUser';
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
     const PRIVATE_CONSTRUCTOR_CLASS = 'Nelmio\Alice\support\models\PrivateConstructorClass';
@@ -1129,15 +1130,16 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadCallsStaticConstructorIfProvided()
     {
         $res = $this->loadData([
-            self::USER => [
+            self::STATIC_USER => [
                 'user' => [
-                    '__construct' => ['create' => ['alice']],
+                    '__construct' => ['create' => ['alice@example.com']],
                 ],
             ],
         ]);
 
-        $this->assertInstanceOf(self::USER, $res['user']);
-        $this->assertSame('alice-from-create', $res['user']->username);
+        $this->assertInstanceOf(self::STATIC_USER, $res['user']);
+        $this->assertSame('alice', $res['user']->username);
+        $this->assertSame('alice@example.com', $res['user']->email);
     }
 
     /**
@@ -1177,9 +1179,9 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadFailsIfStaticMethodDoesntReturnAnInstance()
     {
         $this->loadData([
-            self::USER => [
+            self::STATIC_USER => [
                 'user' => [
-                    '__construct' => ['bogusCreate' => ['alice@example.com']],
+                    '__construct' => ['bogusCreate' => ['alice', 'alice@example.com']],
                 ],
             ],
         ]);

--- a/tests/Nelmio/Alice/support/models/StaticUser.php
+++ b/tests/Nelmio/Alice/support/models/StaticUser.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Nelmio\Alice\support\models;
+
+class StaticUser
+{
+    public $username;
+    public $email;
+
+    public function __construct($username, $email)
+    {
+        $this->username = $username;
+        $this->email = $email;
+    }
+
+    public static function create($email)
+    {
+        return new static(strtok($email, '@'), $email);
+    }
+
+    public static function bogusCreate($username, $email)
+    {
+    }
+}

--- a/tests/Nelmio/Alice/support/models/User.php
+++ b/tests/Nelmio/Alice/support/models/User.php
@@ -19,15 +19,6 @@ class User
         $this->birthDate = $birthDate;
     }
 
-    public static function create($username = null, $email = null, \DateTime $birthDate = null)
-    {
-        return new static($username . '-from-create', $email, $birthDate);
-    }
-
-    public static function bogusCreate($username = null, $email = null, \DateTime $birthDate = null)
-    {
-    }
-
     public function getAge()
     {
         return 25;


### PR DESCRIPTION
There is a limitation/bug in the support for static constructors, in that the static constructor required arguments needed to match the `__construct` method.

This PR fixes that use case.