### PR TITLE
Add PHPUnitBridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "doctrine/common": "~2.3",
         "symfony/property-access": "~2.2|~3.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "autoload": {
         "psr-4": { "Nelmio\\Alice\\": "src/Nelmio/Alice" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false"
-    bootstrap                   = "vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
 
     <testsuites>
         <testsuite name="Fixtures Test Suite">
@@ -22,4 +17,8 @@
             <directory>src</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Add the [PHPUnitBridge](https://symfony.com/doc/current/components/phpunit_bridge.html) package to be able to track deprecation notices.

Example:

<img width="1275" alt="screen shot 2016-05-11 at 21 32 17" src="https://cloud.githubusercontent.com/assets/5175937/15195574/60b5046c-17c0-11e6-94b1-af26aca3884b.png">

Also cleaned up a bit the `phpunit.xml.dist` file by added the XSI (to be able to have auto-completion & validation) and removed the declarations which were defining the default values (i.e. were useless). 