### PR TITLE
Rework Parameter Resolver

### DIFF
--- a/src/Nelmio/Alice/Generator/Resolver/Parameter/ArrayParameterResolver.php
+++ b/src/Nelmio/Alice/Generator/Resolver/Parameter/ArrayParameterResolver.php
@@ -73,28 +73,25 @@ final class ArrayParameterResolver implements ChainableParameterResolverInterfac
         $context = ResolvingContext::createFrom($context, $unresolvedArrayParameter->getKey());
 
         $resolvedArray = [];
-        $resolvedParameterBag = new ParameterBag();
         /* @var array $unresolvedArray */
         $unresolvedArray = $unresolvedArrayParameter->getValue();
         foreach ($unresolvedArray as $index => $unresolvedValue) {
             // Iterate over all the values of the array to resolve each of them
-            $resolvedValueBag = $this->resolver->resolve(
+            $resolvedParameters = $this->resolver->resolve(
                 new Parameter($index, $unresolvedValue),
                 $unresolvedParameters,
                 $resolvedParameters,
                 $context
             );
 
-            $resolvedArray[$index] = $resolvedValueBag->get($index);
-            $resolvedValueBag = $resolvedValueBag->without($index);
-            
-            foreach ($resolvedValueBag as $key => $value) {
-                $resolvedParameterBag = $resolvedParameterBag->with(new Parameter($key, $value));
-            }
+            $resolvedArray[$index] = $resolvedParameters->get($index);
+            $resolvedParameters = $resolvedParameters->without($index);
         }
-        $resolvedParameterBag = $resolvedParameterBag->with($unresolvedArrayParameter->withValue($resolvedArray));
+        $resolvedParameters = $resolvedParameters->with(
+            $unresolvedArrayParameter->withValue($resolvedArray)
+        );
         
-        return $resolvedParameterBag;
+        return $resolvedParameters;
     }
 
     public function __clone()

--- a/src/Nelmio/Alice/Generator/Resolver/Parameter/ParameterBagResolver.php
+++ b/src/Nelmio/Alice/Generator/Resolver/Parameter/ParameterBagResolver.php
@@ -20,7 +20,7 @@ use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 /**
  * Decorates a simple parameter resolver to resolve a bag.
  */
-final class ParameterResolverDecorator implements ParameterBagResolverInterface
+final class ParameterBagResolver implements ParameterBagResolverInterface
 {
     /**
      * @var ParameterResolverInterface
@@ -51,17 +51,12 @@ final class ParameterResolverDecorator implements ParameterBagResolverInterface
             }
             
             $context = new ResolvingContext($key);
-            //TODO: parameter resolver should return $resolvedParameters + $resolvedValues
-            $resolvedValues = $this->resolver->resolve(
+            $resolvedParameters = $this->resolver->resolve(
                 new Parameter($key, $value),
                 $unresolvedParameters,
                 $resolvedParameters,
                 $context
             );
-
-            foreach ($resolvedValues as $keyOfResolvedValue => $resolvedValue) {
-                $resolvedParameters = $resolvedParameters->with(new Parameter($keyOfResolvedValue, $resolvedValue));
-            }
         }
 
         return $resolvedParameters;

--- a/src/Nelmio/Alice/Generator/Resolver/Parameter/SimpleParameterResolver.php
+++ b/src/Nelmio/Alice/Generator/Resolver/Parameter/SimpleParameterResolver.php
@@ -34,6 +34,6 @@ final class SimpleParameterResolver implements ChainableParameterResolverInterfa
      */
     public function resolve(Parameter $parameter, ParameterBag $unresolvedParameters, ParameterBag $resolvedParameters): ParameterBag
     {
-        return (new ParameterBag())->with($parameter);
+        return $resolvedParameters->with($parameter);
     }
 }

--- a/src/Nelmio/Alice/Loader/NativeLoader.php
+++ b/src/Nelmio/Alice/Loader/NativeLoader.php
@@ -40,7 +40,7 @@ use Nelmio\Alice\FixtureBuilder\SimpleBuilder;
 use Nelmio\Alice\FixtureBuilderInterface;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
 use Nelmio\Alice\Generator\Resolver\Parameter\ArrayParameterResolver;
-use Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverDecorator;
+use Nelmio\Alice\Generator\Resolver\Parameter\ParameterBagResolver;
 use Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverRegistry;
 use Nelmio\Alice\Generator\Resolver\Parameter\RecursiveParameterResolver;
 use Nelmio\Alice\Generator\Resolver\Parameter\SimpleParameterResolver;
@@ -169,7 +169,7 @@ final class NativeLoader implements LoaderInterface
             new RecursiveParameterResolver(new StringParameterResolver()),
         ]);
 
-        return new ParameterResolverDecorator($registry);
+        return new ParameterBagResolver($registry);
     }
 
     public function getBuiltInObjectResolver(): ObjectGeneratorInterface

--- a/tests/Nelmio/Alice/Generator/Resolver/Parameter/ArrayParameterResolverTest.php
+++ b/tests/Nelmio/Alice/Generator/Resolver/Parameter/ArrayParameterResolverTest.php
@@ -115,7 +115,8 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
-                    '0' => 'val1'
+                    'name' => 'resolvedParams',
+                    '0' => 'val1',
                 ])
             )
         ;
@@ -128,7 +129,8 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
-                    '1' => 'val2'
+                    'name' => 'resolvedParams',
+                    '1' => 'val2',
                 ])
             )
         ;
@@ -140,6 +142,7 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             new ParameterBag([
+                'name' => 'resolvedParams',
                 'array_param' => [
                     '0' => 'val1',
                     '1' => 'val2',
@@ -214,7 +217,8 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
-                    '0' => 'val1'
+                    'name' => 'resolvedParams',
+                    '0' => 'val1',
                 ])
             )
         ;
@@ -227,7 +231,8 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
-                    '1' => 'val2'
+                    'name' => 'resolvedParams',
+                    '1' => 'val2',
                 ])
             )
         ;
@@ -239,6 +244,7 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             new ParameterBag([
+                'name' => 'resolvedParams',
                 'array_param' => [
                     '0' => 'val1',
                     '1' => 'val2',

--- a/tests/Nelmio/Alice/Generator/Resolver/Parameter/ParameterBagResolverTest.php
+++ b/tests/Nelmio/Alice/Generator/Resolver/Parameter/ParameterBagResolverTest.php
@@ -19,21 +19,21 @@ use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 use Prophecy\Argument;
 
 /**
- * @covers Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverDecorator
+ * @covers Nelmio\Alice\Generator\Resolver\Parameter\ParameterBagResolver
  */
-class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
+class ParameterBagResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsAParameterBagResolver()
     {
-        $this->assertTrue(is_a(ParameterResolverDecorator::class, ParameterBagResolverInterface::class, true));
+        $this->assertTrue(is_a(ParameterBagResolver::class, ParameterBagResolverInterface::class, true));
     }
 
     public function testIsDeepClonable()
     {
-        $resolver = new ParameterResolverDecorator(new DummyParameterResolverInterface());
+        $resolver = new ParameterBagResolver(new DummyParameterResolverInterface());
         $newResolver = clone $resolver;
 
-        $this->assertInstanceOf(ParameterResolverDecorator::class, $newResolver);
+        $this->assertInstanceOf(ParameterBagResolver::class, $newResolver);
         $this->assertNotSame($newResolver, $resolver);
         $this->assertNotSameInjectedResolver($newResolver, $resolver);
     }
@@ -69,6 +69,8 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
+                    'foo' => 'bar',
+                    'other_param' => 'yo',
                     'ping' => 'pong',
                 ])
             )
@@ -76,7 +78,7 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
         /* @var ParameterResolverInterface $injectedResolver */
         $injectedResolver = $injectedResolverProphecy->reveal();
 
-        $resolver = new ParameterResolverDecorator($injectedResolver);
+        $resolver = new ParameterBagResolver($injectedResolver);
         $result = $resolver->resolve($unresolvedParameters);
 
         $this->assertEquals(
@@ -106,7 +108,7 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
         /* @var ParameterResolverInterface $injectedResolver */
         $injectedResolver = $injectedResolverProphecy->reveal();
 
-        $resolver = new ParameterResolverDecorator($injectedResolver);
+        $resolver = new ParameterBagResolver($injectedResolver);
         $result = $resolver->resolve($unresolvedParameters, $resolvedParameters);
 
         $this->assertEquals($resolvedParameters, $result);
@@ -132,8 +134,8 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
-                    'foo' => 'bar',
                     'other_param' => 'yo',
+                    'foo' => 'bar',
                 ])
             )
         ;
@@ -142,13 +144,15 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
                 new Parameter('ping', 'unresolved(pong)'),
                 $unresolvedParameters,
                 new ParameterBag([
-                    'other_param' => 'oï',
+                    'other_param' => 'yo',
                     'foo' => 'bar',
                 ]),
                 new ResolvingContext('ping')
             )
             ->willReturn(
                 new ParameterBag([
+                    'other_param' => 'yo',
+                    'foo' => 'bar',
                     'ping' => 'pong',
                 ])
             )
@@ -156,12 +160,12 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
         /* @var ParameterResolverInterface $injectedResolver */
         $injectedResolver = $injectedResolverProphecy->reveal();
 
-        $resolver = new ParameterResolverDecorator($injectedResolver);
+        $resolver = new ParameterBagResolver($injectedResolver);
         $result = $resolver->resolve($unresolvedParameters, $injectedParameters);
 
         $this->assertEquals(
             new ParameterBag([
-                'other_param' => 'oï',
+                'other_param' => 'yo',
                 'foo' => 'bar',
                 'ping' => 'pong',
             ]),
@@ -169,7 +173,7 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function assertNotSameInjectedResolver(ParameterResolverDecorator $firstResolver, ParameterResolverDecorator $secondResolver)
+    private function assertNotSameInjectedResolver(ParameterBagResolver $firstResolver, ParameterBagResolver $secondResolver)
     {
         $this->assertNotSame(
             $this->getInjectedResolver($firstResolver),
@@ -177,7 +181,7 @@ class ParameterResolverDecoratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function getInjectedResolver(ParameterResolverDecorator $resolver): ParameterResolverInterface
+    private function getInjectedResolver(ParameterBagResolver $resolver): ParameterResolverInterface
     {
         $resolverReflectionObject = new \ReflectionObject($resolver);
         $resolverPropertyReflection = $resolverReflectionObject->getProperty('resolver');

--- a/tests/Nelmio/Alice/Generator/Resolver/Parameter/StringParameterResolverTest.php
+++ b/tests/Nelmio/Alice/Generator/Resolver/Parameter/StringParameterResolverTest.php
@@ -180,8 +180,11 @@ class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
         $unresolvedParameters = new ParameterBag([
             'bar' => 'unresolved(bar)',
         ]);
-        $resolvedParameters = new ParameterBag();
+        $resolvedParameters = new ParameterBag([
+            'random' => 'param',
+        ]);
         $expected = new ParameterBag([
+            'random' => 'param',
             'bar' => 'Mad Hatter',
             'foo' => 'Mad Hatter',
         ]);
@@ -196,6 +199,7 @@ class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn(
                 new ParameterBag([
+                    'random' => 'param',
                     'bar' => 'Mad Hatter',
                 ])
             )

--- a/tests/Nelmio/Alice/Generator/Resolver/ParameterResolverFunctionalTest.php
+++ b/tests/Nelmio/Alice/Generator/Resolver/ParameterResolverFunctionalTest.php
@@ -13,7 +13,7 @@ namespace Nelmio\Alice\Generator\Resolver;
 
 use Nelmio\Alice\Loader\NativeLoader;
 use Nelmio\Alice\ParameterBag;
-use Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverDecorator;
+use Nelmio\Alice\Generator\Resolver\Parameter\ParameterBagResolver;
 
 /**
  * @coversNothing
@@ -21,7 +21,7 @@ use Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverDecorator;
 class ParameterResolverFunctionalTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ParameterResolverDecorator
+     * @var ParameterBagResolver
      */
     private $resolver;
 


### PR DESCRIPTION
Instead of returning a bag of resolved parameter containing only the parameters that have been resolved for resolving the given param, the returned bag includes all the already resolved parameters.