### PR TITLE
[v2] Add support for references with dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Added support for snake_case properties (#323)
   * Deprecate usage of the the range operator with more than two dots (#329)
+  * Added support for dots in reference names (#312)
 
 ### 2.1.2 (2015-12-10)
 

--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -98,7 +98,7 @@ class Collection
     }
 
     /**
-     * Returns an object, or a property on that object if $property is not null
+     * Returns an object, or a property on that object if $property is not null.
      *
      * @param string      $name
      * @param string|null $property

--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -145,7 +145,7 @@ class Collection
         if (!isset($this->keysByMask[$mask])) {
             $this->keysByMask[$mask] = array_values(
                 preg_grep(
-                    '{^'.str_replace('*', '.+', $mask).'$}',
+                    '{^'.str_replace(['.', '*'], ['\.', '.+'], $mask).'$}',
                     array_keys($this->instances)
                 )
             );

--- a/src/Nelmio/Alice/Instances/Collection.php
+++ b/src/Nelmio/Alice/Instances/Collection.php
@@ -145,7 +145,7 @@ class Collection
         if (!isset($this->keysByMask[$mask])) {
             $this->keysByMask[$mask] = array_values(
                 preg_grep(
-                    '{^'.str_replace(['.', '*'], ['\.', '.+'], $mask).'$}',
+                    '{^'.str_replace('\\*', '.+', preg_quote($mask)).'$}',
                     array_keys($this->instances)
                 )
             );

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -499,6 +499,33 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $group->getMembers());
     }
 
+    public function testLoadObjectsWithDotsInTheirReferences()
+    {
+        $res = $this->loadData([
+            self::USER => [
+                'user.alice' => [
+                    'username' => 'alice',
+                ],
+                'user.alias.alice_alias' => [
+                    'username' => '@user.alice->username',
+                ],
+                'user.deep_alias' => [
+                    'username' => '@user.alias.alice_alias->username',
+                ],
+            ]
+        ]);
+
+        $this->assertCount(3, $res);
+
+        $this->assertInstanceOf(self::USER, $res['user.alice']);
+        $this->assertInstanceOf(self::USER, $res['user.alias.alice_alias']);
+        $this->assertInstanceOf(self::USER, $res['user.deep_alias']);
+
+        $this->assertEquals('alice', $res['user.alice']->username);
+        $this->assertEquals($res['user.alice']->username, $res['user.alias.alice_alias']->username);
+        $this->assertEquals($res['user.alias.alice_alias']->username, $res['user.deep_alias']->username);
+    }
+
     public function testLoadParsesOptionalValuesWithPercents()
     {
         $this->loadData([


### PR DESCRIPTION
Reopened #312 against 2.x.

Proposed changes:

- Allow the usage of dots in object references
- Added a mention in the changelog
- Added a test
- Fixed a few comments in `Collection` while at it
