### PR TITLE
Remove immutability

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,8 +38,8 @@
             <file>tests/Generator/ResolvedValueWithFixtureSetTest.php</file>
             <file>tests/Generator/Resolver/Fixture/TemplatingFixtureBagTest.php</file>
             <file>tests/Generator/Resolver/UniqueValuesPoolTest.php</file>
-            <file>tests/ExpressionLanguage/TokenTypeTest.php</file>
-            <file>tests/ExpressionLanguage/TokenTest.php</file>
+            <file>tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php</file>
+            <file>tests/FixtureBuilder/ExpressionLanguage/TokenTest.php</file>
         </testsuite>
         <testsuite name="Independent tests">
             <directory>tests/</directory>

--- a/src/Definition/Property.php
+++ b/src/Definition/Property.php
@@ -33,7 +33,7 @@ final class Property
     public function __construct(string $name, $value)
     {
         $this->name = $name;
-        $this->value = deep_clone($value);
+        $this->value = $value;
     }
 
     /**
@@ -44,7 +44,7 @@ final class Property
     public function withValue($value): self
     {
         $clone = clone $this;
-        $clone->value = deep_clone($value);
+        $clone->value = $value;
 
         return $clone;
     }
@@ -59,6 +59,6 @@ final class Property
      */
     public function getValue()
     {
-        return deep_clone($this->value);
+        return $this->value;
     }
 }

--- a/src/Definition/SpecificationBag.php
+++ b/src/Definition/SpecificationBag.php
@@ -39,7 +39,7 @@ final class SpecificationBag
      */
     public function __construct(MethodCallInterface $constructor = null, PropertyBag $properties, MethodCallBag $calls)
     {
-        $this->constructor = (null === $constructor) ? null : clone $constructor;
+        $this->constructor = $constructor;
         $this->properties = $properties;
         $this->calls = $calls;
     }
@@ -47,7 +47,7 @@ final class SpecificationBag
     public function withConstructor(MethodCallInterface $constructor = null): self
     {
         $clone = clone $this;
-        $clone->constructor = (null === $constructor) ? null : clone $constructor;
+        $clone->constructor = $constructor;
 
         return $clone;
     }
@@ -57,17 +57,17 @@ final class SpecificationBag
      */
     public function getConstructor()
     {
-        return (null === $this->constructor) ? null : clone $this->constructor;
+        return $this->constructor;
     }
     
     public function getProperties(): PropertyBag
     {
-        return clone $this->properties;
+        return $this->properties;
     }
     
     public function getMethodCalls(): MethodCallBag
     {
-        return clone $this->calls;
+        return $this->calls;
     }
 
     /**
@@ -89,5 +89,12 @@ final class SpecificationBag
         $clone->calls = $this->calls->mergeWith($specs->calls);
 
         return $clone;
+    }
+
+    public function __clone()
+    {
+        if (null !== $this->constructor) {
+            $this->constructor = clone $this->constructor;
+        }
     }
 }

--- a/tests/Definition/Fixture/FixtureWithFlagsTest.php
+++ b/tests/Definition/Fixture/FixtureWithFlagsTest.php
@@ -53,27 +53,6 @@ class FixtureWithFlagsTest extends \PHPUnit_Framework_TestCase
         $decoratedFixtureProphecy->getSpecs()->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     * @depends Nelmio\Alice\Definition\FlagBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $specs = SpecificationBagFactory::create();
-        $decoratedFixture = new MutableFixture('mutable', 'Mutable', $specs);
-        $flags = new FlagBag('something');
-        $fixture = new FixtureWithFlags($decoratedFixture, $flags);
-
-        $newSpecs = SpecificationBagFactory::create(new FakeMethodCall());
-        $decoratedFixture->setSpecs($newSpecs);
-
-        $this->assertEquals($specs, $fixture->getSpecs());
-    }
-
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     * @depends Nelmio\Alice\Definition\FlagBagTest::testIsImmutable
-     */
     public function testWithersReturnNewModifiedInstance()
     {
         $specs = SpecificationBagFactory::create();

--- a/tests/Definition/Fixture/SimpleFixtureTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureTest.php
@@ -38,17 +38,6 @@ class SimpleFixtureTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($specs, $fixture->getSpecs());
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $this->assertTrue(true, 'Nothing to do here.');
-    }
-
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     */
     public function testWithersReturnNewModifiedInstance()
     {
         $reference = 'user0';

--- a/tests/Definition/Fixture/TemplatingFixtureTest.php
+++ b/tests/Definition/Fixture/TemplatingFixtureTest.php
@@ -67,28 +67,7 @@ class TemplatingFixtureTest extends \PHPUnit_Framework_TestCase
         $decoratedFixtureProphecy->getSpecs()->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $specs = SpecificationBagFactory::create();
-        $decoratedFixture = new MutableFixture('mutable', 'Mutable', $specs);
-        $flags = new FlagBag('something');
-
-        $fixtureWithFlags = new FixtureWithFlags($decoratedFixture, $flags);
-        $fixture = new TemplatingFixture($fixtureWithFlags);
-
-        $newSpecs = SpecificationBagFactory::create(new FakeMethodCall());
-        $decoratedFixture->setSpecs($newSpecs);
-
-        $this->assertEquals($specs, $fixture->getSpecs());
-    }
-
-    /**
-     * @depends Nelmio\Alice\Definition\SpecificationBagTest::testIsImmutable
-     */
-    public function testWithersKeepsImmutabilityAndReturnNewModifiedInstance()
+    public function testWithersReturnNewModifiedInstance()
     {
         $specs = SpecificationBagFactory::create();
         $newSpecs = SpecificationBagFactory::create(new FakeMethodCall());

--- a/tests/Definition/PropertyBagTest.php
+++ b/tests/Definition/PropertyBagTest.php
@@ -30,18 +30,7 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         $this->propRefl = $propRefl;
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\PropertyTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $this->assertTrue(true, 'Nothing to do.');
-    }
-
-    /**
-     * @depends Nelmio\Alice\Definition\PropertyTest::testIsImmutable
-     */
-    public function testWithersAreImmutableAndReturnNewModifiedInstance()
+    public function testWithersReturnNewModifiedInstance()
     {
         $property = new Property('username', 'alice');
 
@@ -49,7 +38,6 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         $newBag = $bag->with($property);
 
         $this->assertInstanceOf(PropertyBag::class, $newBag);
-        $this->assertNotSame($newBag, $bag);
         $this->assertSame([], $this->propRefl->getValue($bag));
         $this->assertSame(['username' => $property], $this->propRefl->getValue($newBag));
     }

--- a/tests/Definition/PropertyTest.php
+++ b/tests/Definition/PropertyTest.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\Alice\Definition;
 
+use Nelmio\Alice\Entity\StdClassFactory;
+
 /**
  * @covers Nelmio\Alice\Definition\Property
  */
@@ -26,44 +28,36 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $definition->getValue());
     }
 
-    public function testIsImmutable()
+    public function testIsMutable()
     {
-        $value = [
-            $arg0 = new \stdClass(),
-        ];
+        $value = new \stdClass();
         $definition = new Property('username', $value);
 
         // Mutate injected value
-        $arg0->foo = 'bar';
+        $value->foo = 'bar';
 
         // Mutate returned value
-        $definition->getValue()[0]->foo = 'baz';
+        $definition->getValue()->ping = 'pong';
 
-        $this->assertEquals([new \stdClass()], $definition->getValue());
+        $expected = StdClassFactory::create(['foo' => 'bar', 'ping' => 'pong']);
+        $actual = $definition->getValue();
+
+        $this->assertEquals($expected, $actual);
     }
 
-    public function testWithersAreImmutablesAndReturnNewModifiedInstance()
+    public function testWithersReturnNewModifiedInstance()
     {
-        $property = 'username';
-        $value = 'foo';
-        $newValue = [
-            $arg0 = new \stdClass(),
-        ];
-        $definition = new Property($property, $value);
-        $newDefinition = $definition->withValue($newValue);
+        $name = 'username';
+        $definition = new Property($name, 'foo');
+        $newDefinition = $definition->withValue(new \stdClass());
 
-        // Mutate injected value
-        $arg0->foo = 'bar';
-
-        // Mutate returned value
-        $newDefinition->getValue()[0]->foo = 'baz';
-
-        $this->assertInstanceOf(Property::class, $newDefinition);
-
-        $this->assertEquals($property, $definition->getName());
-        $this->assertEquals($property, $newDefinition->getName());
-
-        $this->assertEquals($value, $definition->getValue());
-        $this->assertEquals([new \stdClass()], $newDefinition->getValue());
+        $this->assertEquals(
+            new Property($name, 'foo'),
+            $definition
+        );
+        $this->assertEquals(
+            new Property($name, new \stdClass()),
+            $newDefinition
+        );
     }
 }

--- a/tests/Definition/SpecificationBagTest.php
+++ b/tests/Definition/SpecificationBagTest.php
@@ -38,27 +38,6 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($calls, $bag->getMethodCalls());
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\PropertyBagTest::testIsImmutable
-     * @depends Nelmio\Alice\Definition\MethodCallBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $constructor = new MutableMethodCall(null, 'mutable');
-        $properties = new PropertyBag();
-        $calls = new MethodCallBag();
-
-        $bag = new SpecificationBag($constructor, $properties, $calls);
-
-        // Mutate injected value
-        $constructor->setMethod('foo');
-
-        // Mutate returned value
-        $bag->getConstructor()->setMethod('bar');
-
-        $this->assertNotSame(new MutableMethodCall(null, 'mutable'), $bag->getConstructor());
-    }
-
     public function testWithersReturnNewModifiedInstance()
     {
         $constructor = null;
@@ -66,14 +45,8 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $calls = new MethodCallBag();
         $bag = new SpecificationBag($constructor, $properties, $calls);
 
-        $newConstructor = new MutableMethodCall(null, 'mutable');
+        $newConstructor = new FakeMethodCall();
         $newBag = $bag->withConstructor($newConstructor);
-
-        // Mutate injected value
-        $newConstructor->setMethod('foo');
-
-        // Mutate returned value
-        $newBag->getConstructor()->setMethod('bar');
 
         $this->assertInstanceOf(SpecificationBag::class, $newBag);
 
@@ -81,7 +54,7 @@ class SpecificationBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($calls, $bag->getMethodCalls());
         $this->assertEquals($properties, $bag->getProperties());
 
-        $this->assertEquals(new MutableMethodCall(null, 'mutable'), $newBag->getConstructor());
+        $this->assertEquals(new FakeMethodCall(), $newBag->getConstructor());
         $this->assertEquals($calls, $newBag->getMethodCalls());
         $this->assertEquals($properties, $newBag->getProperties());
     }

--- a/tests/FixtureSetTest.php
+++ b/tests/FixtureSetTest.php
@@ -32,14 +32,4 @@ class FixtureSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($fixtures, $set->getFixtures());
         $this->assertEquals($injectedObjects, $set->getObjects());
     }
-
-    /**
-     * @depends Nelmio\Alice\ParameterBagTest::testIsImmutable
-     * @depends Nelmio\Alice\FixtureBagTest::testIsImmutable
-     * @depends Nelmio\Alice\ObjectBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $this->assertTrue(true, 'Nothing to do.');
-    }
 }

--- a/tests/Generator/ResolvedFixtureSetTest.php
+++ b/tests/Generator/ResolvedFixtureSetTest.php
@@ -32,14 +32,4 @@ class ResolvedFixtureSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($fixtures, $set->getFixtures());
         $this->assertEquals($objects, $set->getObjects());
     }
-
-    /**
-     * @depends Nelmio\Alice\ParameterBagTest::testIsImmutable
-     * @depends Nelmio\Alice\FixtureBagTest::testIsImmutable
-     * @depends Nelmio\Alice\ObjectBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $this->assertTrue(true, 'Nothing to do.');
-    }
 }

--- a/tests/Generator/ResolvedValueWithFixtureSetTest.php
+++ b/tests/Generator/ResolvedValueWithFixtureSetTest.php
@@ -26,24 +26,4 @@ class ResolvedValueWithFixtureSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $resolvedValueWithSet->getValue());
         $this->assertEquals($set, $resolvedValueWithSet->getSet());
     }
-
-    /**
-     * @depends Nelmio\Alice\Generator\ResolvedFixtureSetTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $value = new \stdClass();
-        $set = ResolvedFixtureSetFactory::create();
-
-        $resolvedValueWithSet = new ResolvedValueWithFixtureSet($value, $set);
-
-        // Mutate injected value
-        $value->foo = 'bar';
-
-        // Mutate retrieved value
-        $resolvedValueWithSet->getValue()->foo = 'baz';
-
-        $this->assertEquals(new \stdClass(), $resolvedValueWithSet->getValue());
-        $this->assertEquals($set, $resolvedValueWithSet->getSet());
-    }
 }

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -114,25 +114,6 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $bag->get($this->createFixture('foo', 'Dummy'));
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\Object\SimpleObjectTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $bag = new ObjectBag(['foo' => $std = new \stdClass()]);
-
-        // Mutate injected object
-        $std->foo = 'bar';
-
-        // Mutate retrieved object
-        $bag->get($this->createFixture('foo', 'Dummy'))->getInstance()->foo = 'baz';
-
-        $this->assertEquals(
-            new ObjectBag(['foo' => new \stdClass()]),
-            $bag
-        );
-    }
-
     public function testWithersReturnNewModifiedInstance()
     {
         $bag = new ObjectBag(['foo' => new \stdClass()]);

--- a/tests/ObjectSetTest.php
+++ b/tests/ObjectSetTest.php
@@ -41,13 +41,4 @@ class ObjectSetTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertCount(1, $set->getObjects());
     }
-
-    /**
-     * @depends Nelmio\Alice\ParameterBagTest::testIsImmutable
-     * @depends Nelmio\Alice\ObjectBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
-    {
-        $this->assertTrue(true, 'Nothing to do.');
-    }
 }


### PR DESCRIPTION
The object graph generated by alice should not be immutable. As such immutability has been removed for the objects related to the objects described by the fixtures. Some elements like the Fixture properties or the method call are generated by alice and potentially requires mutability as well. As those elements are internal to alice (unless you dig really deep in which case you ought to know what you are doing), the risk presented by mutability are relatively small.