### PR TITLE
Remove an immutable part of the object graph

### DIFF
--- a/src/Bridge/Symfony/Resources/config/generator/instantiator.xml
+++ b/src/Bridge/Symfony/Resources/config/generator/instantiator.xml
@@ -14,7 +14,12 @@
     <services>
 
         <service id="nelmio_alice.generator.instantiator"
-                 alias="nelmio_alice.generator.instantiator.resolver" />
+                 alias="nelmio_alice.generator.instantiator.existing_instance" />
+
+        <service id="nelmio_alice.generator.instantiator.existing_instance"
+                 class="Nelmio\Alice\Generator\Instantiator\ExistingInstanceInstantiator">
+            <argument type="service" id="nelmio_alice.generator.instantiator.resolver" />
+        </service>
 
         <service id="nelmio_alice.generator.instantiator.resolver"
                  class="Nelmio\Alice\Generator\Instantiator\InstantiatorResolver">

--- a/src/Definition/MethodCall/MethodCallWithReference.php
+++ b/src/Definition/MethodCall/MethodCallWithReference.php
@@ -49,7 +49,7 @@ final class MethodCallWithReference implements MethodCallInterface
     {
         $this->caller = clone $caller;
         $this->method = $method;
-        $this->arguments = deep_clone($arguments);
+        $this->arguments = $arguments;
         $this->stringValue = $caller->getId().$method;
     }
 
@@ -59,7 +59,7 @@ final class MethodCallWithReference implements MethodCallInterface
     public function withArguments(array $arguments = null): self
     {
         $clone = clone $this;
-        $clone->arguments = deep_clone($arguments);
+        $clone->arguments = $arguments;
 
         return $clone;
     }
@@ -85,7 +85,7 @@ final class MethodCallWithReference implements MethodCallInterface
      */
     public function getArguments()
     {
-        return deep_clone($this->arguments);
+        return $this->arguments;
     }
 
     /**

--- a/src/Definition/MethodCall/OptionalMethodCall.php
+++ b/src/Definition/MethodCall/OptionalMethodCall.php
@@ -48,7 +48,7 @@ final class OptionalMethodCall implements MethodCallInterface
     public function withArguments(array $arguments = null): self
     {
         $clone = clone $this;
-        $clone->methodCall = $clone->methodCall->withArguments(deep_clone($arguments));
+        $clone->methodCall = $clone->methodCall->withArguments($arguments);
 
         return $clone;
     }
@@ -58,7 +58,7 @@ final class OptionalMethodCall implements MethodCallInterface
      */
     public function getCaller()
     {
-        return deep_clone($this->methodCall->getCaller());
+        return $this->methodCall->getCaller();
     }
 
     /**
@@ -74,7 +74,7 @@ final class OptionalMethodCall implements MethodCallInterface
      */
     public function getArguments()
     {
-        return deep_clone($this->methodCall->getArguments());
+        return $this->methodCall->getArguments();
     }
 
     /**

--- a/src/Definition/MethodCall/SimpleMethodCall.php
+++ b/src/Definition/MethodCall/SimpleMethodCall.php
@@ -36,7 +36,7 @@ final class SimpleMethodCall implements MethodCallInterface
     public function __construct(string $method, array $arguments = null)
     {
         $this->method = $method;
-        $this->arguments = deep_clone($arguments);
+        $this->arguments = $arguments;
     }
 
     /**
@@ -45,7 +45,7 @@ final class SimpleMethodCall implements MethodCallInterface
     public function withArguments(array $arguments = null): self
     {
         $clone = clone $this;
-        $clone->arguments = deep_clone($arguments);
+        $clone->arguments = $arguments;
 
         return $clone;
     }
@@ -71,7 +71,7 @@ final class SimpleMethodCall implements MethodCallInterface
      */
     public function getArguments()
     {
-        return deep_clone($this->arguments);
+        return $this->arguments;
     }
 
     /**

--- a/src/Generator/Instantiator/ExistingInstanceInstantiator.php
+++ b/src/Generator/Instantiator/ExistingInstanceInstantiator.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Generator\Instantiator;
+
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\InstantiatorInterface;
+use Nelmio\Alice\Generator\ResolvedFixtureSet;
+use Nelmio\Alice\Generator\ValueResolverAwareInterface;
+use Nelmio\Alice\Generator\ValueResolverInterface;
+use Nelmio\Alice\NotClonableTrait;
+
+/**
+ * Check if the given fixture has already been instantiated and delegates the instantiation to the decorated
+ * instantiator if that's not the case.
+ */
+final class ExistingInstanceInstantiator implements InstantiatorInterface, ValueResolverAwareInterface
+{
+    use NotClonableTrait;
+
+    /**
+     * @var InstantiatorInterface
+     */
+    private $instantiator;
+
+    public function __construct(InstantiatorInterface $decoratedInstantiator, ValueResolverInterface $resolver = null)
+    {
+        if ($resolver !== null && $decoratedInstantiator instanceof ValueResolverAwareInterface) {
+            $decoratedInstantiator = $decoratedInstantiator->withResolver($resolver);
+        }
+
+        $this->instantiator = $decoratedInstantiator;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withResolver(ValueResolverInterface $resolver): self
+    {
+        return new self($this->instantiator, $resolver);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    {
+        if ($fixtureSet->getObjects()->has($fixture)) {
+            return $fixtureSet;
+        }
+
+        return $this->instantiator->instantiate($fixture, $fixtureSet);
+    }
+}

--- a/src/Generator/Instantiator/InstantiatorResolver.php
+++ b/src/Generator/Instantiator/InstantiatorResolver.php
@@ -21,6 +21,10 @@ use Nelmio\Alice\Generator\ValueResolverAwareInterface;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * Resolves each argument to be passed to the constructor when is relevant before handling over the updated fixture to
+ * instantiate to the decorated instantiator.
+ */
 final class InstantiatorResolver implements InstantiatorInterface, ValueResolverAwareInterface
 {
     use NotClonableTrait;

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -83,6 +83,7 @@ use Nelmio\Alice\Generator\Instantiator\Chainable\NoCallerMethodCallInstantiator
 use Nelmio\Alice\Generator\Instantiator\Chainable\NoMethodCallInstantiator;
 use Nelmio\Alice\Generator\Instantiator\Chainable\NullConstructorInstantiator;
 use Nelmio\Alice\Generator\Instantiator\Chainable\StaticFactoryInstantiator;
+use Nelmio\Alice\Generator\Instantiator\ExistingInstanceInstantiator;
 use Nelmio\Alice\Generator\Instantiator\InstantiatorRegistry;
 use Nelmio\Alice\Generator\Instantiator\InstantiatorResolver;
 use Nelmio\Alice\Generator\InstantiatorInterface;
@@ -460,13 +461,15 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
 
     protected function createBuiltInInstantiator(): InstantiatorInterface
     {
-        return new InstantiatorResolver(
-            new InstantiatorRegistry([
-                new NoCallerMethodCallInstantiator(),
-                new NullConstructorInstantiator(),
-                new NoMethodCallInstantiator(),
-                new StaticFactoryInstantiator(),
-            ])
+        return new ExistingInstanceInstantiator(
+            new InstantiatorResolver(
+                new InstantiatorRegistry([
+                    new NoCallerMethodCallInstantiator(),
+                    new NullConstructorInstantiator(),
+                    new NoMethodCallInstantiator(),
+                    new StaticFactoryInstantiator(),
+                ])
+            )
         );
     }
 

--- a/tests/Definition/MethodCall/MethodCallWithReferenceTest.php
+++ b/tests/Definition/MethodCall/MethodCallWithReferenceTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Definition\MethodCall;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\MutableReference;
+use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers Nelmio\Alice\Definition\MethodCall\MethodCallWithReference
@@ -46,7 +47,7 @@ class MethodCallWithReferenceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('user.factorysetUsername', $definition->__toString());
     }
 
-    public function testIsImmutable()
+    public function testIsMutable()
     {
         $caller = new MutableReference();
         $method = 'setUsername';
@@ -65,12 +66,15 @@ class MethodCallWithReferenceTest extends \PHPUnit_Framework_TestCase
         $caller = $definition->getCaller();
         $caller->setId('user.factory');
         $arguments = $definition->getArguments();
-        $arguments[0]->foo = 'bar';
+        $arguments[0]->foz = 'baz';
 
         $this->assertEquals(new MutableReference(), $definition->getCaller());
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create([
+                    'foo' => 'bar',
+                    'foz' => 'baz',
+                ]),
             ],
             $definition->getArguments()
         );
@@ -110,7 +114,6 @@ class MethodCallWithReferenceTest extends \PHPUnit_Framework_TestCase
         $newDefinition = $definition->withArguments($newArguments);
 
         // Mutate argument before reading it
-        // Test done to ensure we are keeping the immutability
         $arg0->foo = 'bar';
 
         $this->assertInstanceOf(MethodCallWithReference::class, $newDefinition);
@@ -123,7 +126,7 @@ class MethodCallWithReferenceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($method, $newDefinition->getMethod());
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create(['foo' => 'bar']),
             ],
             $newDefinition->getArguments()
         );

--- a/tests/Definition/MethodCall/OptionalMethodCallTest.php
+++ b/tests/Definition/MethodCall/OptionalMethodCallTest.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Flag\OptionalFlag;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\MutableReference;
+use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers Nelmio\Alice\Definition\MethodCall\OptionalMethodCall
@@ -57,10 +58,7 @@ class OptionalMethodCallTest extends \PHPUnit_Framework_TestCase
         $methodCallProphecy->getArguments()->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\FlagBagTest::testIsImmutable
-     */
-    public function testIsImmutable()
+    public function testIsMutable()
     {
         $caller = new MutableMethodCall(
             new MutableReference(),
@@ -79,12 +77,15 @@ class OptionalMethodCallTest extends \PHPUnit_Framework_TestCase
 
         // Mutate retrieved values
         $definition->getCaller()->setId('mutated');
-        $definition->getArguments()[0]->foo = 'baz';
+        $definition->getArguments()[0]->foz = 'baz';
 
         $this->assertEquals(new MutableReference(), $definition->getCaller());
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create([
+                    'foo' => 'bar',
+                    'foz' => 'baz',
+                ]),
             ],
             $definition->getArguments()
         );
@@ -112,9 +113,6 @@ class OptionalMethodCallTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($newArguments, $newDefinition->getArguments());
     }
 
-    /**
-     * @depends Nelmio\Alice\Definition\FlagBagTest::testIsImmutable
-     */
     public function testCanCreateANewInstanceWithArguments()
     {
         $methodCall = new SimpleMethodCall('getUsername', null);
@@ -140,7 +138,7 @@ class OptionalMethodCallTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($methodCall->getMethod(), $newDefinition->getMethod());
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create(['foo' => 'bar']),
             ],
             $newDefinition->getArguments()
         );

--- a/tests/Definition/MethodCall/SimpleMethodCallTest.php
+++ b/tests/Definition/MethodCall/SimpleMethodCallTest.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Definition\MethodCall;
 
 use Nelmio\Alice\Definition\MethodCallInterface;
+use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers Nelmio\Alice\Definition\MethodCall\SimpleMethodCall
@@ -43,7 +44,7 @@ class SimpleMethodCallTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($method, $definition->__toString());
     }
 
-    public function testIsImmutable()
+    public function testIsMutable()
     {
         $arguments = [
             $arg0 = new \stdClass(),
@@ -54,11 +55,14 @@ class SimpleMethodCallTest extends \PHPUnit_Framework_TestCase
         $arg0->foo = 'bar';
 
         // Mutate retrieved values
-        $definition->getArguments()[0]->foo = 'baz';
+        $definition->getArguments()[0]->foz = 'baz';
 
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create([
+                    'foo' => 'bar',
+                    'foz' => 'baz',
+                ]),
             ],
             $definition->getArguments()
         );
@@ -111,7 +115,9 @@ class SimpleMethodCallTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($method, $newDefinition->getMethod());
         $this->assertEquals(
             [
-                new \stdClass(),
+                StdClassFactory::create([
+                    'foo' => 'bar',
+                ]),
             ],
             $newDefinition->getArguments()
         );

--- a/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
+++ b/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Generator\Instantiator;
+
+use Nelmio\Alice\Definition\Fixture\DummyFixture;
+use Nelmio\Alice\Definition\Object\SimpleObject;
+use Nelmio\Alice\Generator\InstantiatorInterface;
+use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
+use Nelmio\Alice\Generator\ValueResolverAwareInterface;
+use Nelmio\Alice\ObjectBag;
+use Prophecy\Argument;
+
+/**
+ * @covers Nelmio\Alice\Generator\Instantiator\ExistingInstanceInstantiator
+ */
+class ExistingInstanceInstantiatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAnInstantiator()
+    {
+        $this->assertTrue(is_a(ExistingInstanceInstantiator::class, InstantiatorInterface::class, true));
+    }
+
+    public function testIsValueResolverAware()
+    {
+        $this->assertTrue(is_a(ExistingInstanceInstantiator::class, ValueResolverAwareInterface::class, true));
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testIsNotClonable()
+    {
+        clone new ExistingInstanceInstantiator(new FakeInstantiator());
+    }
+
+    public function testReturnsUnchangedSetIfFixtureHasAlreadyBeenInstantiated()
+    {
+        $fixture = new DummyFixture('dummy');
+        $set = $expected = ResolvedFixtureSetFactory::create(
+            null,
+            null,
+            (new ObjectBag())->with(
+                new SimpleObject(
+                    'dummy',
+                    new \stdClass()
+                )
+            )
+        );
+
+        $instantiator = new ExistingInstanceInstantiator(new FakeInstantiator());
+        $actual = $instantiator->instantiate($fixture, $set);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testReturnsTheResultOfTheDecoratedInstantiatorIfTheFixtureHasNotBeenInstantiated()
+    {
+        $fixture = new DummyFixture('dummy');
+        $set = ResolvedFixtureSetFactory::create();
+
+        $decoratedInstantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
+        $decoratedInstantiatorProphecy
+            ->instantiate($fixture, $set)
+            ->willReturn(
+                $expected = $set->withObjects(
+                    (new ObjectBag())->with(
+                        new SimpleObject(
+                            'dummy',
+                            new \stdClass()
+                        )
+                    )
+                )
+            )
+        ;
+        /** @var InstantiatorInterface $decoratedInstantiator */
+        $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
+
+        $instantiator = new ExistingInstanceInstantiator($decoratedInstantiator);
+        $actual = $instantiator->instantiate($fixture, $set);
+
+        $this->assertSame($expected, $actual);
+
+        $decoratedInstantiatorProphecy->instantiate(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+}

--- a/tests/Generator/Instantiator/InstantiatorResolverTest.php
+++ b/tests/Generator/Instantiator/InstantiatorResolverTest.php
@@ -37,6 +37,14 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_a(InstantiatorResolver::class, InstantiatorInterface::class, true));
     }
 
+    public function testIsResolverAware()
+    {
+        $this->assertEquals(
+            new InstantiatorResolver(new FakeInstantiator(), new FakeValueResolver()),
+            (new InstantiatorResolver(new FakeInstantiator()))->withResolver(new FakeValueResolver())
+        );
+    }
+
     /**
      * @expectedException \DomainException
      */
@@ -45,14 +53,6 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         clone new InstantiatorResolver(new FakeInstantiator(), new FakeValueResolver());
     }
 
-    public function testIsResolverAware()
-    {
-        $this->assertEquals(
-            new InstantiatorResolver(new FakeInstantiator(), new FakeValueResolver()),
-            (new InstantiatorResolver(new FakeInstantiator()))->withResolver(new FakeValueResolver())
-        );
-    }
-    
     public function testResolvesAllArguments()
     {
         $specs = SpecificationBagFactory::create(
@@ -74,7 +74,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
             )
         );
         $fixture = new SimpleFixture('dummy', 'stdClass', $specs);
-        $set = new ResolvedFixtureSet(new ParameterBag(), new FixtureBag(), new ObjectBag());
+        $set = ResolvedFixtureSetFactory::create();
 
         $expected = ResolvedFixtureSetFactory::create(
             null,

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -764,9 +764,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 'dummy' => $dummy = StdClassFactory::create([
                     'injected' => false,
                 ]),
-                'another_dummy' => new DummyWithConstructorParam(new \stdClass()),
-                //TODO: fix that
-                //'another_dummy' => new DummyWithConstructorParam($dummy),
+                'another_dummy' => new DummyWithConstructorParam($dummy),
             ])
         );
 


### PR DESCRIPTION
The object graph must be mutable as an object injected during instantiation will be populated later on so immutability would break that. The rest of the graph is already immutable but there was this case of instantiation left aside.