### PR TITLE
Create absolute references for flags

### DIFF
--- a/src/Nelmio/Alice/Definition/Fixture/Templating.php
+++ b/src/Nelmio/Alice/Definition/Fixture/Templating.php
@@ -33,8 +33,9 @@ final class Templating
      */
     private $extends = [];
 
-    public function __construct(FlagBag $flags)
+    public function __construct(FixtureWithFlags $fixture)
     {
+        $flags = $fixture->getFlags();
         foreach ($flags as $flag) {
             if ($flag instanceof TemplateFlag) {
                 $this->isATemplate = true;
@@ -44,7 +45,7 @@ final class Templating
 
             if ($flag instanceof ExtendFlag) {
                 // Potential flag duplication is handled at the flagbag level
-                $this->extends[] = $flag->getExtendedFixture();
+                $this->extends[] = $flag->getExtendedFixture()->createAbsoluteFrom($fixture);
             }
         }
     }

--- a/src/Nelmio/Alice/Definition/Fixture/TemplatingFixture.php
+++ b/src/Nelmio/Alice/Definition/Fixture/TemplatingFixture.php
@@ -33,7 +33,7 @@ final class TemplatingFixture implements FixtureInterface
     public function __construct(FixtureWithFlags $fixture)
     {
         $this->fixture = $fixture;
-        $this->templating = new Templating($fixture->getFlags());
+        $this->templating = new Templating($fixture);
     }
 
     /**

--- a/src/Nelmio/Alice/Definition/ServiceReference/FixtureReference.php
+++ b/src/Nelmio/Alice/Definition/ServiceReference/FixtureReference.php
@@ -12,9 +12,11 @@
 namespace Nelmio\Alice\Definition\ServiceReference;
 
 use Nelmio\Alice\Definition\ServiceReferenceInterface;
+use Nelmio\Alice\FixtureInterface;
 
 /**
- * Value object to point to refer to a fixture, e.g. 'Nelmio\Alice\User#user_base'. 
+ * Value object to point to refer to a fixture. The reference can be relative, e.g. 'user_base' (fixture reference) or
+ * absolute e.g. 'Nelmio\Alice\User#user_base' (fixture ID).
  */
 final class FixtureReference implements ServiceReferenceInterface
 {
@@ -24,11 +26,38 @@ final class FixtureReference implements ServiceReferenceInterface
     private $reference;
 
     /**
-     * @param string $reference 
+     * @param string $reference
      */
     public function __construct(string $reference)
     {
         $this->reference = $reference;
+    }
+
+    /**
+     * A fixture reference may be relative, e.g. 'user_base' (fixture reference). By giving it a fixture, this method
+     * creates a new reference which will be absolute, e.g. 'Nelmio\Alice\User#user_base' (fixture ID.
+     *
+     * @param FixtureInterface $fixture
+     *
+     * @return self
+     */
+    public function createAbsoluteFrom(FixtureInterface $fixture): self
+    {
+        if (false !== strpos($this->reference, '#')) {
+            throw new \BadMethodCallException(
+                sprintf(
+                    'Attempted to make the reference "%s" absolute from the fixture of ID "%s", however the reference '.
+                    'is already absolute.',
+                    $this->reference,
+                    $fixture->getId()
+                )
+            );
+        }
+        
+        $clone = clone $this;
+        $clone->reference = $fixture->getClassName().'#'.$this->reference;
+
+        return $clone;
     }
 
     public function getReference(): string

--- a/tests/Nelmio/Alice/Definition/Fixture/TemplatingFixtureTest.php
+++ b/tests/Nelmio/Alice/Definition/Fixture/TemplatingFixtureTest.php
@@ -46,7 +46,7 @@ class TemplatingFixtureTest extends \PHPUnit_Framework_TestCase
         /** @var FixtureInterface $decoratedFixture */
         $decoratedFixture = $decoratedFixtureProphecy->reveal();
 
-        $extendedFixtureReference = new FixtureReference('Nelmio\User\Alice#user_base');
+        $extendedFixtureReference = new FixtureReference('user_base');
         $flag1 = new TemplateFlag();
         $flag2 = new ExtendFlag($extendedFixtureReference);
 
@@ -64,11 +64,11 @@ class TemplatingFixtureTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($specs, $fixture->getSpecs());
         $this->assertTrue($fixture->isATemplate());
         $this->assertTrue($fixture->extendsFixtures());
-        $this->assertEquals([$extendedFixtureReference], $fixture->getExtendedFixturesReferences());
+        $this->assertEquals([new FixtureReference('Nelmio\Entity\User#user_base')], $fixture->getExtendedFixturesReferences());
 
         $decoratedFixtureProphecy->getId()->shouldHaveBeenCalledTimes(1);
         $decoratedFixtureProphecy->getReference()->shouldHaveBeenCalledTimes(1);
-        $decoratedFixtureProphecy->getClassName()->shouldHaveBeenCalledTimes(1);
+        $decoratedFixtureProphecy->getClassName()->shouldHaveBeenCalledTimes(2);
         $decoratedFixtureProphecy->getSpecs()->shouldHaveBeenCalledTimes(1);
     }
 


### PR DESCRIPTION
When resolving fixture templates, what is required to find fixtures in the bag are fixture IDs and not (fixture) references. However the flag parser has no idea of which fixture flags it is parsing. As the parser is re-used for parsing FQCN for example, case where there is no fixture, I'm not sure it's a good idea to make it "fixture aware". An alternative solution is to reworking `Templating`, i.e. when creating a template fixture, to change the extended fixture references at that time. The only drawbacks I see is that it makes `FixtureReference` a bit confusing as it can refer to a relative OR absolute fixture, but in both cases they are accessed via `::getReference()` which comes from the implemented interface.