### PR TITLE
Avoid multiple parameter resolution

### DIFF
--- a/src/Nelmio/Alice/Resolver/Parameter/RecursiveParameterResolver.php
+++ b/src/Nelmio/Alice/Resolver/Parameter/RecursiveParameterResolver.php
@@ -67,18 +67,31 @@ final class RecursiveParameterResolver implements ChainableParameterResolverInte
         }
         $previousParameterValue = $previousResult->get($parameter->getKey());
 
-        $currentResult = $this->resolver->resolve(
+        $newResult = $this->resolver->resolve(
             $parameter->withValue($previousParameterValue),
             $unresolvedParameters,
             $resolvedParameters,
             $context
         );
-        $currentParameterValue = $currentResult->get($parameter->getKey());
-        if ($previousParameterValue === $currentParameterValue) {
-            return $currentResult;
+        $newParameterValue = $newResult->get($parameter->getKey());
+        $result = $this->mergeResults($previousResult, $newResult);
+
+        if ($previousParameterValue === $newParameterValue) {
+            return $result;
         }
 
-        return $this->resolve($parameter, $unresolvedParameters, $resolvedParameters, $context, $currentResult);
+        return $this->resolve($parameter, $unresolvedParameters, $resolvedParameters, $context, $result);
+    }
+
+    private function mergeResults(ParameterBag $previous, ParameterBag $new): ParameterBag
+    {
+        foreach ($previous as $key => $value) {
+            $new = $new->with(
+                new Parameter($key, $value)
+            );
+        }
+
+        return $new;
     }
 
     public function __clone()

--- a/tests/Nelmio/Alice/Resolver/ParameterResolverFunctionalTest.php
+++ b/tests/Nelmio/Alice/Resolver/ParameterResolverFunctionalTest.php
@@ -190,6 +190,22 @@ class ParameterResolverFunctionalTest extends \PHPUnit_Framework_TestCase
             ])
         ];
 
+        $return['composite stringified reference'] = [
+            new ParameterBag([
+                'param1' => '<{param2}> <{param4}>',
+                'param2' => '<{param3}>',
+                'param3' => false,
+                'param4' => -.89,
+            ]),
+            null,
+            new ParameterBag([
+                'param1' => ' -0.89',
+                'param2' => false,
+                'param3' => false,
+                'param4' => -.89,
+            ])
+        ];
+
         $return['nested parameters'] = [
             new ParameterBag([
                 'param1' => '<{param<{param2}>}>',


### PR DESCRIPTION
Previously if:

- `param1` required `param2` and `param3` to be resolved
- the first result of the resolution of `param1` was giving a dynamic value which needed to be resolved again
- the second resolution required `param3` to be resolved

Then the results of first resolution where being lost, i.e. `param2` and `param3` needed to be resolved again later on when this could have been avoided.

Fix PR fixes that.