### PR TITLE
Rework ObjectBag

### DIFF
--- a/src/Nelmio/Alice/ObjectSet.php
+++ b/src/Nelmio/Alice/ObjectSet.php
@@ -29,7 +29,7 @@ final class ObjectSet
     public function __construct(ParameterBag $parameters, ObjectBag $objects)
     {
         $this->parameters = $parameters->toArray();
-        $this->objects = $objects->toFlatArray();
+        $this->objects = $objects->toArray();
     }
 
     public function getParameters(): array

--- a/tests/Nelmio/Alice/FixtureBuilder/SimpleBuilderTest.php
+++ b/tests/Nelmio/Alice/FixtureBuilder/SimpleBuilderTest.php
@@ -41,15 +41,11 @@ class SimpleBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBuildSet()
     {
         $data = [
-            'stdClass' => [
-                'dummy' => new \stdClass(),
-            ],
+            'dummy' => new \stdClass(),
         ];
         $injectedParameters = ['foo' => 'bar'];
         $injectedObjects = [
-            'stdClass' => [
-                'another_dummy' => new \stdClass(),
-            ],
+            'another_dummy' => new \stdClass(),
         ];
         $loadedParameters = new ParameterBag(['rab' => 'oof']);
         $loadedFixtures = new FixtureBag();

--- a/tests/Nelmio/Alice/FixtureSetTest.php
+++ b/tests/Nelmio/Alice/FixtureSetTest.php
@@ -22,9 +22,7 @@ class FixtureSetTest extends \PHPUnit_Framework_TestCase
         $injectedParameters = new ParameterBag(['foo' => 'baz']);
         $fixtures = new FixtureBag();
         $injectedObjects = new ObjectBag([
-            'stdClass' => [
-                'dummy' => new \stdClass(),
-            ],
+            'dummy' => new \stdClass(),
         ]);
 
         $set = new FixtureSet($loadedParameters, $injectedParameters, $fixtures, $injectedObjects);
@@ -41,9 +39,7 @@ class FixtureSetTest extends \PHPUnit_Framework_TestCase
         $injectedParameters = new ParameterBag(['foo' => 'baz']);
         $fixtures = new FixtureBag();
         $injectedObjects = new ObjectBag([
-            'stdClass' => [
-                'dummy' => new \stdClass(),
-            ],
+            'dummy' => new \stdClass(),
         ]);
 
         $set = new FixtureSet($loadedParameters, $injectedParameters, $fixtures, $injectedObjects);
@@ -63,9 +59,7 @@ class FixtureSetTest extends \PHPUnit_Framework_TestCase
         $injectedParameters = new ParameterBag(['foo' => 'baz']);
         $fixtures = new FixtureBag();
         $injectedObjects = new ObjectBag([
-            'stdClass' => [
-                'dummy' => new \stdClass(),
-            ],
+            'dummy' => new \stdClass(),
         ]);
 
         $set = new FixtureSet($loadedParameters, $injectedParameters, $fixtures, $injectedObjects);

--- a/tests/Nelmio/Alice/Generator/Instantiator/InstantiatorResolverTest.php
+++ b/tests/Nelmio/Alice/Generator/Instantiator/InstantiatorResolverTest.php
@@ -66,7 +66,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedFixtureSet(
             new ParameterBag(),
             (new FixtureBag())->with($fixture->withSpecs($resolvedSpecs)),
-            new ObjectBag(['std' => ['dummy' => new \stdClass()]])
+            new ObjectBag(['dummy' => new \stdClass()])
         );
 
         $resolverProphecy = $this->prophesize(ValueResolverInterface::class);
@@ -132,7 +132,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedFixtureSet(
             new ParameterBag(),
             (new FixtureBag())->with($fixture),
-            new ObjectBag(['std' => ['dummy' => new \stdClass()]])
+            new ObjectBag(['dummy' => new \stdClass()])
         );
 
         $resolverProphecy = $this->prophesize(ValueResolverInterface::class);
@@ -164,7 +164,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedFixtureSet(
             new ParameterBag(),
             (new FixtureBag())->with($fixture),
-            new ObjectBag(['std' => ['dummy' => new \stdClass()]])
+            new ObjectBag(['dummy' => new \stdClass()])
         );
 
         $resolverProphecy = $this->prophesize(ValueResolverInterface::class);

--- a/tests/Nelmio/Alice/Generator/Resolver/SimpleResolverTest.php
+++ b/tests/Nelmio/Alice/Generator/Resolver/SimpleResolverTest.php
@@ -46,9 +46,7 @@ class SimpleResolverTest extends \PHPUnit_Framework_TestCase
         $injectedParameters = new ParameterBag(['fou' => 'baz']);
         $unresolvedFixtures = (new FixtureBag())->with($unresolvedFixture);
         $injectedObjects = new ObjectBag([
-            'stdClass' => [
-                'std' => new \stdClass(),
-            ],
+            'std' => new \stdClass(),
         ]);
 
         $set = new FixtureSet($loadedParameters, $injectedParameters, $unresolvedFixtures, $injectedObjects);

--- a/tests/Nelmio/Alice/Generator/SimpleGeneratorTest.php
+++ b/tests/Nelmio/Alice/Generator/SimpleGeneratorTest.php
@@ -63,9 +63,7 @@ class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $fixtures = (new FixtureBag())->with($fixture);
         $objects = new ObjectBag([
-            'stdClass' => [
-                'std' => new \stdClass(),
-            ],
+            'std' => new \stdClass(),
         ]);
 
         $set = new FixtureSet($loadedParameters, $injectedParameters, $fixtures, $objects);

--- a/tests/Nelmio/Alice/ObjectBagTest.php
+++ b/tests/Nelmio/Alice/ObjectBagTest.php
@@ -33,27 +33,15 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
     public function testConstructBag()
     {
         $objects = [
-            'Nelmio\Entity\User' => [
-                'user1' => new \stdClass(),
-                'user2' => new \stdClass(),
-            ],
-            'Nelmio\Entity\Group' => [
-                'group1' => new \stdClass(),
-                'group2' => new \stdClass(),
-            ],
+            'user1' => new \stdClass(),
+            'user2' => new \stdClass(),
         ];
         $bag = new ObjectBag($objects);
 
         $this->assertSameObjects(
             [
-                'Nelmio\Entity\User' => [
-                    'user1' => new SimpleObject('user1', new \stdClass()),
-                    'user2' => new SimpleObject('user2', new \stdClass()),
-                ],
-                'Nelmio\Entity\Group' => [
-                    'group1' => new SimpleObject('group1', new \stdClass()),
-                    'group2' => new SimpleObject('group2', new \stdClass()),
-                ],
+                'user1' => new SimpleObject('user1', new \stdClass()),
+                'user2' => new SimpleObject('user2', new \stdClass()),
             ],
             $bag
         );
@@ -67,49 +55,29 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         );
 
         $objects = [
-            'Nelmio\Entity\User' => [
-                0 => new \stdClass(),
-            ],
+            0 => new \stdClass(),
         ];
         $bag = new ObjectBag($objects);
 
         $this->assertSameObjects(
             [
-                'Nelmio\Entity\User' => [
-                    '0' => new SimpleObject('0', new \stdClass()),
-                ],
+                '0' => new SimpleObject('0', new \stdClass()),
             ],
             $bag
         );
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessage Expected array of objects to be an array where keys are FQCN and values arrays of
-     *                           object reference/object pairs but found a "object" instead of an array.',
-     */
-    public function testThrowErrorOnInvalidArgument()
-    {
-        new ObjectBag([
-            'user1' => new \stdClass(),
-        ]);
-    }
-
     public function testAccessors()
     {
         $objects = [
-            'Nelmio\Entity\User' => [
-                'user1' => new \stdClass(),
-            ],
-            'Nelmio\Entity\Group' => [
-                'group1' => new \stdClass(),
-            ],
+            'user1' => new \stdClass(),
+            'group1' => new \stdClass(),
         ];
         $bag = new ObjectBag($objects);
 
-        $user1Fixture = $this->createFixture('user1', 'Nelmio\Entity\User');
-        $group1Fixture = $this->createFixture('group1', 'Nelmio\Entity\Group');
-        $userWithWrongClass = $this->createFixture('user1', 'stdClass');
+        $user1Fixture = $this->createFixture('user1', \stdClass::class);
+        $group1Fixture = $this->createFixture('group1', \stdClass::class);
+        $inexistingReference = $this->createFixture('unknown', 'Dummy');
 
         $this->assertTrue($bag->has($user1Fixture));
         $this->assertEquals(
@@ -123,13 +91,13 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
             $bag->get($group1Fixture)
         );
 
-        $this->assertFalse($bag->has($userWithWrongClass));
+        $this->assertFalse($bag->has($inexistingReference));
         try {
-            $bag->get($userWithWrongClass);
+            $bag->get($inexistingReference);
             $this->fail('Expected exception to be thrown.');
         } catch (ObjectNotFoundException $exception) {
             $this->assertEquals(
-                'Could not find the object "user1" of the class "stdClass".',
+                'Could not find the object "unknown" of the class "Dummy".',
                 $exception->getMessage()
             );
         }
@@ -156,25 +124,16 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $this->assertSameObjects([], $bag);
         $this->assertSameObjects(
             [
-                'stdClass' => [
-                    'foo' => $object1,
-                    'bar' => $object2,
-                ],
+                'foo' => $object1,
+                'bar' => $object2,
             ],
             $bag1
         );
         $this->assertSameObjects(
             [
-                'stdClass' => [
-                    'foo' => $object1,
-                    'bar' => $object2,
-                ],
-                'Nelmio\Alice\Dummy' => [
-                    'foo' => $object3,
-                ],
-                'Nelmio\Alice\AnotherDummy' => [
-                    'baz' => $object4,
-                ],
+                'foo' => $object3,
+                'bar' => $object2,
+                'baz' => $object4,
             ],
             $bag2
         );
@@ -205,33 +164,23 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(ObjectBag::class, $bag);
         $this->assertSameObjects(
             [
-                'stdClass' => [
-                    'foo' => $object1,
-                    'bar' => $object2,
-                ],
+                'foo' => $object1,
+                'bar' => $object2,
             ],
             $bag1
         );
         $this->assertSameObjects(
             [
-                'stdClass' => [
-                    'bar' => $object3,
-                ],
-                'Nelmio\Alice\Dummy' => [
-                    'baz' => $object4,
-                ],
+                'bar' => $object3,
+                'baz' => $object4,
             ],
             $bag2
         );
         $this->assertSameObjects(
             [
-                'stdClass' => [
-                    'foo' => $object1,
-                    'bar' => $object3,
-                ],
-                'Nelmio\Alice\Dummy' => [
-                    'baz' => $object4,
-                ],
+                'foo' => $object1,
+                'bar' => $object3,
+                'baz' => $object4,
             ],
             $bag
         );
@@ -250,13 +199,52 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(
             [
-                'stdClass' => [
-                    'foo' => $object1,
-                    'bar' => $object2,
-                ],
+                'foo' => $object1,
+                'bar' => $object2,
             ],
             $traversed
         );
+    }
+
+    public function testToArray()
+    {
+        $object1 = new SimpleObject('foo', new \stdClass());
+        $object2 = new SimpleObject('bar', new \stdClass());
+        $bag = (new ObjectBag())->with($object1)->with($object2);
+
+        $this->assertEquals(
+            [
+                'foo' => $object1->getInstance(),
+                'bar' => $object2->getInstance(),
+            ],
+            $bag->toArray()
+        );
+        $this->assertEquals(count($bag), count($bag->toArray()));
+    }
+
+    public function testCountable()
+    {
+        $this->assertTrue(is_a(ObjectBag::class, \Countable::class, true));
+
+        $bag = new ObjectBag();
+        $this->assertEquals(0, $bag->count());
+
+        $bag = new ObjectBag([
+            'foo' => new \stdClass(),
+            'bar' => new \stdClass(),
+        ]);
+        $this->assertEquals(2, $bag->count());
+
+        $object1 = new SimpleObject('foo', new \stdClass());
+        $object2 = new SimpleObject('bar', new \stdClass());
+        $bag = (new ObjectBag())->with($object1)->with($object2);
+        $this->assertEquals(2, $bag->count());
+
+        $object3 = new SimpleObject('foz', new \stdClass());
+        $object4 = new SimpleObject('baz', new \stdClass());
+        $anotherBag = (new ObjectBag())->with($object3)->with($object4);
+        $bag = $bag->mergeWith($anotherBag);
+        $this->assertEquals(4, $bag->count());
     }
 
     private function assertSameObjects(array $expected, ObjectBag $actual)
@@ -274,73 +262,6 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $fixtureProphecy->getClassName()->willReturn($className);
 
         return $fixtureProphecy->reveal();
-    }
-
-    public function testCountable()
-    {
-        $this->assertTrue(is_a(ObjectBag::class, \Countable::class, true));
-
-        $bag = new ObjectBag();
-        $this->assertEquals(0, $bag->count());
-
-        $bag = new ObjectBag([
-            'stdClass' => [
-                'foo' => new \stdClass(),
-                'bar' => new \stdClass(),
-            ],
-        ]);
-        $this->assertEquals(2, $bag->count());
-
-        $object1 = new SimpleObject('foo', new \stdClass());
-        $object2 = new SimpleObject('bar', new \stdClass());
-        $bag = (new ObjectBag())->with($object1)->with($object2);
-        $this->assertEquals(2, $bag->count());
-
-        $object3 = new SimpleObject('foz', new \stdClass());
-        $object4 = new SimpleObject('baz', new \stdClass());
-        $anotherBag = (new ObjectBag())->with($object3)->with($object4);
-        $bag = $bag->mergeWith($anotherBag);
-        $this->assertEquals(4, $bag->count());
-    }
-
-    public function toFlatArray()
-    {
-        $bag = new ObjectBag();
-
-        $this->assertSame([], $bag->toFlatArray());
-
-        $object1 = new SimpleObject('foo', new \stdClass());
-        $object2 = new SimpleObject('bar', new \stdClass());
-        $bag = (new ObjectBag())->with($object1)->with($object2);
-
-        $this->assertSame(
-            [
-                'foo' => $object1->getInstance(),
-                'bar' => $object2->getInstance(),
-            ],
-            $bag->toFlatArray()
-        );
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Two objects have the reference "foo".
-     */
-    public function toFlatArrayWithReferenceOverlap()
-    {
-        $foo = new \stdClass();
-        $foo->faz = true;
-        $bag = new ObjectBag([
-            'stdClass' => [
-                'foo' => new \stdClass(),
-                'bar' => new \stdClass(),
-            ],
-            'stdFaz' => [
-                'foo' => $foo,
-            ]
-        ]);
-
-        $bag->toFlatArray();
     }
 }
 

--- a/tests/Nelmio/Alice/ObjectSetTest.php
+++ b/tests/Nelmio/Alice/ObjectSetTest.php
@@ -22,9 +22,7 @@ class ObjectSetTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar',
         ]);
         $objects = new ObjectBag([
-            'stdClass' => [
-                'dummy' => $std = new \stdClass(),
-            ]
+            'dummy' => $std = new \stdClass(),
         ]);
 
         $set = new ObjectSet($parameters, $objects);


### PR DESCRIPTION
The object bag is more complex than it needs to be because was assuming that the final output of the loader would follow the format:

```
[
  'Nelmio\Entity\User' => [
    'user1' => object,
  ]
]
```

But instead is:

```
[
  'user1' => object,
]
```

As mentioned in https://github.com/nelmio/alice/issues/420 this may lead to reference conflicts, however we don't think this should be much of a problem and a warning mechanism should be put into place to prevent that.