### PR TITLE
Deprecate misusage of range

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -43,7 +43,7 @@ class RangeName implements MethodInterface
         $fixtures = [];
 
         $from = $this->matches[1];
-        $to = $this->matches[2] - 1;
+        $to = $this->matches[2];
         if ($from > $to) {
             list($to, $from) = [$from, $to];
         }

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -22,17 +22,18 @@ class RangeName implements MethodInterface
      */
     public function canBuild($name)
     {
-        if (1 === preg_match('/\{([0-9]+)\.{3,}([0-9]+)\}/', $name, $this->matches)) {
+        if (1 === preg_match('/\{([0-9]+)(\.{3})([0-9]+)\}/', $name, $this->matches)) {
             @trigger_error(
                 'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} instead is now deprecated and '
-                .'will be removed in 3.0',
+                .'will be removed in 3.0. Please mind the change of behavior: "user{0..10}" is creating 11 users '
+                .'whereas "user{0...10}" is creating 10',
                 E_USER_DEPRECATED
             );
 
             return true;
         }
 
-        return 1 === preg_match('/\{([0-9]+)\.{2,}([0-9]+)\}/', $name, $this->matches);
+        return 1 === preg_match('/\{([0-9]+)(\.{2,})([0-9]+)\}/', $name, $this->matches);
     }
 
     /**
@@ -43,7 +44,7 @@ class RangeName implements MethodInterface
         $fixtures = [];
 
         $from = $this->matches[1];
-        $to = $this->matches[2];
+        $to = 2 === strlen($this->matches[2]) ? $this->matches[3] : $this->matches[3] - 1;
         if ($from > $to) {
             list($to, $from) = [$from, $to];
         }

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -24,8 +24,9 @@ class RangeName implements MethodInterface
     {
         if (1 === preg_match('/\{([0-9]+)\.{3,}([0-9]+)\}/', $name, $this->matches)) {
             @trigger_error(
-                'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} instead is now deprecated and will be removed in 3.0',
-                E_NOTICE
+                'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} instead is now deprecated and '
+                .'will be removed in 3.0',
+                E_USER_DEPRECATED
             );
 
             return true;

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -22,7 +22,16 @@ class RangeName implements MethodInterface
      */
     public function canBuild($name)
     {
-        return 1 === preg_match('#\{([0-9]+)\.\.(\.?)([0-9]+)\}#i', $name, $this->matches);
+        if (1 === preg_match('/\{([0-9]+)\.{3,}([0-9]+)\}/', $name, $this->matches)) {
+            @trigger_error(
+                'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} instead is now deprecated and will be removed in 3.0',
+                E_NOTICE
+            );
+
+            return true;
+        }
+
+        return 1 === preg_match('/\{([0-9]+)\.{2,}([0-9]+)\}/', $name, $this->matches);
     }
 
     /**
@@ -33,13 +42,13 @@ class RangeName implements MethodInterface
         $fixtures = [];
 
         $from = $this->matches[1];
-        $to = empty($this->matches[2]) ? $this->matches[3] : $this->matches[3] - 1;
+        $to = $this->matches[2] - 1;
         if ($from > $to) {
             list($to, $from) = [$from, $to];
         }
         for ($currentIndex = $from; $currentIndex <= $to; $currentIndex++) {
             $currentName = str_replace($this->matches[0], $currentIndex, $name);
-            $fixture = new Fixture($class, $currentName, $spec, $currentIndex);
+            $fixture = new Fixture($class, $currentName, $spec, (string) $currentIndex);
             $fixtures[] = $fixture;
         }
 

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * This file is part of the Alice package.
  *
  *  (c) Nelmio <hello@nelm.io>
@@ -29,7 +30,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
 
     public function test_is_a_builder_method()
     {
-        $this->assertInstanceOf(MethodInterface::class, $this->method);
+        $this->assertInstanceOf('Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface', $this->method);
     }
 
     /**
@@ -68,10 +69,12 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
 
     public function provideData()
     {
+        $return = [];
+
         $class = 'Dummy';
         $specs= [];
 
-        yield [
+        $return['nominal'] = [
             $class,
             'user_{0..2}',
             $specs,
@@ -91,7 +94,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        yield [
+        $return['with template'] = [
             $class,
             'user_{0..2} (template)',
             $specs,
@@ -111,7 +114,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        yield [
+        $return['with extends'] = [
             $class,
             'user_{0..2} (extends something)',
             $specs,
@@ -130,5 +133,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
                 ),
             ]
         ];
+
+        return $return;
     }
 }

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Fixtures\Builder\Methods;
+
+use Nelmio\Alice\Fixtures\Fixture;
+
+/**
+ * @covers Nelmio\Alice\Fixtures\Builder\Methods\RangeName
+ */
+class RangeNameTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RangeName
+     */
+    private $method;
+
+    public function setUp()
+    {
+        $this->method = new RangeName();
+    }
+
+    public function test_is_a_builder_method()
+    {
+        $this->assertInstanceOf(MethodInterface::class, $this->method);
+    }
+
+    /**
+     * @dataProvider provideFixtureSet
+     */
+    public function test_can_build_fixture($name, $expected)
+    {
+        $this->assertEquals($expected, $this->method->canBuild($name));
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function test_build_fixture($class, $name, $specs, $expected)
+    {
+        $this->assertTrue($this->method->canBuild($name));
+        $actual = $this->method->build($class, $name, $specs);
+
+        $this->assertEquals($expected, $actual, null, 0.0, 10, true);
+    }
+
+    public function provideFixtureSet()
+    {
+        return [
+            'nominal' => ['user_{0..10}', true],
+            'with extend' => ['user_{0..10} (extends something)', true],
+            'with template' => ['user_{0..10} (template)', true],
+            'with extend and template' => ['user_{0..10} (template)', true],
+            'with deprecated range operator' => ['user_{0...10} (template)', true],
+            'with more than 3 dots' => ['user_{0....10}', true],
+
+            'with only one dot' => ['user_{0.10}', false],
+            'with no upper bound' => ['user_{0..}', false],
+        ];
+    }
+
+    public function provideData()
+    {
+        $class = 'Dummy';
+        $specs= [];
+
+        yield [
+            $class,
+            'user_{0..2}',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1',
+                    $specs,
+                    '1'
+                ),
+            ]
+        ];
+
+        yield [
+            $class,
+            'user_{0..2} (template)',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0 (template)',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1 (template)',
+                    $specs,
+                    '1'
+                ),
+            ]
+        ];
+
+        yield [
+            $class,
+            'user_{0..2} (extends something)',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0 (extends something)',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1 (extends something)',
+                    $specs,
+                    '1'
+                ),
+            ]
+        ];
+    }
+}

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -91,6 +91,12 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
                     $specs,
                     '1'
                 ),
+                new Fixture(
+                    $class,
+                    'user_2',
+                    $specs,
+                    '2'
+                ),
             ]
         ];
 
@@ -111,6 +117,12 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
                     $specs,
                     '1'
                 ),
+                new Fixture(
+                    $class,
+                    'user_2 (template)',
+                    $specs,
+                    '2'
+                ),
             ]
         ];
 
@@ -130,6 +142,12 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
                     'user_1 (extends something)',
                     $specs,
                     '1'
+                ),
+                new Fixture(
+                    $class,
+                    'user_2 (extends something)',
+                    $specs,
+                    '2'
                 ),
             ]
         ];

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -677,9 +677,9 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $this->assertCount(10, $res);
+        $this->assertCount(11, $res);
         $this->assertInstanceOf(self::USER, $this->loader->getReference('user0'));
-        $this->assertInstanceOf(self::USER, $this->loader->getReference('user9'));
+        $this->assertInstanceOf(self::USER, $this->loader->getReference('user10'));
     }
 
     public function testLoadSwapsRanges()

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -677,9 +677,9 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $this->assertCount(11, $res);
+        $this->assertCount(10, $res);
         $this->assertInstanceOf(self::USER, $this->loader->getReference('user0'));
-        $this->assertInstanceOf(self::USER, $this->loader->getReference('user10'));
+        $this->assertInstanceOf(self::USER, $this->loader->getReference('user9'));
     }
 
     public function testLoadSwapsRanges()


### PR DESCRIPTION
Closes #329

Proposed changes:

- Add deprecation warning (no test for it)
- Added tests for `RangeName`
- Fixed `valueForCurrent` to be a string regardless of the index (previously could be `0` and then `'1'`...

~~I must say I also find it weird to have `user_{1...10}` creating the fixtures `user_1`, ... `user_9` where I would expect it to go up to `user_10`.~~

Looks like it's a misunderstanding of my part: `user{0...10}` is creating 10 users, not 9, whereas `user{0..10}` creates 10 users as expected...