### PR TITLE
Change SpecificationBag merge behaviour

### DIFF
--- a/src/Nelmio/Alice/Definition/MethodCallBag.php
+++ b/src/Nelmio/Alice/Definition/MethodCallBag.php
@@ -21,14 +21,14 @@ final class MethodCallBag
     public function with(MethodCallInterface $methodCall): self
     {
         $clone = clone $this;
-        $clone->methodCalls[$methodCall->__toString()] = $methodCall;
+        $clone->methodCalls[] = $methodCall;
 
         return $clone;
     }
 
     /**
      * Creates a new instance to which the given properties have been merged. In case of conflicts, the existing values
-     * are overridden.
+     * are kept.
      *
      * @param self $methodCallsBag
      *
@@ -36,9 +36,9 @@ final class MethodCallBag
      */
     public function mergeWith(self $methodCallsBag): self
     {
-        $clone = clone $this;
-        foreach ($methodCallsBag->methodCalls as $stringValue => $methodCall) {
-            $clone->methodCalls[$stringValue] = $methodCall;
+        $clone = clone $methodCallsBag;
+        foreach ($this->methodCalls as $methodCall) {
+            $clone->methodCalls[] = $methodCall;
         }
 
         return $clone;

--- a/src/Nelmio/Alice/Definition/PropertyBag.php
+++ b/src/Nelmio/Alice/Definition/PropertyBag.php
@@ -28,7 +28,7 @@ final class PropertyBag
 
     /**
      * Creates a new instance to which the given properties have been merged. In case of conflicts, the existing values
-     * are overridden.
+     * are kept.
      *
      * @param PropertyBag $propertyBag
      *
@@ -36,8 +36,8 @@ final class PropertyBag
      */
     public function mergeWith(self $propertyBag): self
     {
-        $clone = clone $this;
-        foreach ($propertyBag->properties as $name => $property) {
+        $clone = clone $propertyBag;
+        foreach ($this->properties as $name => $property) {
             $clone->properties[$name] = $property;
         }
         

--- a/src/Nelmio/Alice/Definition/SpecificationBag.php
+++ b/src/Nelmio/Alice/Definition/SpecificationBag.php
@@ -64,7 +64,7 @@ final class SpecificationBag
 
     /**
      * Creates a new instance to which the given specs have been merged. In case of conflicts, the existing values are
-     * overridden.
+     * kept.
      * 
      * @param self $specs
      *
@@ -73,7 +73,7 @@ final class SpecificationBag
     public function mergeWith(self $specs): self
     {
         $clone = clone $this;
-        if (null !== $specs->constructor) {
+        if (null === $clone->constructor) {
             $clone->constructor = $specs->constructor;
         }
         

--- a/tests/Nelmio/Alice/Definition/PropertyBagTest.php
+++ b/tests/Nelmio/Alice/Definition/PropertyBagTest.php
@@ -30,7 +30,7 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         $this->propRefl = $propRefl;
     }
 
-    public function testImmutableMutator()
+    public function testMutatorsAreImmutable()
     {
         $property = new Property('username', 'alice');
 
@@ -43,12 +43,15 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['username' => $property], $this->propRefl->getValue($newBag));
     }
 
+    /**
+     * @testdox Can merge two bags. When properties overlaps, the existing ones are kept.
+     */
     public function testMergeTwoBags()
     {
         $propertyA1 = new Property('username', 'alice');
         $propertyA2 = new Property('owner', 'bob');
 
-        $propertyB1 = new Property('username', 'mad');
+        $propertyB1 = new Property('username', 'mad');  // overlapping value
         $propertyB2 = new Property('mail', 'bob@ex.com');
 
         $bagA = (new PropertyBag())
@@ -79,9 +82,9 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertSame(
             [
-                'username' => $propertyB1,
-                'owner' => $propertyA2,
+                'username' => $propertyA1,
                 'mail' => $propertyB2,
+                'owner' => $propertyA2,
             ],
             $this->propRefl->getValue($bag)
         );

--- a/tests/Nelmio/Alice/Definition/SpecificationBagTest.php
+++ b/tests/Nelmio/Alice/Definition/SpecificationBagTest.php
@@ -31,7 +31,7 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $constructor = $constructorProphecy->reveal();
 
         $methodCallProphecy = $this->prophesize(MethodCallInterface::class);
-        $methodCallProphecy->__toString()->willReturn('call');
+        $methodCallProphecy->__toString()->shouldNotBeCalled();
         /** @var MethodCallInterface $methodCall */
         $methodCall = $methodCallProphecy->reveal();
 
@@ -49,8 +49,6 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($constructor, $bag->getConstructor());
         $this->assertEquals($properties, $bag->getProperties());
         $this->assertEquals($calls, $bag->getMethodCalls());
-
-        $methodCallProphecy->__toString()->shouldHaveBeenCalledTimes(1);
     }
 
     public function testIsImmutable()
@@ -96,12 +94,9 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($bagWithConstructor, $clone);
     }
 
-    /**
-     * Scenario where the existing bag has a constructor method and the new one does not.
-     */
-    public function testMergeTwoBags1()
+    public function testMergeTwoBags()
     {
-        $constructorA = new SimpleMethodCall('create', []);
+        $constructorA = null;
         $constructorB = null;
 
         $propertyA1 = new Property('username', 'alice');
@@ -151,56 +146,38 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Scenario where the existing bag has a constructor method and the new one as well.
+     * @testdox Merging a bag that has a constructor method with a new one that does not, the result will have a
+     *          constructor method.
+     */
+    public function testMergeTwoBags1()
+    {
+        $constructorA = new SimpleMethodCall('create', []);
+        $constructorB = null;
+
+        $bagA = new SpecificationBag($constructorA, new PropertyBag(), new MethodCallBag());
+        $bagB = new SpecificationBag($constructorB, new PropertyBag(), new MethodCallBag());
+        $bag = $bagA->mergeWith($bagB);
+
+        $this->assertEquals($constructorA, $bagA->getConstructor());
+        $this->assertEquals($constructorB, $bagB->getConstructor());
+        $this->assertEquals($constructorA, $bag->getConstructor());
+    }
+
+    /**
+     * @testdox Merging a bag that has a constructor method with a new one that has one as well, the result will kept
+     *          its constructor method.
      */
     public function testMergeTwoBags2()
     {
-        $constructorA = new SimpleMethodCall('create', []);
-        $constructorB = new SimpleMethodCall('newInstance', []);
+        $constructorA = new SimpleMethodCall('childCreate', []);
+        $constructorB = new SimpleMethodCall('parentCreate', []);
 
-        $propertyA1 = new Property('username', 'alice');
-        $propertyA2 = new Property('owner', 'bob');
-
-        $propertyB1 = new Property('username', 'mad');
-        $propertyB2 = new Property('mail', 'bob@ex.com');
-
-        $propertiesA = (new PropertyBag())
-            ->with($propertyA1)
-            ->with($propertyA2)
-        ;
-        $propertiesB = (new PropertyBag())
-            ->with($propertyB1)
-            ->with($propertyB2)
-        ;
-
-        $callA1 = new SimpleMethodCall('setUsername', []);
-        $callA2 = new SimpleMethodCall('setOwner', []);
-
-        $callB1 = new SimpleMethodCall('setUsername', []);
-        $callB2 = new SimpleMethodCall('setMail', []);
-
-        $callsA = (new MethodCallBag())
-            ->with($callA1)
-            ->with($callA2)
-        ;
-        $callsB = (new MethodCallBag())
-            ->with($callB1)
-            ->with($callB2)
-        ;
-
-        $bagA = new SpecificationBag($constructorA, $propertiesA, $callsA);
-        $bagB = new SpecificationBag($constructorB, $propertiesB, $callsB);
+        $bagA = new SpecificationBag($constructorA, new PropertyBag(), new MethodCallBag());
+        $bagB = new SpecificationBag($constructorB, new PropertyBag(), new MethodCallBag());
         $bag = $bagA->mergeWith($bagB);
 
-        $this->assertInstanceOf(SpecificationBag::class, $bag);
         $this->assertEquals($constructorA, $bagA->getConstructor());
-        $this->assertEquals($propertiesA, $bagA->getProperties());
-        $this->assertEquals($callsA, $bagA->getMethodCalls());
-
         $this->assertEquals($constructorB, $bagB->getConstructor());
-        $this->assertEquals($propertiesB, $bagB->getProperties());
-        $this->assertEquals($callsB, $bagB->getMethodCalls());
-
-        $this->assertEquals($constructorB, $bag->getConstructor());
+        $this->assertEquals($constructorA, $bag->getConstructor());
     }
 }


### PR DESCRIPTION
As of now, when merging a fixture specs with another, the overlapping values where overridden. However, when fixtures are being resolved, we start from the child fixtures and not the parent one. As a result, it is much more convenient to have the opposite behaviour which is keeping the existing values. Reversing the order of the resolution would be doable, but much more complex and less performant, whereas this fix is quite simple although a bit confusing.

Also fixed a bug with `MethodCallBag`: overlapping methods were being overridden instead of being stacked.