### PR TITLE
Add support for snake_care properties in fixtures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.x (WIP)
+
+  * Added support for snake_case properties (#323)
+
 ### 2.1.2 (2015-12-10)
 
   * Bug fix - private properties were populatable directly on the instance, but not private properties of parent classes. Although this is an antipattern, if we're allowing it for the instance we should allow it up the chain.

--- a/src/Nelmio/Alice/Instances/Populator/Methods/Direct.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/Direct.php
@@ -31,7 +31,7 @@ class Direct implements MethodInterface
      */
     public function canSet(Fixture $fixture, $object, $property, $value)
     {
-        return method_exists($object, $this->setterFor($property));
+        return method_exists($object, $this->setterFor($object, $property));
     }
 
     /**
@@ -39,7 +39,7 @@ class Direct implements MethodInterface
      */
     public function set(Fixture $fixture, $object, $property, $value)
     {
-        $setter = $this->setterFor($property);
+        $setter = $this->setterFor($object, $property);
         $value = $this->typeHintChecker->check($object, $setter, $value);
 
         if (!is_callable([$object, $setter])) {
@@ -54,11 +54,16 @@ class Direct implements MethodInterface
     /**
      * return the name of the setter for a given property
      *
+     * @param object|string $object
      * @param  string $property
      * @return string
      */
-    private function setterFor($property)
+    private function setterFor($object, $property)
     {
-        return "set{$property}";
+        if (method_exists($object, 'set' . $property)) {
+            return 'set' . $property;
+        } else {
+            return 'set' . str_replace('_', '', $property);
+        }
     }
 }

--- a/src/Nelmio/Alice/Instances/Populator/Methods/MethodInterface.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/MethodInterface.php
@@ -7,18 +7,19 @@ use Nelmio\Alice\Fixtures\Fixture;
 interface MethodInterface
 {
     /**
-     * returns true if the method is able to set the property to the value on the object described by the given fixture
+     * Returns true if the method is able to set the property to the value on the object described by the given fixture.
      *
      * @param  Fixture $fixture
      * @param  mixed   $object
      * @param  string  $property
      * @param  mixed   $value
+     *
      * @return boolean
      */
     public function canSet(Fixture $fixture, $object, $property, $value);
 
     /**
-     * sets the property to the value on the object described by the given fixture
+     * Sets the property to the value on the object described by the given fixture.
      *
      * @param Fixture $fixture
      * @param mixed   $object

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -219,6 +219,23 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('group', $group->getSortName());
     }
 
+    public function testSnakeCaseProperty()
+    {
+        $res = $this->loadData([
+            self::USER => [
+                'user0' => [
+                    'familyName' => 'Wonderland',
+                    'display_name' => 'Hatter',
+                ],
+            ],
+        ]);
+        /** @var User $user */
+        $user = $res['user0'];
+
+        $this->assertEquals('Wonderland', $user->family_name);
+        $this->assertEquals('Mad Hatter', $user->display_name);
+    }
+
     public function testLoadAssignsDataToMagicCall()
     {
         $res = $this->loadData([

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeCamelCaseDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeCamelCaseDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class CompositeCamelCaseDummy
+{
+    /** @var string */
+    public $fullName;
+
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeMixedCaseDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeMixedCaseDummy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class CompositeMixedCaseDummy
+{
+    /** @var string */
+    public $fullname;
+
+    public function setFullname($fullname)
+    {
+        $this->fullname = $fullname;
+    }
+
+    public function setfull_name($full_name)
+    {
+        // Do not set anything
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase1Dummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase1Dummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class CompositeSnakeCase1Dummy
+{
+    /** @var string */
+    public $full_name;
+
+    public function set_full_name($full_name)
+    {
+        $this->full_name = $full_name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase2Dummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase2Dummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class CompositeSnakeCase2Dummy
+{
+    /** @var string */
+    public $full_name;
+
+    public function setfull_name($full_name)
+    {
+        $this->full_name = $full_name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase3Dummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/CompositeSnakeCase3Dummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class CompositeSnakeCase3Dummy
+{
+    /** @var string */
+    public $full_name;
+
+    public function set_fullname($full_name)
+    {
+        $this->full_name = $full_name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/PrivateDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/PrivateDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class PrivateDummy
+{
+    /** @var string */
+    public $name;
+
+    private function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/ProtectedDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/ProtectedDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class ProtectedDummy
+{
+    /** @var string */
+    public $name;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/PublicDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/PublicDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class PublicDummy
+{
+    /** @var string */
+    public $name;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/SimpleCamelCaseDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/SimpleCamelCaseDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class SimpleCamelCaseDummy
+{
+    /** @var string */
+    public $name;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/SimpleSnakeCaseDummy.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Fixtures/Direct/SimpleSnakeCaseDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Instances\Populator\Fixtures\Direct;
+
+class SimpleSnakeCaseDummy
+{
+    /** @var string */
+    public $name;
+
+    public function set_name($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
@@ -1,8 +1,28 @@
 <?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\Alice\Instances\Populator\Methods;
 
 use Nelmio\Alice\Fixtures\Fixture;
-use Nelmio\Alice\support\models\User;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\CompositeCamelCaseDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\CompositeMixedCaseDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\CompositeSnakeCase1Dummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\CompositeSnakeCase2Dummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\CompositeSnakeCase3Dummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\PrivateDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\ProtectedDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\PublicDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\SimpleCamelCaseDummy;
+use Nelmio\Alice\Instances\Populator\Fixtures\Direct\SimpleSnakeCaseDummy;
+use Nelmio\Alice\Util\TypeHintChecker;
 use Prophecy\Argument;
 
 /**
@@ -20,76 +40,234 @@ class DirectTest extends \PHPUnit_Framework_TestCase
      */
     private $direct;
 
-    /**
-     * @var User
-     */
-    private $user;
-
     protected function setUp()
     {
-        $this->user      = new User();
-        $this->fixture   = $this->prophesize('Nelmio\Alice\Fixtures\Fixture')->reveal();
-        $typeHintChecker = $this->prophesize('Nelmio\Alice\Util\TypeHintChecker');
-        $this->direct    = new Direct($typeHintChecker->reveal());
+        $fixtureProphecy = $this->prophesize('Nelmio\Alice\Fixtures\Fixture');
+        $fixtureProphecy->isLocal()->shouldNotBeCalled();
+        $this->fixture = $fixtureProphecy->reveal();
+        
+        $typeHintCheckerProphecy = $this->prophesize('Nelmio\Alice\Util\TypeHintChecker');
+        $typeHintCheckerProphecy->check(Argument::cetera())->willReturnArgument(2);
+        /** @var TypeHintChecker $typeHintChecker */
+        $typeHintChecker = $typeHintCheckerProphecy->reveal();
 
-        $typeHintChecker
-            ->check(Argument::any(), Argument::any(), Argument::any())
-            ->willReturnArgument(2);
+        $this->direct = new Direct($typeHintChecker);
     }
 
     /**
-     * @return array<{bool, string}>
+     * @dataProvider provideProperties
      */
-    public function canSetProvider()
+    public function testCanSet($property, $model, $expected)
+    {
+        $actual = $this->direct->canSet($this->fixture, $model, $property, null);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testSetPropertyViaSetter()
+    {
+        $property = 'name';
+        $name = 'John Doe';
+
+        $typeHintCheckerProphecy = $this->prophesize('Nelmio\Alice\Util\TypeHintChecker');
+        $typeHintCheckerProphecy->check(Argument::cetera())->willReturnArgument(2);
+        /** @var TypeHintChecker $typeHintChecker */
+        $typeHintChecker = $typeHintCheckerProphecy->reveal();
+
+        $direct = new Direct($typeHintChecker);
+
+        $modelProphecy = $this->prophesize('Nelmio\Alice\Instances\Populator\Fixtures\Direct\PublicDummy');
+        $modelProphecy->setName($name)->shouldBeCalled();
+        /** @var PublicDummy $model */
+        $model = $modelProphecy->reveal();
+
+        $direct->set($this->fixture, $model, $property, $name);
+
+        $typeHintCheckerProphecy->check(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+        $modelProphecy->setName(Argument::any())->shouldHaveBeenCalledTimes(1);
+    }
+
+    /**
+     * @dataProvider provideModelsToSet
+     */
+    public function testSetProperty($model, $property, $value, $expectedProperty)
+    {
+        $this->direct->set($this->fixture, $model, $property, $value);
+
+        self::assertEquals($value, $model->$expectedProperty);
+    }
+
+    public function provideProperties()
     {
         return [
-            [false, 'uuid'],            // No setter, property exists
-            [true, 'family_name'],      // setFamilyName exists
-            [false, 'non-existing'],    // No setter, property does not exist
-            [true, 'familyname'],       // setFamilyName exists
-            [true, 'favoriteNumber'],   // setFavoriteNumber exists
-            [true, 'favoritenumber'],   // methods are case insensitive in PHP
-            [true, 'favORite_Number'],  // methods are case insensitive in PHP, and snake case is supported
-            [true, 'display_name'],     // when there are two methods, BC is preserved.
+            'simple property with camelCase setter' => [
+                'name',
+                new SimpleCamelCaseDummy(),
+                true,
+            ],
+            'simple property with snake_case setter' => [
+                'name',
+                new SimpleSnakeCaseDummy(),
+                true,
+            ],
+
+            'composite camelCase property with camelCase setter' => [
+                'fullName',
+                new CompositeCamelCaseDummy(),
+                true,
+            ],
+            'composite snake_case property with camelCase setter' => [
+                'full_name',
+                new CompositeCamelCaseDummy(),
+                true,
+            ],
+
+            'composite camelCase property with snake_case1 setter' => [
+                'fullName',
+                new CompositeSnakeCase1Dummy(),
+                false,
+            ],
+            'composite snake_case property with snake_case1 setter' => [
+                'full_name',
+                new CompositeSnakeCase1Dummy(),
+                true,
+            ],
+
+            'composite camelCase property with snake_case2 setter' => [
+                'fullName',
+                new CompositeSnakeCase2Dummy(),
+                false,
+            ],
+            'composite snake_case property with snake_case2 setter' => [
+                'full_name',
+                new CompositeSnakeCase2Dummy(),
+                true,
+            ],
+
+            'composite camelCase property with snake_case3 setter' => [
+                'fullName',
+                new CompositeSnakeCase3Dummy(),
+                true,
+            ],
+            'composite snake_case property with snake_case3 setter' => [
+                'full_name',
+                new CompositeSnakeCase3Dummy(),
+                true,
+            ],
+
+            'composite camelCase property with mixed setter (BC preserved)' => [
+                'fullName',
+                new CompositeMixedCaseDummy(),
+                true,
+            ],
+            'composite snake_case property with mixed setter (BC preserved)' => [
+                'full_name',
+                new CompositeMixedCaseDummy(),
+                true,
+            ],
+
+            'no setter' => [
+                'propertyWithoutAccessor',
+                new SimpleCamelCaseDummy(),
+                false,
+            ],
         ];
-    }
-
-    /**
-     * @dataProvider canSetProvider
-     * @param bool $expected
-     * @param string $property
-     */
-    public function testCanSet($expected, $property)
-    {
-
-        self::assertSame($expected, $this->direct->canSet($this->fixture, $this->user, $property, null));
     }
 
     /**
      * @return array<{string, string, mixed}>
      */
-    public function setProvider()
+    public function provideModelsToSet()
     {
-        return [
-            ['username',     'username', 'alice'],
-            ['user_name',    'username', 'bill'],
-            ['UsEr_N_a_m_e', 'username', 'tweedle-dee'],
-            ['family_name',  'family_name', 'Dee'],
-            ['familyname',   'family_name', 'Dum'],
-            ['familyName',   'family_name', 'Wonderland'],
-            ['display_name', 'display_name', 'Hatter'],
-        ];
-    }
+        $value = 'John Doe';
 
-    /**
-     * @dataProvider setProvider
-     * @param $expectedProperty
-     * @param $fixtureProperty
-     * @param $value
-     */
-    public function testSet($fixtureProperty, $expectedProperty, $value)
-    {
-        $this->direct->set($this->fixture, $this->user, $fixtureProperty, $value);
-        self::assertSame($value, $this->user->$expectedProperty);
+        return [
+            'simple property with camelCase setter' => [
+                new SimpleCamelCaseDummy(),
+                'name',
+                $value,
+                'name',
+            ],
+            'simple property with snake_case setter' => [
+                new SimpleSnakeCaseDummy(),
+                'name',
+                $value,
+                'name',
+            ],
+
+            'composite camelCase property with camelCase setter' => [
+                new CompositeCamelCaseDummy(),
+                'fullName',
+                $value,
+                'fullName',
+            ],
+            'composite snake_case property with camelCase setter' => [
+                new CompositeCamelCaseDummy(),
+                'full_name',
+                $value,
+                'fullName',
+            ],
+
+            'composite snake_case property with snake_case1 setter' => [
+                new CompositeSnakeCase1Dummy(),
+                'full_name',
+                $value,
+                'full_name',
+            ],
+
+            'composite snake_case property with snake_case2 setter' => [
+                new CompositeSnakeCase2Dummy(),
+                'full_name',
+                $value,
+                'full_name',
+            ],
+
+            'composite camelCase property with snake_case3 setter' => [
+                new CompositeSnakeCase3Dummy(),
+                'fullName',
+                $value,
+                'full_name',
+            ],
+            'composite snake_case property with snake_case3 setter' => [
+                new CompositeSnakeCase3Dummy(),
+                'full_name',
+                $value,
+                'full_name',
+            ],
+
+            'composite camelCase property with mixed setter (BC preserved)' => [
+                new CompositeMixedCaseDummy(),
+                'fullName',
+                $value,
+                'fullname',
+            ],
+            'composite snake_case property with mixed setter (BC preserved)' => [
+                new CompositeMixedCaseDummy(),
+                'full_name',
+                $value,
+                'fullname',
+            ],
+
+            'public setter' => [
+                new PublicDummy(),
+                'name',
+                $value,
+                'name',
+            ],
+
+            'protected setter' => [
+                new ProtectedDummy(),
+                'name',
+                $value,
+                'name',
+            ],
+
+            'private setter' => [
+                new PrivateDummy(),
+                'name',
+                $value,
+                'name',
+            ],
+        ];
     }
 }

--- a/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
@@ -1,0 +1,95 @@
+<?php
+namespace Nelmio\Alice\Instances\Populator\Methods;
+
+use Nelmio\Alice\Fixtures\Fixture;
+use Nelmio\Alice\support\models\User;
+use Prophecy\Argument;
+
+/**
+ * @covers Nelmio\Alice\Instances\Populator\Methods\Direct
+ */
+class DirectTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Fixture
+     */
+    private $fixture;
+
+    /**
+     * @var Direct
+     */
+    private $direct;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    protected function setUp()
+    {
+        $this->user      = new User();
+        $this->fixture   = $this->prophesize('Nelmio\Alice\Fixtures\Fixture')->reveal();
+        $typeHintChecker = $this->prophesize('Nelmio\Alice\Util\TypeHintChecker');
+        $this->direct    = new Direct($typeHintChecker->reveal());
+
+        $typeHintChecker
+            ->check(Argument::any(), Argument::any(), Argument::any())
+            ->willReturnArgument(2);
+    }
+
+    /**
+     * @return array<{bool, string}>
+     */
+    public function canSetProvider()
+    {
+        return [
+            [false, 'uuid'],            // No setter, property exists
+            [true, 'family_name'],      // setFamilyName exists
+            [false, 'non-existing'],    // No setter, property does not exist
+            [true, 'familyname'],       // setFamilyName exists
+            [true, 'favoriteNumber'],   // setFavoriteNumber exists
+            [true, 'favoritenumber'],   // methods are case insensitive in PHP
+            [true, 'favORite_Number'],  // methods are case insensitive in PHP, and snake case is supported
+            [true, 'display_name'],     // when there are two methods, BC is preserved.
+        ];
+    }
+
+    /**
+     * @dataProvider canSetProvider
+     * @param bool $expected
+     * @param string $property
+     */
+    public function testCanSet($expected, $property)
+    {
+
+        self::assertSame($expected, $this->direct->canSet($this->fixture, $this->user, $property, null));
+    }
+
+    /**
+     * @return array<{string, string, mixed}>
+     */
+    public function setProvider()
+    {
+        return [
+            ['username',     'username', 'alice'],
+            ['user_name',    'username', 'bill'],
+            ['UsEr_N_a_m_e', 'username', 'tweedle-dee'],
+            ['family_name',  'family_name', 'Dee'],
+            ['familyname',   'family_name', 'Dum'],
+            ['familyName',   'family_name', 'Wonderland'],
+            ['display_name', 'display_name', 'Hatter'],
+        ];
+    }
+
+    /**
+     * @dataProvider setProvider
+     * @param $expectedProperty
+     * @param $fixtureProperty
+     * @param $value
+     */
+    public function testSet($fixtureProperty, $expectedProperty, $value)
+    {
+        $this->direct->set($this->fixture, $this->user, $fixtureProperty, $value);
+        self::assertSame($value, $this->user->$expectedProperty);
+    }
+}

--- a/tests/Nelmio/Alice/support/models/User.php
+++ b/tests/Nelmio/Alice/support/models/User.php
@@ -7,14 +7,16 @@ class User
     public $uuid;
     public $username;
     public $fullname;
+    public $display_name;
     public $birthDate;
     public $email;
     public $favoriteNumber;
     public $friends;
+    public $family_name;
 
     public function __construct($username = null, $email = null, \DateTime $birthDate = null)
     {
-        $this->username = $username ?: 'tmp-username';
+        $this->setUsername($username ?: 'tmp-username');
         $this->email = $email;
         $this->birthDate = $birthDate;
     }
@@ -32,5 +34,30 @@ class User
     public function customSetter($key, $value)
     {
         $this->$key = $value . ' set by custom setter';
+    }
+
+    public function setFamilyName($family_name)
+    {
+        $this->family_name = $family_name;
+    }
+
+    public function setFavoriteNumber($favoriteNumber)
+    {
+        $this->favoriteNumber = $favoriteNumber;
+    }
+
+    protected function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    public function setdisplay_name($display_name)
+    {
+        $this->display_name = $display_name;
+    }
+
+    public function setDisplayName($displayName)
+    {
+        $this->display_name = 'Mad ' . $displayName;
     }
 }


### PR DESCRIPTION
When for a property a setter exists Alice will use that setter to populate the value. Now properties that use snake case are also transformed into their corresponding setters. For example:

```yaml
Nelmio\Alice\support\models\User:
    user{1..10}:
        family_name: <lastName()>
```
    
Will use the setter setFamilyName if available and otherwise fill the property without setter.