### PR TITLE
Add tests for templates declared in includes

### DIFF
--- a/tests/Nelmio/Alice/Fixtures/Files/includes/base_user.yml
+++ b/tests/Nelmio/Alice/Fixtures/Files/includes/base_user.yml
@@ -1,0 +1,3 @@
+Nelmio\Alice\support\models\User:
+    base_user (template):
+        username: 'Base user'

--- a/tests/Nelmio/Alice/Fixtures/Files/includes/user.yml
+++ b/tests/Nelmio/Alice/Fixtures/Files/includes/user.yml
@@ -1,0 +1,5 @@
+include:
+    - 'base_user.yml'
+
+Nelmio\Alice\support\models\User:
+    user0 (extends base_user): {}

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1020,6 +1020,17 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->loader->getReference('user2')->fullname, 'testfullname');
     }
 
+    public function testTemplatesAreKeptBetweenFiles()
+    {
+        $objects = $this->createLoader()->load(__DIR__.'/Files/includes/user.yml');
+
+        $this->assertCount(1, $objects);
+        /** @var User $user0 */
+        $user0 = $this->loader->getReference('user0');
+        $this->assertInstanceOf(self::USER, $user0);
+        $this->assertSame($user0->username, 'Base user');
+    }
+
     public function testTemplateCanExtendOtherTemplateObjectsCombinedWithRange()
     {
         $res = $this->loadData([


### PR DESCRIPTION
As reported in https://github.com/nelmio/alice/issues/276, it appears that if a fixture extends a template declared in another file which is included, an exception stating that the template has not been found is thrown.

The issue has been reported the Sep 24, 2015 which is quite old at the time of writing. This commit includes a test to account for that scenario, which appears to have been solved since then.