### PR TITLE
Simplify Token API

### DIFF
--- a/src/Exception/FixtureBuilder/ExpressionLanguage/ParseException.php
+++ b/src/Exception/FixtureBuilder/ExpressionLanguage/ParseException.php
@@ -25,7 +25,7 @@ class ParseException extends \Exception implements ExpressionLanguageParseThrowa
             sprintf(
                 'Could not parse the token "%s" (type: %s).',
                 $token->getValue(),
-                $token->getType()->getValue()
+                $token->getType()
             ),
             $code,
             $previous

--- a/src/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundException.php
+++ b/src/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundException.php
@@ -24,7 +24,7 @@ class ParserNotFoundException extends \LogicException
             sprintf(
                 'No suitable token parser found to handle the token "%s" (type: %s).',
                 $token->getValue(),
-                $token->getType()->getValue()
+                $token->getType()
             ),
             $code,
             $previous

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
@@ -26,7 +26,7 @@ final class DynamicArrayTokenParser extends AbstractChainableParserAwareParser
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::DYNAMIC_ARRAY_TYPE;
+        return $token->getType() === TokenType::DYNAMIC_ARRAY_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedArrayTokenParser.php
@@ -28,7 +28,7 @@ final class EscapedArrayTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::ESCAPED_ARRAY_TYPE;
+        return $token->getType() === TokenType::ESCAPED_ARRAY_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedTokenParser.php
@@ -32,7 +32,7 @@ final class EscapedTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return isset(self::SUPPORTED_TYPES[$token->getType()->getValue()]);
+        return isset(self::SUPPORTED_TYPES[$token->getType()]);
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParser.php
@@ -42,7 +42,7 @@ final class FixtureListReferenceTokenParser implements ChainableTokenParserInter
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::LIST_REFERENCE_TYPE;
+        return $token->getType() === TokenType::LIST_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParser.php
@@ -26,7 +26,7 @@ final class FixtureMethodReferenceTokenParser extends AbstractChainableParserAwa
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::METHOD_REFERENCE_TYPE;
+        return $token->getType() === TokenType::METHOD_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParser.php
@@ -43,7 +43,7 @@ final class FixtureRangeReferenceTokenParser implements ChainableTokenParserInte
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::RANGE_REFERENCE_TYPE;
+        return $token->getType() === TokenType::RANGE_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -29,7 +29,7 @@ final class FunctionTokenParser extends AbstractChainableParserAwareParser
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::FUNCTION_TYPE;
+        return $token->getType() === TokenType::FUNCTION_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
@@ -22,7 +22,7 @@ final class IdentityTokenParser extends AbstractChainableParserAwareParser
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::IDENTITY_TYPE;
+        return $token->getType() === TokenType::IDENTITY_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParser.php
@@ -25,7 +25,7 @@ final class MethodReferenceTokenParser extends AbstractChainableParserAwareParse
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::METHOD_REFERENCE_TYPE;
+        return $token->getType() === TokenType::METHOD_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParser.php
@@ -27,7 +27,7 @@ final class OptionalTokenParser extends AbstractChainableParserAwareParser
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::OPTIONAL_TYPE;
+        return $token->getType() === TokenType::OPTIONAL_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParser.php
@@ -29,7 +29,7 @@ final class ParameterTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::PARAMETER_TYPE;
+        return $token->getType() === TokenType::PARAMETER_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParser.php
@@ -24,7 +24,7 @@ final class PropertyReferenceTokenParser extends AbstractChainableParserAwarePar
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::PROPERTY_REFERENCE_TYPE;
+        return $token->getType() === TokenType::PROPERTY_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParser.php
@@ -29,7 +29,7 @@ final class SimpleReferenceTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::SIMPLE_REFERENCE_TYPE;
+        return $token->getType() === TokenType::SIMPLE_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
@@ -25,7 +25,7 @@ final class StringArrayTokenParser extends AbstractChainableParserAwareParser
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::STRING_ARRAY_TYPE;
+        return $token->getType() === TokenType::STRING_ARRAY_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParser.php
@@ -25,7 +25,7 @@ final class StringTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::STRING_TYPE;
+        return $token->getType() === TokenType::STRING_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
@@ -60,7 +60,7 @@ final class TolerantFunctionTokenParser extends AbstractChainableParserAwarePars
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::FUNCTION_TYPE;
+        return $token->getType() === TokenType::FUNCTION_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
@@ -29,7 +29,7 @@ final class VariableTokenParser implements ChainableTokenParserInterface
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::VARIABLE_TYPE;
+        return $token->getType() === TokenType::VARIABLE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/WildcardReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/WildcardReferenceTokenParser.php
@@ -27,7 +27,7 @@ final class WildcardReferenceTokenParser implements ChainableTokenParserInterfac
      */
     public function canParse(Token $token): bool
     {
-        return $token->getType()->getValue() === TokenType::WILDCARD_REFERENCE_TYPE;
+        return $token->getType() === TokenType::WILDCARD_REFERENCE_TYPE;
     }
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Token.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Token.php
@@ -42,9 +42,9 @@ final class Token
         return $this->value;
     }
 
-    public function getType(): TokenType
+    public function getType(): string
     {
-        return $this->type;
+        return $this->type->getValue();
     }
 
     public function __toString()

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTest.php
@@ -24,7 +24,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $token = new Token($value, $type);
 
         $this->assertEquals($value, $token->getValue());
-        $this->assertEquals($type, $token->getType());
+        $this->assertEquals($type->getValue(), $token->getType());
         $this->assertEquals('(DYNAMIC_ARRAY_TYPE) bob', $token->__toString());
     }
 
@@ -46,10 +46,10 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $newToken = $token->withValue($newValue);
 
         $this->assertEquals($value, $token->getValue());
-        $this->assertEquals($type, $token->getType());
+        $this->assertEquals($type->getValue(), $token->getType());
 
         $this->assertInstanceOf(Token::class, $newToken);
         $this->assertEquals($newValue, $newToken->getValue());
-        $this->assertEquals($type, $newToken->getType());
+        $this->assertEquals($type->getValue(), $newToken->getType());
     }
 }


### PR DESCRIPTION
Return the type value instead of the type object as having the object is useful only to safetype the type during instantiation.