### PR TITLE
Fix usage of empty values with Faker provider

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -145,13 +145,13 @@ class Faker implements MethodInterface
      */
     public function replacePlaceholder($matches, array $variables)
     {
-        $args = isset($matches['args']) && '' !== $matches['args'] ? $matches['args'] : null;
+        $args = array_key_exists('args', $matches) && '' !== $matches['args'] ? $matches['args'] : null;
 
         if (trim($matches['name']) == '') {
             $matches['name'] = 'identity';
         }
 
-        if (!$args) {
+        if (null === $args) {
             return $this->fake($matches['name'], $matches['locale']);
         }
 

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\Alice\Fixtures;
 
+use Nelmio\Alice\support\extensions\FakerProviderWithRequiredParameter;
+use Nelmio\Alice\support\models\DummyWithVariadicConstructor;
 use Nelmio\Alice\support\models\Group;
 use Nelmio\Alice\support\models\MagicUser;
 use Nelmio\Alice\support\models\User;
@@ -103,6 +105,45 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
             sprintf('%s cannot be parsed - no parser exists that can handle it.', $file)
         );
         $this->createLoader()->load($file);
+    }
+
+    public function testFakerProviderWithEmptyValues()
+    {
+        $objects = $this
+            ->createLoader([
+                'providers' => [
+                    new FakerProviderWithRequiredParameter(),
+                ]
+            ])
+            ->load([
+                DummyWithVariadicConstructor::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            '<passValue([])>',
+                            '<passValue(0)>',
+                            '<passValue("")>',
+                            '<passValue(null)>',
+                            '<passValue(false)>',
+                        ],
+                    ],
+                ],
+            ])
+        ;
+
+        $this->assertCount(1, $objects);
+        /** @var DummyWithVariadicConstructor $dummy */
+        $dummy = $objects['dummy'];
+
+        $this->assertSame(
+            [
+                [],
+                0,
+                '',
+                null,
+                false,
+            ],
+            $dummy->data
+        );
     }
 
     public function testCreatePrivateConstructorInstance()

--- a/tests/Nelmio/Alice/support/extensions/FakerProviderWithRequiredParameter.php
+++ b/tests/Nelmio/Alice/support/extensions/FakerProviderWithRequiredParameter.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\extensions;
+
+/**
+ * Faker provider with a method that takes 1 mandatory parameter.
+ */
+class FakerProviderWithRequiredParameter
+{
+    public function passValue($value)
+    {
+        return $value;
+    }
+}

--- a/tests/Nelmio/Alice/support/models/DummyWithVariadicConstructor.php
+++ b/tests/Nelmio/Alice/support/models/DummyWithVariadicConstructor.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\models;
+
+class DummyWithVariadicConstructor
+{
+    /**
+     * @var array
+     */
+    public $data;
+
+    public function __construct(...$arguments)
+    {
+        $this->data = $arguments;
+    }
+}


### PR DESCRIPTION
Due to some laxist checks done for a custom Faker provider function arguments, if empty values are passed, it is passing as if no arguments has been given. This PR enforce stricter checks and add a test case for it.

Closes https://github.com/nelmio/alice/issues/196.