### PR TITLE
Rework exceptions

### DIFF
--- a/fixtures/Definition/Flag/ElementWithToStringFlag.php
+++ b/fixtures/Definition/Flag/ElementWithToStringFlag.php
@@ -13,7 +13,6 @@ namespace Nelmio\Alice\Definition\Flag;
 
 use Nelmio\Alice\Definition\FlagInterface;
 
-//TODO: remove the final keyword in fixtures and tests
 class ElementWithToStringFlag implements FlagInterface
 {
     /**

--- a/src/Exception/FixtureBuilder/Denormalizer/DenormalizerNotFoundException.php
+++ b/src/Exception/FixtureBuilder/Denormalizer/DenormalizerNotFoundException.php
@@ -13,23 +13,33 @@ namespace Nelmio\Alice\Exception\FixtureBuilder\Denormalizer;
 
 class DenormalizerNotFoundException extends \LogicException
 {
-    public static function createForFixture(string $fixtureId)
+    /**
+     * @return static
+     */
+    public static function createForFixture(string $fixtureId, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No suitable fixture denormalizer found to handle the fixture with the reference "%s".',
                 $fixtureId
-            )
+            ),
+            $code,
+            $previous
         );
     }
 
-    public static function createUnexpectedCall(string $method)
+    /**
+     * @return static
+     */
+    public static function createUnexpectedCall(string $method, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Expected method "%s" to be called only if it has a denormalizer.',
                 $method
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserNotFoundException.php
+++ b/src/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserNotFoundException.php
@@ -13,23 +13,33 @@ namespace Nelmio\Alice\Exception\FixtureBuilder\Denormalizer\FlagParser;
 
 class FlagParserNotFoundException extends \LogicException
 {
-    public static function create(string $element): self
+    /**
+     * @return static
+     */
+    public static function create(string $element, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No suitable flag parser found to handle the element "%s".',
                 $element
-            )
+            ),
+            $code,
+            $previous
         );
     }
 
-    public static function createUnexpectedCall(string $method)
+    /**
+     * @return static
+     */
+    public static function createUnexpectedCall(string $method, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Expected method "%s" to be called only if it has a flag parser.',
                 $method
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/FixtureBuilder/Denormalizer/UnexpectedValueException.php
+++ b/src/Exception/FixtureBuilder/Denormalizer/UnexpectedValueException.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the Alice package.
  *
  * (c) Nelmio <hello@nelm.io>

--- a/src/Exception/FixtureBuilder/ExpressionLanguage/LexException.php
+++ b/src/Exception/FixtureBuilder/ExpressionLanguage/LexException.php
@@ -15,6 +15,9 @@ use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 class LexException extends \Exception implements ExpressionLanguageParseThrowable
 {
+    /**
+     * @return static
+     */
     public static function create(string $value, int $code = 0, \Throwable $previous = null)
     {
         return new static(

--- a/src/Exception/FixtureBuilder/ExpressionLanguage/ParseException.php
+++ b/src/Exception/FixtureBuilder/ExpressionLanguage/ParseException.php
@@ -16,6 +16,9 @@ use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 class ParseException extends \Exception implements ExpressionLanguageParseThrowable
 {
+    /**
+     * @return static
+     */
     public static function createForToken(Token $token, int $code = 0, \Throwable $previous = null)
     {
         return new static(

--- a/src/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundException.php
+++ b/src/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundException.php
@@ -15,24 +15,34 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 
 class ParserNotFoundException extends \LogicException
 {
-    public static function create(Token $token): self
+    /**
+     * @return static
+     */
+    public static function create(Token $token, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No suitable token parser found to handle the token "%s" (type: %s).',
                 $token->getValue(),
                 $token->getType()->getValue()
-            )
+            ),
+            $code,
+            $previous
         );
     }
 
-    public static function createUnexpectedCall(string $method)
+    /**
+     * @return static
+     */
+    public static function createUnexpectedCall(string $method, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Expected method "%s" to be called only if it has a parser.',
                 $method
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/FixtureNotFoundException.php
+++ b/src/Exception/FixtureNotFoundException.php
@@ -13,13 +13,18 @@ namespace Nelmio\Alice\Exception;
 
 class FixtureNotFoundException extends \UnexpectedValueException
 {
-    public static function create(string $id)
+    /**
+     * @return static
+     */
+    public static function create(string $id, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Could not find the fixture "%s".',
                 $id
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Hydrator/HydrationException.php
+++ b/src/Exception/Generator/Hydrator/HydrationException.php
@@ -15,21 +15,17 @@ use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\ObjectInterface;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 
-/**
- * @TODO: remove usage of self in return type for non final classes
- */
 class HydrationException extends \RuntimeException implements HydrationThrowable
 {
     /**
-     * @param ObjectInterface $object
-     * @param Property        $property
-     * @param int             $code
-     * @param \Throwable|null $previous
-     *
      * @return static
      */
-    public static function create(ObjectInterface $object, Property $property, int $code = 0, \Throwable $previous = null)
-    {
+    public static function create(
+        ObjectInterface $object,
+        Property $property,
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
         return new static(
             sprintf(
                 'Could not hydrate the property "%s" of the object "%s" (class: %s).',

--- a/src/Exception/Generator/Hydrator/HydratorNotFoundException.php
+++ b/src/Exception/Generator/Hydrator/HydratorNotFoundException.php
@@ -16,8 +16,15 @@ use Nelmio\Alice\ObjectInterface;
 
 class HydratorNotFoundException extends \LogicException
 {
-    public static function create(ObjectInterface $object, Property $property, int $code = 0, \Throwable $previous = null)
-    {
+    /**
+     * @return static
+     */
+    public static function create(
+        ObjectInterface $object,
+        Property $property,
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
         return new static(
             sprintf(
                 'Could not find the property "%s" for the object "%s" (class: %s).',

--- a/src/Exception/Generator/Hydrator/PropertyAccessException.php
+++ b/src/Exception/Generator/Hydrator/PropertyAccessException.php
@@ -19,8 +19,12 @@ class PropertyAccessException extends HydrationException
     /**
      * @inheritdoc
      */
-    public static function create(ObjectInterface $object, Property $property, int $code = 0, \Throwable $previous = null)
-    {
+    public static function create(
+        ObjectInterface $object,
+        Property $property,
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
         return new static(
             sprintf(
                 'Could not access to the property "%s" of the object "%s" (class: %s).',

--- a/src/Exception/Generator/Instantiator/InstantiationException.php
+++ b/src/Exception/Generator/Instantiator/InstantiationException.php
@@ -16,14 +16,17 @@ use Nelmio\Alice\Throwable\InstantiationThrowable;
 
 class InstantiationException extends \RuntimeException implements InstantiationThrowable
 {
-    public static function create(FixtureInterface $fixture, \Throwable $previous = null)
+    /**
+     * @return static
+     */
+    public static function create(FixtureInterface $fixture, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Could not instantiate fixture "%s".',
                 $fixture->getId()
             ),
-            0,
+            $code,
             $previous
         );
     }

--- a/src/Exception/Generator/Instantiator/InstantiatorNotFoundException.php
+++ b/src/Exception/Generator/Instantiator/InstantiatorNotFoundException.php
@@ -15,13 +15,18 @@ use Nelmio\Alice\FixtureInterface;
 
 class InstantiatorNotFoundException extends \LogicException
 {
-    public static function create(FixtureInterface $fixture): self
+    /**
+     * @return static
+     */
+    public static function create(FixtureInterface $fixture, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No suitable instantiator found for the fixture "%s".',
                 $fixture->getId()
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundException.php
+++ b/src/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundException.php
@@ -13,13 +13,18 @@ namespace Nelmio\Alice\Exception\Generator\ObjectGenerator;
 
 class ObjectGeneratorNotFoundException extends \LogicException
 {
-    public static function createUnexpectedCall(string $method)
+    /**
+     * @return static
+     */
+    public static function createUnexpectedCall(string $method, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Expected method "%s" to be called only if it has a generator.',
                 $method
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Resolver/CircularReferenceException.php
+++ b/src/Exception/Generator/Resolver/CircularReferenceException.php
@@ -15,14 +15,19 @@ use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 class CircularReferenceException extends \RuntimeException implements ResolutionThrowable
 {
-    public static function createForParameter(string $key, array $resolving)
+    /**
+     * @return static
+     */
+    public static function createForParameter(string $key, array $resolving, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Circular reference detected for the parameter "%s" while resolving ["%s"].',
                 $key,
                 implode('", "', array_keys($resolving))
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Resolver/NoSuchPropertyException.php
+++ b/src/Exception/Generator/Resolver/NoSuchPropertyException.php
@@ -16,8 +16,15 @@ use Nelmio\Alice\FixtureInterface;
 
 class NoSuchPropertyException extends UnresolvableValueException
 {
-    public static function createForFixture(FixtureInterface $fixture, FixturePropertyValue $value, int $code = 0, \Throwable $previous = null)
-    {
+    /**
+     * @return static
+     */
+    public static function createForFixture(
+        FixtureInterface $fixture,
+        FixturePropertyValue $value,
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
         return new static(
             sprintf(
                 'Could not find the property "%s" of the object "%s" (class: %s).',

--- a/src/Exception/Generator/Resolver/RecursionLimitReachedException.php
+++ b/src/Exception/Generator/Resolver/RecursionLimitReachedException.php
@@ -15,14 +15,19 @@ use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 class RecursionLimitReachedException extends \RuntimeException implements ResolutionThrowable
 {
-    public static function create(int $limit, string $key)
+    /**
+     * @return static
+     */
+    public static function create(int $limit, string $key, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Recursion limit (%d tries) reached while resolving the parameter "%s"',
                 $limit,
                 $key
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Resolver/ResolverNotFoundException.php
+++ b/src/Exception/Generator/Resolver/ResolverNotFoundException.php
@@ -15,33 +15,48 @@ use Nelmio\Alice\Definition\ValueInterface;
 
 class ResolverNotFoundException extends \LogicException
 {
-    public static function createForParameter(string $parameterKey)
+    /**
+     * @return static
+     */
+    public static function createForParameter(string $parameterKey, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No resolver found to resolve parameter "%s".',
                 $parameterKey
-            )
+            ),
+            $code,
+            $previous
         );
     }
 
-    public static function createForValue(ValueInterface $value)
+    /**
+     * @return static
+     */
+    public static function createForValue(ValueInterface $value, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No resolver found to resolve value "%s".',
                 $value
-            )
+            ),
+            $code,
+            $previous
         );
     }
 
-    public static function createUnexpectedCall(string $method)
+    /**
+     * @return static
+     */
+    public static function createUnexpectedCall(string $method, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Expected method "%s" to be called only if it has a resolver.',
                 $method
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedException.php
+++ b/src/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedException.php
@@ -16,14 +16,19 @@ use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 class UniqueValueGenerationLimitReachedException extends \RuntimeException implements ResolutionThrowable
 {
-    public static function create(UniqueValue $value, int $limit): self
+    /**
+     * @return static
+     */
+    public static function create(UniqueValue $value, int $limit, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Could not generate a unique value after %d attempts for "%s".',
                 $limit,
                 $value->getId()
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Generator/Resolver/UnresolvableValueException.php
+++ b/src/Exception/Generator/Resolver/UnresolvableValueException.php
@@ -16,7 +16,10 @@ use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 class UnresolvableValueException extends \RuntimeException implements ResolutionThrowable
 {
-    public static function create(ValueInterface $value, int $code = 0, \Throwable $previous = null): self
+    /**
+     * @return static
+     */
+    public static function create(ValueInterface $value, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(

--- a/src/Exception/NoValueForCurrentException.php
+++ b/src/Exception/NoValueForCurrentException.php
@@ -15,13 +15,18 @@ use Nelmio\Alice\FixtureInterface;
 
 class NoValueForCurrentException extends \RuntimeException
 {
-    public static function create(FixtureInterface $fixture)
+    /**
+     * @return static
+     */
+    public static function create(FixtureInterface $fixture, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No value for \'<current()>\' found for the fixture "%s".',
                 $fixture->getId()
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/ObjectNotFoundException.php
+++ b/src/Exception/ObjectNotFoundException.php
@@ -13,14 +13,19 @@ namespace Nelmio\Alice\Exception;
 
 class ObjectNotFoundException extends \UnexpectedValueException
 {
-    public static function create(string $id, string $className)
+    /**
+     * @return static
+     */
+    public static function create(string $id, string $className, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Could not find the object "%s" of the class "%s".',
                 $id,
                 $className
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/ParameterNotFoundException.php
+++ b/src/Exception/ParameterNotFoundException.php
@@ -13,13 +13,18 @@ namespace Nelmio\Alice\Exception;
 
 class ParameterNotFoundException extends \UnexpectedValueException
 {
-    public static function create(string $key)
+    /**
+     * @return static
+     */
+    public static function create(string $key, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'Could not find the parameter "%s".',
                 $key
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Exception/Parser/ParserNotFoundException.php
+++ b/src/Exception/Parser/ParserNotFoundException.php
@@ -13,13 +13,18 @@ namespace Nelmio\Alice\Exception\Parser;
 
 class ParserNotFoundException extends \LogicException
 {
-    public static function create(string $file): self
+    /**
+     * @return static
+     */
+    public static function create(string $file, int $code = 0, \Throwable $previous = null)
     {
         return new static(
             sprintf(
                 'No suitable parser found for the file "%s".',
                 $file
-            )
+            ),
+            $code,
+            $previous
         );
     }
 }

--- a/src/Generator/Instantiator/Chainable/AbstractChainableInstantiator.php
+++ b/src/Generator/Instantiator/Chainable/AbstractChainableInstantiator.php
@@ -35,7 +35,7 @@ abstract class AbstractChainableInstantiator implements ChainableInstantiatorInt
         } catch (InstantiationThrowable $throwable) {
             throw $throwable;
         } catch (\Throwable $throwable) {
-            throw InstantiationException::create($fixture, $throwable);
+            throw InstantiationException::create($fixture, 0, $throwable);
         }
 
         $objects = $fixtureSet->getObjects()->with(

--- a/tests/Exception/Generator/Instantiator/InstantiationExceptionTest.php
+++ b/tests/Exception/Generator/Instantiator/InstantiationExceptionTest.php
@@ -32,17 +32,19 @@ class InstantiationExceptionTest extends \PHPUnit_Framework_TestCase
     public function testTestCreateNewExceptionWithFactory()
     {
         $exception0 = InstantiationException::create(new DummyFixture('foo'));
-        $exception1 = InstantiationException::create(new DummyFixture('foo'), $previous = new \Exception());
+        $exception1 = InstantiationException::create(new DummyFixture('foo'), 10, $previous = new \Exception());
 
         $this->assertEquals(
             'Could not instantiate fixture "foo".',
             $exception0->getMessage()
         );
         $this->assertNull($exception0->getPrevious());
+
         $this->assertEquals(
             'Could not instantiate fixture "foo".',
             $exception1->getMessage()
         );
+        $this->assertEquals(10, $exception1->getCode());
         $this->assertSame($previous, $exception1->getPrevious());
     }
 }


### PR DESCRIPTION
- Remove the usage of the return value `self` in named factories which prevented method overloading via inheritance
- Add `$code` and `$previous` to every named factories