### PR TITLE
Add test for using the dynamic array notation with a scalar value

### DIFF
--- a/tests/Loader/AbstractLoaderIntegrationTestCase.php
+++ b/tests/Loader/AbstractLoaderIntegrationTestCase.php
@@ -2158,6 +2158,24 @@ abstract class AbstractLoaderIntegrationTestCase extends \PHPUnit_Framework_Test
                 'objects' => [],
             ],
         ];
+
+        yield 'dynamic array with scalar value' => [
+            [
+                \stdClass::class => [
+                    'dummy' => [
+                        'foo' => '5x bar',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => StdClassFactory::create([
+                        'foo' => ['bar', 'bar', 'bar', 'bar', 'bar']
+                    ]),
+                ],
+            ],
+        ];
     }
 
     //TODO: test with circular reference


### PR DESCRIPTION
This should be handled by design but added a test for it still. The original issue was https://github.com/nelmio/alice/issues/191.