### PR TITLE
Add link to trappar/AliceGeneratorBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For more information, refer to [the documentation](#table-of-contents).
   * [hautelook/AliceBundle](https://github.com/hautelook/AliceBundle)
   * [h4cc/AliceFixturesBundle](https://github.com/h4cc/AliceFixturesBundle)
   * [knplabs/rad-fixtures-load](https://github.com/KnpLabs/rad-fixtures-load)
+  * [trappar/AliceGeneratorBundle](https://github.com/trappar/AliceGeneratorBundle)
 * Nette
   * [Zenify/DoctrineFixtures](https://github.com/Zenify/DoctrineFixtures)
 * Zend Framework 2:


### PR DESCRIPTION
Just published version 0.1.0 of this library which offers the ability to recursively convert existing Doctrine entities into Alice fixtures. Seems like a resource which fits right in with the other third part libraries 😄 