### PR TITLE
Fix some integration tests

### DIFF
--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -123,6 +123,7 @@ use Nelmio\Alice\NotClonableTrait;
 use Nelmio\Alice\ObjectSet;
 use Nelmio\Alice\Generator\Resolver\ParameterBagResolverInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
 
 /**
@@ -380,7 +381,7 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
             new DynamicArrayValueResolver(),
             new FakerFunctionCallValueResolver($this->fakerGenerator),
             new FixturePropertyReferenceResolver(
-                PropertyAccess::createPropertyAccessor()
+                $this->getPropertyAccessor()
             ),
             new FixtureReferenceResolver(),
             new FixtureWildcardReferenceResolver(),
@@ -395,7 +396,7 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
     protected function _getBuiltInPropertyHydrator(): PropertyHydratorInterface
     {
         return new SymfonyPropertyAccessorHydrator(
-            PropertyAccess::createPropertyAccessor()
+            $this->getPropertyAccessor()
         );
     }
 
@@ -461,5 +462,10 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
         $this->cache[$method] = $service;
 
         return $service;
+    }
+
+    protected function getPropertyAccessor(): PropertyAccessorInterface
+    {
+        return PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor();
     }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -159,7 +159,11 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 $this->fail('Expected exception to be thrown.');
             }
         } catch (InstantiationThrowable $exception) {
-            return;
+            if (null === $expected) {
+                return;
+            }
+
+            throw $exception;
         }
 
         $this->assertCount(1, $objects);
@@ -177,7 +181,11 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 $this->fail('Expected exception to be thrown.');
             }
         } catch (HydrationThrowable $exception) {
-            return;
+            if (null === $expected) {
+                return;
+            }
+
+            throw $exception;
         }
 
         $this->assertEquals(count($expected), count($objects));
@@ -195,7 +203,11 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 $this->fail('Expected exception to be thrown.');
             }
         } catch (GenerationThrowable $exception) {
-            return;
+            if (null === $expected) {
+                return;
+            }
+
+            throw $exception;
         }
 
         $expectedParameters = $expected['parameters'];
@@ -518,7 +530,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             [
                 DummyWithRequiredParameterInConstructor::class => [
                     'dummy' => [
-                        100,
+                        '__construct' => [100],
                     ],
                 ],
             ],
@@ -816,7 +828,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'dummy' => (function (MagicCallDummy $dummy) {
-                    $dummy->magicProperty('bob');
+                    $dummy->setMagicProperty('bob');
 
                     return $dummy;
                 })(new MagicCallDummy())
@@ -825,7 +837,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
 
         yield 'magic call snake_case property' => [
             [
-                SnakeCaseDummy::class => [
+                MagicCallDummy::class => [
                     'dummy' => [
                         'magic_property' => 'bob',
                     ],
@@ -833,7 +845,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'dummy' => (function (MagicCallDummy $dummy) {
-                    $dummy->magic_property('bob');
+                    $dummy->setMagicProperty('bob');
 
                     return $dummy;
                 })(new MagicCallDummy())
@@ -850,7 +862,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'dummy' => (function (MagicCallDummy $dummy) {
-                    $dummy->MagicProperty('bob');
+                    $dummy->setMagicProperty('bob');
 
                     return $dummy;
                 })(new MagicCallDummy())


### PR DESCRIPTION
Throw properly the exception when an exception is not expected to make the test fail in such cases instead of passing.