### PR TITLE
Add tests for Typehints in setters

### DIFF
--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -13,6 +13,9 @@ namespace Nelmio\Alice\Fixtures;
 
 use Nelmio\Alice\support\models\Group;
 use Nelmio\Alice\support\models\MagicUser;
+use Nelmio\Alice\support\models\typehint\Dummy;
+use Nelmio\Alice\support\models\typehint\DummyWithInterface;
+use Nelmio\Alice\support\models\typehint\RelatedDummy;
 use Nelmio\Alice\support\models\User;
 use Nelmio\Alice\support\extensions;
 
@@ -1546,6 +1549,102 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
                 ]
             ]
         );
+    }
+
+    public function testUseTypehintInSetter()
+    {
+        $loader = $this->createLoader();
+        $objects = $loader->load([
+            Dummy::class => [
+               'dummy0' => [
+                   'related_dummy' => '@related_dummy0',
+               ],
+            ],
+            RelatedDummy::class => [
+                'related_dummy0' => [],
+            ],
+        ]);
+
+        $dummy0 = $loader->getReference('dummy0');
+        $relatedDummy0 = $loader->getReference('related_dummy0');
+
+        $this->assertInstanceOf(Dummy::class, $dummy0);
+        $this->assertInstanceOf(RelatedDummy::class, $relatedDummy0);
+
+        $this->assertCount(2, $objects);
+        $this->assertSame($dummy0->data, $relatedDummy0);
+    }
+
+    public function testUseTypehintInSetterWithLocalFlag()
+    {
+        $loader = $this->createLoader();
+        $objects = $loader->load([
+            Dummy::class => [
+                'dummy0' => [
+                    'related_dummy' => '@related_dummy0',
+                ],
+            ],
+            RelatedDummy::class => [
+                'related_dummy0 (local)' => [],
+            ],
+        ]);
+
+        $dummy0 = $loader->getReference('dummy0');
+        $relatedDummy0 = $loader->getReference('related_dummy0');
+
+        $this->assertInstanceOf(Dummy::class, $dummy0);
+        $this->assertInstanceOf(RelatedDummy::class, $relatedDummy0);
+
+        $this->assertCount(1, $objects);
+        $this->assertSame($dummy0->data, $relatedDummy0);
+    }
+
+    public function testUseTypehintInSetterWithInterface()
+    {
+        $loader = $this->createLoader();
+        $objects = $loader->load([
+            DummyWithInterface::class => [
+                'dummy0' => [
+                    'related_dummy' => '@related_dummy0',
+                ],
+            ],
+            RelatedDummy::class => [
+                'related_dummy0' => [],
+            ],
+        ]);
+
+        $dummy0 = $loader->getReference('dummy0');
+        $relatedDummy0 = $loader->getReference('related_dummy0');
+
+        $this->assertInstanceOf(DummyWithInterface::class, $dummy0);
+        $this->assertInstanceOf(RelatedDummy::class, $relatedDummy0);
+
+        $this->assertCount(2, $objects);
+        $this->assertSame($dummy0->data, $relatedDummy0);
+    }
+
+    public function testUseTypehintInSetterWithInterfaceAndLocalFlag()
+    {
+        $loader = $this->createLoader();
+        $objects = $loader->load([
+            DummyWithInterface::class => [
+                'dummy0' => [
+                    'related_dummy' => '@related_dummy0',
+                ],
+            ],
+            RelatedDummy::class => [
+                'related_dummy0 (local)' => [],
+            ],
+        ]);
+
+        $dummy0 = $loader->getReference('dummy0');
+        $relatedDummy0 = $loader->getReference('related_dummy0');
+
+        $this->assertInstanceOf(DummyWithInterface::class, $dummy0);
+        $this->assertInstanceOf(RelatedDummy::class, $relatedDummy0);
+
+        $this->assertCount(1, $objects);
+        $this->assertSame($dummy0->data, $relatedDummy0);
     }
 
     public function testNullVariable()

--- a/tests/Nelmio/Alice/support/models/typehint/Dummy.php
+++ b/tests/Nelmio/Alice/support/models/typehint/Dummy.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\models\typehint;
+
+class Dummy
+{
+    public $data;
+    
+    public function setRelatedDummy(RelatedDummy $relatedDummy)
+    {
+        $this->data = $relatedDummy;
+    }
+}

--- a/tests/Nelmio/Alice/support/models/typehint/DummyWithInterface.php
+++ b/tests/Nelmio/Alice/support/models/typehint/DummyWithInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\models\typehint;
+
+class DummyWithInterface
+{
+    public $data;
+    
+    public function setRelatedDummy(RelatedDummyInterface $relatedDummy)
+    {
+        $this->data = $relatedDummy;
+    }
+}

--- a/tests/Nelmio/Alice/support/models/typehint/RelatedDummy.php
+++ b/tests/Nelmio/Alice/support/models/typehint/RelatedDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\models\typehint;
+
+/**
+ * Empty class, used only for the typehint.
+ */
+class RelatedDummy implements RelatedDummyInterface
+{
+}

--- a/tests/Nelmio/Alice/support/models/typehint/RelatedDummyInterface.php
+++ b/tests/Nelmio/Alice/support/models/typehint/RelatedDummyInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *  
+ * (c) Nelmio <hello@nelm.io>
+ *  
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\support\models\typehint;
+
+/**
+ * Empty class, used only for the typehint.
+ */
+interface RelatedDummyInterface
+{
+}


### PR DESCRIPTION
As reported in https://github.com/nelmio/alice/issues/357, there was an issue when using typehint in setters with embedabbles objects. It seems that this issue has been solved in 2.2.0. This commit add tests for this use case to demonstrate it.

Closes #357.