### PR TITLE
[v2] Deprecate range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.x (WIP)
 
   * Added support for snake_case properties (#323)
+  * Deprecate usage of the the range operator with more than two dots (#329)
 
 ### 2.1.2 (2015-12-10)
 

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -22,7 +22,7 @@ class RangeName implements MethodInterface
      */
     public function canBuild($name)
     {
-        if (1 === preg_match('/\{([0-9]+)(\.{3,})([0-9]+)\}/', $name, $this->matches)) {
+        if (1 === preg_match('/\{([0-9]+)(\.{3,})([0-9]+)\}/i', $name, $this->matches)) {
             @trigger_error(
                 'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} or with more dots instead is '
                 .'now deprecated and will be removed in 3.0. Please mind the change of behavior: "user{0..10}" is '
@@ -33,7 +33,7 @@ class RangeName implements MethodInterface
             return true;
         }
 
-        return 1 === preg_match('/\{([0-9]+)(\.{2,})([0-9]+)\}/', $name, $this->matches);
+        return 1 === preg_match('/\{([0-9]+)(\.{2,})([0-9]+)\}/i', $name, $this->matches);
     }
 
     /**

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -22,7 +22,18 @@ class RangeName implements MethodInterface
      */
     public function canBuild($name)
     {
-        return 1 === preg_match('#\{([0-9]+)\.\.(\.?)([0-9]+)\}#i', $name, $this->matches);
+        if (1 === preg_match('/\{([0-9]+)(\.{3,})([0-9]+)\}/', $name, $this->matches)) {
+            @trigger_error(
+                'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} or with more dots instead is '
+                .'now deprecated and will be removed in 3.0. Please mind the change of behavior: "user{0..10}" is '
+                .'creating 11 users whereas "user{0...10}" is creating 10',
+                E_USER_DEPRECATED
+            );
+
+            return true;
+        }
+
+        return 1 === preg_match('/\{([0-9]+)(\.{2,})([0-9]+)\}/', $name, $this->matches);
     }
 
     /**
@@ -33,13 +44,13 @@ class RangeName implements MethodInterface
         $fixtures = [];
 
         $from = $this->matches[1];
-        $to = empty($this->matches[2]) ? $this->matches[3] : $this->matches[3] - 1;
+        $to = 2 === strlen($this->matches[2]) ? $this->matches[3] : $this->matches[3] - 1;
         if ($from > $to) {
             list($to, $from) = [$from, $to];
         }
         for ($currentIndex = $from; $currentIndex <= $to; $currentIndex++) {
             $currentName = str_replace($this->matches[0], $currentIndex, $name);
-            $fixture = new Fixture($class, $currentName, $spec, $currentIndex);
+            $fixture = new Fixture($class, $currentName, $spec, (string) $currentIndex);
             $fixtures[] = $fixture;
         }
 

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Fixtures\Builder\Methods;
+
+use Nelmio\Alice\Fixtures\Fixture;
+
+/**
+ * @covers Nelmio\Alice\Fixtures\Builder\Methods\RangeName
+ */
+class RangeNameTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RangeName
+     */
+    private $method;
+
+    public function setUp()
+    {
+        $this->method = new RangeName();
+    }
+
+    public function test_is_a_builder_method()
+    {
+        $this->assertInstanceOf('Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface', $this->method);
+    }
+
+    /**
+     * @dataProvider provideFixtureSet
+     */
+    public function test_can_build_fixture($name, $expected)
+    {
+        $this->assertEquals($expected, $this->method->canBuild($name));
+    }
+
+    /**
+     * @dataProvider provideLegacyFixtureSet
+     * @group legacy
+     * @TODO: remove legacy group once https://github.com/symfony/symfony/issues/18755 is sorted
+     */
+    public function test_legacy_can_build_fixture($name, $expected)
+    {
+        $this->assertEquals($expected, $this->method->canBuild($name));
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function test_build_fixture($class, $name, $specs, $expected)
+    {
+        $this->assertTrue($this->method->canBuild($name));
+        $actual = $this->method->build($class, $name, $specs);
+
+        $this->assertEquals($expected, $actual, null, 0.0, 10, true);
+    }
+
+    /**
+     * @dataProvider provideLegacyData
+     * @group legacy
+     * @TODO: remove legacy group once https://github.com/symfony/symfony/issues/18755 is sorted
+     */
+    public function test_legacy_build_fixture($class, $name, $specs, $expected)
+    {
+        $this->assertTrue($this->method->canBuild($name));
+        $actual = $this->method->build($class, $name, $specs);
+
+        $this->assertEquals($expected, $actual, null, 0.0, 10, true);
+    }
+
+    public function provideFixtureSet()
+    {
+        return [
+            'nominal' => ['user_{0..10}', true],
+            'with extend' => ['user_{0..10} (extends something)', true],
+            'with template' => ['user_{0..10} (template)', true],
+            'with extend and template' => ['user_{0..10} (template)', true],
+
+            'with only one dot' => ['user_{0.10}', false],
+            'with no upper bound' => ['user_{0..}', false],
+        ];
+    }
+
+    public function provideLegacyFixtureSet()
+    {
+        $data = $this->provideFixtureSet();
+        $data = array_merge(
+            $data,
+            [
+                'with deprecated range operator' => ['user_{0...10} (template)', true],
+                'with more than 3 dots' => ['user_{0....10}', true],
+            ]
+        );
+
+        return $data;
+    }
+
+    public function provideData()
+    {
+        $return = [];
+
+        $class = 'Dummy';
+        $specs= [];
+
+        $return['nominal'] = [
+            $class,
+            'user_{0..2}',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1',
+                    $specs,
+                    '1'
+                ),
+                new Fixture(
+                    $class,
+                    'user_2',
+                    $specs,
+                    '2'
+                ),
+            ]
+        ];
+
+        $return['with template'] = [
+            $class,
+            'user_{0..2} (template)',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0 (template)',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1 (template)',
+                    $specs,
+                    '1'
+                ),
+                new Fixture(
+                    $class,
+                    'user_2 (template)',
+                    $specs,
+                    '2'
+                ),
+            ]
+        ];
+
+        $return['with extends'] = [
+            $class,
+            'user_{0..2} (extends something)',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0 (extends something)',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1 (extends something)',
+                    $specs,
+                    '1'
+                ),
+                new Fixture(
+                    $class,
+                    'user_2 (extends something)',
+                    $specs,
+                    '2'
+                ),
+            ]
+        ];
+
+        return $return;
+    }
+
+    public function provideLegacyData()
+    {
+        $return = [];
+
+        $class = 'Dummy';
+        $specs= [];
+
+        $return['with 3 dots'] = [
+            $class,
+            'user_{0...2}',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1',
+                    $specs,
+                    '1'
+                ),
+            ]
+        ];
+
+        $return['with more than 3 dots'] = [
+            $class,
+            'user_{0....2}',
+            $specs,
+            [
+                new Fixture(
+                    $class,
+                    'user_0',
+                    $specs,
+                    '0'
+                ),
+                new Fixture(
+                    $class,
+                    'user_1',
+                    $specs,
+                    '1'
+                ),
+            ]
+        ];
+
+        return $return;
+    }
+}

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -28,7 +28,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
         $this->method = new RangeName();
     }
 
-    public function test_is_a_builder_method()
+    public function testIsABuilderMethod()
     {
         $this->assertInstanceOf('Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface', $this->method);
     }
@@ -36,7 +36,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideFixtureSet
      */
-    public function test_can_build_fixture($name, $expected)
+    public function testCanBuildFixture($name, $expected)
     {
         $this->assertEquals($expected, $this->method->canBuild($name));
     }
@@ -44,9 +44,8 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideLegacyFixtureSet
      * @group legacy
-     * @TODO: remove legacy group once https://github.com/symfony/symfony/issues/18755 is sorted
      */
-    public function test_legacy_can_build_fixture($name, $expected)
+    public function testCanBuildFixtureWithLegacySyntax($name, $expected)
     {
         $this->assertEquals($expected, $this->method->canBuild($name));
     }
@@ -54,7 +53,7 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideData
      */
-    public function test_build_fixture($class, $name, $specs, $expected)
+    public function testBuildFixture($class, $name, $specs, $expected)
     {
         $this->assertTrue($this->method->canBuild($name));
         $actual = $this->method->build($class, $name, $specs);
@@ -65,9 +64,8 @@ class RangeNameTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideLegacyData
      * @group legacy
-     * @TODO: remove legacy group once https://github.com/symfony/symfony/issues/18755 is sorted
      */
-    public function test_legacy_build_fixture($class, $name, $specs, $expected)
+    public function testBuildFixtureWithLegacySyntax($class, $name, $specs, $expected)
     {
         $this->assertTrue($this->method->canBuild($name));
         $actual = $this->method->build($class, $name, $specs);

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -688,7 +688,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     {
         $res = $this->loadData([
             self::USER => [
-                'user{0...10}' => [
+                'user{0..9}' => [
                     'username' => 'alice',
                 ],
             ],

--- a/tests/Nelmio/Alice/support/fixtures/complete.yml
+++ b/tests/Nelmio/Alice/support/fixtures/complete.yml
@@ -17,7 +17,7 @@ Nelmio\Alice\support\models\Contact:
         __construct: ['@user0']
 
 Nelmio\Alice\support\models\Group:
-    group{0...1}:
+    group{0..0}:
         name: <company()>
         members: 20%? 3x @user*
         owner: '@user<current()>'

--- a/tests/Nelmio/Alice/support/fixtures/part_2.yml
+++ b/tests/Nelmio/Alice/support/fixtures/part_2.yml
@@ -3,7 +3,7 @@ Nelmio\Alice\support\models\Contact:
         __construct: ['@user0']
 
 Nelmio\Alice\support\models\Group:
-    group{0...1}:
+    group{0..0}:
         name: <company()>
         members: 20%? 3x @user*
         owner: '@user<current()>'


### PR DESCRIPTION
Reopen #331 against 2.x. Closes #329.

Proposed changes:

- Add deprecation message
- Add tests for `RangeName` (affected class)
- Fix tests fixture files where the old syntax was being used
- Added a mention in the `CHANGELOG` for the future release
- Checked the doc (RAS)