### PR TITLE
Fix composite parameters

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Parameterized.php
@@ -16,7 +16,7 @@ use Nelmio\Alice\Instances\Processor\ProcessableInterface;
 
 class Parameterized implements MethodInterface
 {
-    private static $regex = '/<\{(?<parameter>.*)\}>/i';
+    private static $regex = '/<\{(?<parameter>.*?)\}>/i';
 
     /**
      * @var ParameterBag
@@ -58,7 +58,7 @@ class Parameterized implements MethodInterface
                 if (false === $this->parameters->has($key)) {
                     throw new \UnexpectedValueException(
                         sprintf(
-                            'Parameter "%s" was not found',
+                            'Parameter "%s" was not found.',
                             $key
                         )
                     );

--- a/tests/Nelmio/Alice/Fixtures/Files/parameters/composite.yml
+++ b/tests/Nelmio/Alice/Fixtures/Files/parameters/composite.yml
@@ -10,8 +10,10 @@
 parameters:
     key1: NaN
     key2: Bat
-    composite: '<{key1}> <{key2>!'
+    composite: '<{key1}> <{key2}>!'
 
 Nelmio\Alice\support\models\User:
     user0:
         username: '<{composite}>'
+    user1:
+        username: '<{key1}> <{key2}>!'

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1707,30 +1707,40 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testCompositeParametersLoading()
     {
-        $this->markTestSkipped('Parameters cannot be composite yet.');
-        $res = $this->createLoader()->load(__DIR__ . '/Files/parameters/composite.yml');
+        $objects = $this->createLoader()->load(__DIR__ . '/Files/parameters/composite.yml');
 
-        $this->assertCount(1, $res);
+        $this->assertCount(2, $objects);
 
-        $user = $res['user0'];
+        $user = $objects['user0'];
         $this->assertInstanceOf(self::USER, $user);
-        $this->assertEquals('Nan Bat!', $user->username);
+        //$this->assertEquals('NaN Bat!', $user->username); Not supported yet
+        $this->assertEquals('<{key1}> <{key2}>!', $user->username);
+
+        $user = $objects['user1'];
+        $this->assertInstanceOf(self::USER, $user);
+        //$this->assertEquals('NaN Bat!', $user->username); Not supported yet
+        $this->assertEquals('NaN Bat!', $user->username);
     }
 
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Parameter "username_<current()>" was not found.
+     */
     public function testDynamicParametersLoading()
     {
-        $this->markTestSkipped('Parameters cannot be dynamic yet.');
-        $res = $this->createLoader()->load(__DIR__ . '/Files/parameters/dynamic.yml');
+        $objects = $this->createLoader()->load(__DIR__ . '/Files/parameters/dynamic.yml');
+        $this->fail('Expected exception to be thrown.');
 
-        $this->assertCount(2, $res);
+        // Skipped: not supported yet
+        //$this->assertCount(2, $objects);
 
-        $alice = $res['user_alice'];
-        $this->assertInstanceOf(self::USER, $alice);
-        $this->assertEquals('Alice', $alice->username);
+        //$alice = $objects['user_alice'];
+        //$this->assertInstanceOf(self::USER, $alice);
+        //$this->assertEquals('Alice', $alice->username);
 
-        $bob = $res['user_bob'];
-        $this->assertInstanceOf(self::USER, $bob);
-        $this->assertEquals('Bob', $bob->username);
+        //$bob = $objects['user_bob'];
+        //$this->assertInstanceOf(self::USER, $bob);
+        //$this->assertEquals('Bob', $bob->username);
     }
 
     public function testBackslashes()

--- a/tests/Nelmio/Alice/Instances/Processor/Methods/ParameterizedTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/Methods/ParameterizedTest.php
@@ -101,6 +101,10 @@ class ParameterizedTest extends \PHPUnit_Framework_TestCase
                 new Processable('<{<{part1}> <{part2}>}>'),
                 true,
             ],
+            'successive' => [
+                new Processable('<{foo}> <{bar}>'),
+                true,
+            ],
             'dynamic' => [
                 new Processable('<{username_<current()>}>'),
                 true,


### PR DESCRIPTION
In b80fdfa (https://github.com/nelmio/alice/pull/355), the Processor method Parameterized has been refactored to be more readable and robust. In the process, a non covered case involving composite keys has been broken. This commit fix the BC break introduced and add a test case for it.

Related to #421.