### PR TITLE
Support instanciation of object with named constructor

### DIFF
--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
@@ -22,6 +22,10 @@ class ReflectionWithoutConstructor implements MethodInterface
     {
         $reflConstruct = new \ReflectionMethod($fixture->getClass(), '__construct');
 
+        if (!$reflConstruct->isPublic() && '__construct' !== $fixture->getConstructorMethod()) {
+            return false;
+        }
+
         return !$reflConstruct->isPublic() || (!$fixture->shouldUseConstructor() && !version_compare(PHP_VERSION, '5.4', '<'));
     }
 

--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
@@ -22,11 +22,7 @@ class ReflectionWithoutConstructor implements MethodInterface
     {
         $reflConstruct = new \ReflectionMethod($fixture->getClass(), '__construct');
 
-        if (!$reflConstruct->isPublic() && '__construct' !== $fixture->getConstructorMethod()) {
-            return false;
-        }
-
-        return !$reflConstruct->isPublic() || (!$fixture->shouldUseConstructor() && !version_compare(PHP_VERSION, '5.4', '<'));
+        return (!$reflConstruct->isPublic() && '__construct' === $fixture->getConstructorMethod()) || (!$fixture->shouldUseConstructor() && !version_compare(PHP_VERSION, '5.4', '<'));
     }
 
     /**

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -22,6 +22,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     const GROUP = 'Nelmio\Alice\support\models\Group';
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
     const PRIVATE_CONSTRUCTOR_CLASS = 'Nelmio\Alice\support\models\PrivateConstructorClass';
+    const NAMED_CONSTRUCTOR_CLASS = 'Nelmio\Alice\support\models\NamedConstructorClass';
 
     /**
      * @var \Nelmio\Alice\Fixtures\Loader
@@ -103,6 +104,20 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 
         $res = $loader->load($file = __DIR__.'/../support/fixtures/private_constructs.yml');
         $this->assertInstanceOf(self::PRIVATE_CONSTRUCTOR_CLASS, $res['test1']);
+    }
+
+    public function testCreateNamedConstructorInstance()
+    {
+        $res = $this->loadData([
+            self::NAMED_CONSTRUCTOR_CLASS => [
+                'foo' => [
+                    '__construct' => ['withLambda' => ['λ']],
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(self::NAMED_CONSTRUCTOR_CLASS, $res['foo']);
+        $this->assertSame('λ', $res['foo']->lambda);
     }
 
     public function testLoadInvalidFile()

--- a/tests/Nelmio/Alice/support/models/NamedConstructorClass.php
+++ b/tests/Nelmio/Alice/support/models/NamedConstructorClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nelmio\Alice\support\models;
+
+class NamedConstructorClass
+{
+   public $lambda;
+
+   private function __construct($lambda)
+   {
+       $this->lambda = $lambda;
+   }
+
+   public static function withLambda($lambda)
+   {
+       return new self($lambda);
+   }
+}


### PR DESCRIPTION
Currently having a private constructor will force instanciation using reflection (using instanciator `ReflectionWithoutConstructor`).

Current implementation only allows to use factory method when the class constructor is public.

This is not working when using the Named constructors (http://verraes.net/2014/06/named-constructors-in-php/)

This PR intends to provide the use case describing this scenario and open discussion about the best way to handle it.

So far, I've tried to manipulate the `ReflectionWithConstructor` and `ReflectionWithoutConstructor` `canInstantiate` method, but I can't make the whole test suite pass.