### PR TITLE
Add IsolatedLoader for tests

### DIFF
--- a/fixtures/Loader/IsolatedLoader.php
+++ b/fixtures/Loader/IsolatedLoader.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Loader;
+
+use Nelmio\Alice\DataLoaderInterface;
+use Nelmio\Alice\FileLoaderInterface;
+use Nelmio\Alice\ObjectSet;
+
+/**
+ * Make use of NativeLoader for easy usage but ensure than no state is kept between each usage, perfect for isolated
+ * tests.
+ */
+class IsolatedLoader implements FileLoaderInterface, DataLoaderInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function loadData(array $data, array $parameters = [], array $objects = []): ObjectSet
+    {
+        return (new NativeLoader())->loadData($data, $parameters, $objects);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function loadFile(string $file, array $parameters = [], array $objects = []): ObjectSet
+    {
+        return (new NativeLoader())->loadFile($file, $parameters, $objects);
+    }
+}

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Loader;
 
+use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Entity\Instantiator\DummyWithDefaultConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithExplicitDefaultConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructor;
@@ -21,6 +22,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithOptionalParameterInConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithPrivateConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithProtectedConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
+use Nelmio\Alice\FileLoaderInterface;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
 
 /**
@@ -29,13 +31,13 @@ use Nelmio\Alice\Throwable\InstantiationThrowable;
 class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var NativeLoader
+     * @var FileLoaderInterface|DataLoaderInterface
      */
     private $loader;
 
     public function setUp()
     {
-        $this->loader = (new NativeLoader())->getBuiltInDataLoader();
+        $this->loader = new IsolatedLoader();
     }
 
     public function testLoadEmptyInstances()


### PR DESCRIPTION
For the loader integration tests, we want to make sure to have a new fresh instance of the NativeLoader between each scenario to ensure a proper isolation. At this effect, IsolatedLoader provides a simple API for that.