### PR TITLE
Fixed referencing to another key when using dots in the keys

### DIFF
--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -145,7 +145,7 @@ class Collection
         if (!isset($this->keysByMask[$mask])) {
             $this->keysByMask[$mask] = array_values(
                 preg_grep(
-                    '{^'.str_replace('*', '.+', $mask).'$}',
+                    '{^'.str_replace(['.', '*'], ['\.', '.+'], $mask).'$}',
                     array_keys($this->instances)
                 )
             );

--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -145,7 +145,7 @@ class Collection
         if (!isset($this->keysByMask[$mask])) {
             $this->keysByMask[$mask] = array_values(
                 preg_grep(
-                    '{^'.str_replace(['.', '*'], ['\.', '.+'], $mask).'$}',
+                    '{^'.str_replace('\\*', '.+', preg_quote($mask)).'$}',
                     array_keys($this->instances)
                 )
             );


### PR DESCRIPTION
I like to use dots in the keys to make the keys more readable. Its like a hierarchy where every part (separated by a dot) represents a level en avoid naming collisions. When you have entities like user_group in a user bundle, the key will be user.user_group.first_group and you can reference with user.user_group.* (this is a bit like SQL syntax)

This fix escapes the dots from the keys so the regex won't match wrong keys.

Issue #309