### PR TITLE
[v2] 	Port parameters feature to PHP loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Added support for snake_case properties (#323)
   * Deprecate usage of the the range operator with more than two dots (#329)
   * Added support for dots in reference names (#312)
+  * Added support for Fixture parameters in PHP File (#341)
 
 ### 2.1.2 (2015-12-10)
 

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -114,6 +114,33 @@ abstract class Base implements MethodInterface
      * @param array $data        Parsed file data
      * @param array $includeData Parsed file data to merge
      *
+     * @param array $data
+     *
+     * @return mixed
+     */
+    protected function processParameters(array $data)
+    {
+        if (isset($data['parameters']) && $this->context instanceof Loader) {
+            /* @var Loader $loader */
+            $loader = $this->context;
+
+            $parameterBag = $loader->getParameterBag();
+            foreach ($data['parameters'] as $name => $value) {
+                $parameterBag->set($name, $value);
+            }
+        }
+
+        unset($data['parameters']);
+
+        return $data;
+    }
+
+    /**
+     * Merges a parsed file data with another. If some data overlaps, the existent data is kept.
+     *
+     * @param array $data        Parsed file data
+     * @param array $includeData Parsed file data to merge
+     *
      * @return array
      */
     protected function mergeIncludeData($data, $includeData)

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -109,10 +109,7 @@ abstract class Base implements MethodInterface
     }
 
     /**
-     * Merges a parsed file data with another. If some data overlaps, the existent data is kept.
-     *
-     * @param array $data        Parsed file data
-     * @param array $includeData Parsed file data to merge
+     * Merges a parsed file parameters with another. If some data overlaps, the existent data is kept.
      *
      * @param array $data
      *

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Php.php
@@ -59,6 +59,7 @@ class Php extends Base
         }
 
         $data = $this->processIncludes($data, $file);
+        $data = $this->processParameters($data);
 
         return $data;
     }

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
@@ -55,26 +55,4 @@ class Yaml extends Base
 
         return $data;
     }
-
-    /**
-     * @param array $data
-     *
-     * @return mixed
-     */
-    private function processParameters(array $data)
-    {
-        if (isset($data['parameters']) && $this->context instanceof Loader) {
-            /* @var Loader $loader */
-            $loader = $this->context;
-
-            $parameterBag = $loader->getParameterBag();
-            foreach ($data['parameters'] as $name => $value) {
-                $parameterBag->set($name, $value);
-            }
-        }
-
-        unset($data['parameters']);
-
-        return $data;
-    }
 }

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1630,6 +1630,17 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testPhpArrayParametersAreProperlyInterpreted()
+    {
+        $res = $this->createLoader()->load(__DIR__ . '/../support/fixtures/array_parameters.php');
+
+        $this->assertCount(5, $res);
+        foreach ($this->loader->getReferences() as $user) {
+            $this->assertInstanceOf(self::USER, $user);
+            $this->assertContains($user->username, ['Alice', 'Bob', 'Ogi']);
+        }
+    }
+
     public function testBackslashes()
     {
         $loader = new Loader();

--- a/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/file_with_parameters.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/file_with_parameters.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+return [
+    'parameters' => [
+        'foo' => 'bar',
+    ],
+];

--- a/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/included.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/included.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+return [
+    'parameters' => [
+        'foo' => 'boo',
+        'ping' => 'pong',
+    ],
+];

--- a/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/main1.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/main1.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+return [
+    'include' => [
+        'included.php',
+    ],
+    // Case where parameters block is after include block
+    'parameters' => [
+        'foo' => 'bar',
+    ],
+];

--- a/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/main2.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Files/Php/include_parameters/main2.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ *  (c) Nelmio <hello@nelm.io>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+return [
+    // Case where parameters block is before include block
+    'parameters' => [
+        'foo' => 'bar',
+    ],
+    'include' => [
+        'included.php',
+    ],
+];

--- a/tests/Nelmio/Alice/support/fixtures/array_parameters.php
+++ b/tests/Nelmio/Alice/support/fixtures/array_parameters.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'parameters' => [
+        'usernames' => [
+            'Alice',
+            'Bob',
+            'Ogi',
+        ],
+    ],
+    'Nelmio\Alice\support\models\User' => [
+        'user{1..5}' => [
+            'username' => '<randomElement(<{usernames}>)>',
+        ],
+    ],
+];


### PR DESCRIPTION
**Warning: requires #340 to be merged first**. For review, just check the last commit.

When the [parameters feature](https://github.com/nelmio/alice/blob/2.x/doc/fixtures-refactoring.md#parameters) has been added (https://github.com/nelmio/alice/pull/130), it has been done only for the YAML parser. This PR adds it for PHP as well.

While the usage of parameters is arguable in PHP – I personally find the usage of PHP in favour of YAML questionable enough already, I believe it is better to try to keep the parsers sync in terms of features.