### PR TITLE
[On Hold] Add support for stdClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.3.0 (WIP)
+
+#### Features
+
+* Add support for stdClass objects (#425)
+
+
 ### 2.2.2 (2016-07-15)
 
 #### Bugfixes

--- a/src/Nelmio/Alice/Model/stdClass.php
+++ b/src/Nelmio/Alice/Model/stdClass.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Model;
+
+/**
+ * Extends stdclass to support alice Populator.
+ */
+final class stdClass extends \stdClass
+{
+    /**
+     * @param string $method    Method name
+     * @param array  $arguments Arguments of the method
+     */
+    function __call($method, $arguments)
+    {
+        $property = preg_replace('/^set/', '', $method);
+        $this->$property = $arguments[0];
+    }
+}

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -1626,6 +1626,54 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Could not determine how to assign name to a stdClass object
+     */
+    public function testCannotUseStdClass()
+    {
+        $this->loadData(
+            [
+                \stdClass::class => [
+                    'dummy0' => [
+                        'name' => 'foo',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function testStdClassSupport()
+    {
+        $loader = $this->createLoader();
+        $objects = $loader->load(
+            [
+                \Nelmio\Alice\Model\stdClass::class => [
+                    'dummy0' => [
+                        'name' => 'foo',
+                        'pseudo' => null,
+                    ],
+                    'dummy1' => [
+                        'name' => 'bar',
+                        'related' => '@dummy0',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertCount(2, $objects);
+
+        $dummy0 = $loader->getReference('dummy0');
+        $this->assertInstanceOf(\Nelmio\Alice\Model\stdClass::class, $dummy0);
+        $this->assertEquals('foo', $dummy0->name);
+        $this->assertNull($dummy0->pseudo);
+
+        $dummy1 = $loader->getReference('dummy1');
+        $this->assertInstanceOf(\Nelmio\Alice\Model\stdClass::class, $dummy1);
+        $this->assertEquals('bar', $dummy1->name);
+        $this->assertSame($dummy0, $dummy1->related);
+    }
+
     public function testUseTypehintInSetter()
     {
         $loader = $this->createLoader();


### PR DESCRIPTION
Sometimes, especially for testing, it is cumbersome to have to create a dedicated model and it would be nicer to have a more flexible class with the most basic behaviour. Ideally, stdClass would be a perfect candidate for that. However this cannot work as alice Populator will throw an exception as it will find no properties or methods. To avoid weird behaviours in regular usage, it is better to not change that and instead have a custom class to mimicate stdClass.

Closes https://github.com/nelmio/alice/issues/187

Status on hold: as is a new feature will wait `2.2.1` which should come shortly to be released.