### PR TITLE
Fix values toString methods

### DIFF
--- a/src/Definition/Value/ChoiceListValue.php
+++ b/src/Definition/Value/ChoiceListValue.php
@@ -46,6 +46,6 @@ final class ChoiceListValue implements ValueInterface
      */
     public function __toString(): string
     {
-        return '(choice) vals';
+        return sprintf('(choice) %s', var_export($this->values, true));
     }
 }

--- a/src/Definition/Value/FixtureMethodCallValue.php
+++ b/src/Definition/Value/FixtureMethodCallValue.php
@@ -64,7 +64,7 @@ final class FixtureMethodCallValue implements ValueInterface
             '%s->%s(%s)',
             $this->reference,
             $this->function->getName(),
-            [] === $this->function->getArguments() ? '' : 'args'
+            [] === $this->function->getArguments() ? '' : var_export($this->function->getArguments(), true)
         );
     }
 }

--- a/src/Definition/Value/FunctionCallValue.php
+++ b/src/Definition/Value/FunctionCallValue.php
@@ -67,6 +67,6 @@ final class FunctionCallValue implements ValueInterface
      */
     public function __toString(): string
     {
-        return sprintf('<%s(%s)>', $this->name, [] === $this->arguments ? '' : 'args');
+        return sprintf('<%s(%s)>', $this->name, [] === $this->arguments ? '' : var_export($this->arguments, true));
     }
 }

--- a/src/Definition/Value/NestedValue.php
+++ b/src/Definition/Value/NestedValue.php
@@ -43,6 +43,6 @@ final class NestedValue implements ValueInterface
      */
     public function __toString(): string
     {
-        return '(nested) vals';
+        return sprintf('(nested) %s', var_export($this->values, true));
     }
 }

--- a/src/Definition/Value/UniqueValue.php
+++ b/src/Definition/Value/UniqueValue.php
@@ -72,7 +72,7 @@ final class UniqueValue implements ValueInterface
             '(unique) %s',
             $this->value instanceof ValueInterface
                 ? $this->value
-                : is_scalar($this->value) ? $this->value : 'vals'
+                : var_export($this->value, true)
         );
     }
 }

--- a/src/Exception/Generator/Resolver/ResolverNotFoundException.php
+++ b/src/Exception/Generator/Resolver/ResolverNotFoundException.php
@@ -30,7 +30,7 @@ class ResolverNotFoundException extends \LogicException
         return new static(
             sprintf(
                 'No resolver found to resolve value "%s".',
-                get_class($value)
+                $value
             )
         );
     }

--- a/src/Exception/Generator/Resolver/UnresolvableValueException.php
+++ b/src/Exception/Generator/Resolver/UnresolvableValueException.php
@@ -20,8 +20,8 @@ class UnresolvableValueException extends \RuntimeException implements Resolution
     {
         return new static(
             sprintf(
-                'Could not resolve value %s.',
-                get_class($value)
+                'Could not resolve value "%s".',
+                $value
             ),
             $code,
             $previous

--- a/tests/Definition/Value/ChoiceListValueTest.php
+++ b/tests/Definition/Value/ChoiceListValueTest.php
@@ -59,6 +59,9 @@ class ChoiceListValueTest extends \PHPUnit_Framework_TestCase
     public function testIsCastableIntoAString()
     {
         $value = new ChoiceListValue([]);
-        $this->assertEquals('(choice) vals', (string) $value);
+        $this->assertEquals("(choice) array (\n)", (string) $value);
+
+        $value = new ChoiceListValue(['foo', 'bar']);
+        $this->assertEquals("(choice) array (\n  0 => 'foo',\n  1 => 'bar',\n)", (string) $value);
     }
 }

--- a/tests/Definition/Value/FixtureMethodCallValueTest.php
+++ b/tests/Definition/Value/FixtureMethodCallValueTest.php
@@ -56,6 +56,6 @@ class FixtureMethodCallValueTest extends \PHPUnit_Framework_TestCase
             new FixtureReferenceValue('dummy'),
             new FunctionCallValue('foo', ['bar'])
         );
-        $this->assertEquals('@dummy->foo(args)', (string) $value);
+        $this->assertEquals("@dummy->foo(array (\n  0 => 'bar',\n))", (string) $value);
     }
 }

--- a/tests/Definition/Value/FunctionCallValueTest.php
+++ b/tests/Definition/Value/FunctionCallValueTest.php
@@ -69,6 +69,6 @@ class FunctionCallValueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<foo()>', (string) $value);
 
         $value = new FunctionCallValue('foo', ['bar']);
-        $this->assertEquals('<foo(args)>', (string) $value);
+        $this->assertEquals("<foo(array (\n  0 => 'bar',\n))>", (string) $value);
     }
 }

--- a/tests/Definition/Value/NestedValueTest.php
+++ b/tests/Definition/Value/NestedValueTest.php
@@ -47,6 +47,6 @@ class NestedValueTest extends \PHPUnit_Framework_TestCase
 
     public function testIsCastableIntoAString()
     {
-        $this->assertEquals('(nested) vals', (string) (new NestedValue([])));
+        $this->assertEquals("(nested) array (\n)", (string) (new NestedValue([])));
     }
 }

--- a/tests/Definition/Value/UniqueValueTest.php
+++ b/tests/Definition/Value/UniqueValueTest.php
@@ -83,10 +83,10 @@ class UniqueValueTest extends \PHPUnit_Framework_TestCase
     public function testIsCastableIntoAString()
     {
         $value = new UniqueValue('', 'foo');
-        $this->assertEquals('(unique) foo', (string) $value);
+        $this->assertEquals('(unique) \'foo\'', (string) $value);
 
         $value = new UniqueValue('', new \stdClass());
-        $this->assertEquals('(unique) vals', (string) $value);
+        $this->assertEquals("(unique) stdClass::__set_state(array(\n))", (string) $value);
 
         $value = new UniqueValue('', new DummyValue('foo'));
         $this->assertEquals('(unique) foo', (string) $value);

--- a/tests/Exception/Generator/Resolver/ResolverNotFoundExceptionTest.php
+++ b/tests/Exception/Generator/Resolver/ResolverNotFoundExceptionTest.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\Alice\Exception\Generator\Resolver;
 
-use Nelmio\Alice\Definition\Value\FakeValue;
+use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
@@ -41,10 +41,10 @@ class ResolverNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testTestCreateNewExceptionWithFactoryForValue()
     {
-        $exception = ResolverNotFoundException::createForValue(new FakeValue());
+        $exception = ResolverNotFoundException::createForValue(new DummyValue('dummy'));
 
         $this->assertEquals(
-            'No resolver found to resolve value "Nelmio\Alice\Definition\Value\FakeValue".',
+            'No resolver found to resolve value "dummy".',
             $exception->getMessage()
         );
     }

--- a/tests/Exception/Generator/Resolver/UnresolvableValueExceptionTest.php
+++ b/tests/Exception/Generator/Resolver/UnresolvableValueExceptionTest.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\Alice\Exception\Generator\Resolver;
 
-use Nelmio\Alice\Definition\Value\FakeValue;
+use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
@@ -31,10 +31,10 @@ class UnresolvableValueExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testTestCreateNewExceptionWithFactory()
     {
-        $exception = UnresolvableValueException::create(new FakeValue());
+        $exception = UnresolvableValueException::create(new DummyValue('dummy'));
 
         $this->assertEquals(
-            'Could not resolve value Nelmio\Alice\Definition\Value\FakeValue.',
+            'Could not resolve value "dummy".',
             $exception->getMessage()
         );
     }

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
+use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 use Nelmio\Alice\Entity\Hydrator\Dummy;
@@ -115,11 +116,12 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException
+     * @expectedExceptionMessage Could not resolve value "dummy->prop".
      */
     public function testCatchesAccessorExceptionsToThrowResolverException()
     {
         $value = new FixturePropertyValue(
-            $reference = new FakeValue(),
+            $reference = new DummyValue('dummy'),
             $property = 'prop'
         );
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
@@ -178,11 +180,12 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException
+     * @expectedExceptionMessage Could not resolve value "dummy->publicProperty".
      */
     public function testThrowsAnExceptionIfReferenceResolvedIsNotAnObject()
     {
         $value = new FixturePropertyValue(
-            $reference = new FakeValue(),
+            $reference = new DummyValue('dummy'),
             $property = 'publicProperty'
         );
 

--- a/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
+use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBag;
@@ -185,11 +186,11 @@ class FixtureReferenceResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not resolve value Nelmio\Alice\Definition\Value\FixtureReferenceValue.
+     * @expectedExceptionMessage Could not resolve value "@dummy".
      */
     public function testIfTheResolvedReferenceIsInvalidThenAnExceptionIsThrown()
     {
-        $value = new FixtureReferenceValue(new FakeValue());
+        $value = new FixtureReferenceValue(new DummyValue('dummy'));
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy

--- a/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
+use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
@@ -95,7 +96,7 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage No resolver found to resolve value "Nelmio\Alice\Definition\Value\FakeValue".
+     * @expectedExceptionMessage No resolver found to resolve value "foo".
      */
     public function testThrowExceptionIfNoSuitableParserIsFound()
     {
@@ -104,6 +105,6 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $registry = new ValueResolverRegistry([]);
-        $registry->resolve(new FakeValue(), $fixture, $set);
+        $registry->resolve(new DummyValue('foo'), $fixture, $set);
     }
 }


### PR DESCRIPTION
In some cases, the values were discarded in the string representation. This can falsify an equivalence comparison.

cf. https://3v4l.org/80WYW