### PR TITLE
Account for circular dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ script:
         fi
     else
         if [ -n "$SYMFONY_VERSION" ]; then
-            bin/phpunit -c $PHPUNIT_CONFIG --stop-on-failure --group=symfony
+            bin/phpunit -c $PHPUNIT_CONFIG --group=symfony
         else
-            bin/phpunit -c $PHPUNIT_CONFIG --stop-on-failure --exclude-group=symfony
+            bin/phpunit -c $PHPUNIT_CONFIG --exclude-group=symfony
         fi
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,17 @@ matrix:
     - php: nightly
     - env: SYMFONY_VERSION='^3.2@dev'
 
-install:
+before_install:
   - set -eo pipefail
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - |
     if [ "nightly" != "$TRAVIS_PHP_VERSION" ]; then
         phpenv config-rm xdebug.ini
     fi
   - PHPUNIT_CONFIG='phpunit.xml.dist'
   - PHPUNIT_FLAGS='--stop-on-failure --verbose'
+
+install:
   - composer install --prefer-dist $COMPOSER_FLAGS
   - |
     if [ -n "$SYMFONY_VERSION" ]; then

--- a/fixtures/Generator/Hydrator/FakeHydrator.php
+++ b/fixtures/Generator/Hydrator/FakeHydrator.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Generator\Hydrator;
 
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\HydratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\NotCallableTrait;
@@ -23,7 +24,7 @@ class FakeHydrator implements HydratorInterface
     /**
      * @inheritdoc
      */
-    public function hydrate(ObjectInterface $object, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function hydrate(ObjectInterface $object, ResolvedFixtureSet $fixtureSet, GenerationContext $context): ResolvedFixtureSet
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Generator/Hydrator/FakePropertyHydrator.php
+++ b/fixtures/Generator/Hydrator/FakePropertyHydrator.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Generator\Hydrator;
 
 use Nelmio\Alice\Definition\Property;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\NotCallableTrait;
 use Nelmio\Alice\ObjectInterface;
 
@@ -22,7 +23,7 @@ class FakePropertyHydrator implements PropertyHydratorInterface
     /**
      * @inheritdoc
      */
-    public function hydrate(ObjectInterface $object, Property $property): ObjectInterface
+    public function hydrate(ObjectInterface $object, Property $property, GenerationContext $context): ObjectInterface
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Generator/Instantiator/FakeChainableInstantiator.php
+++ b/fixtures/Generator/Instantiator/FakeChainableInstantiator.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Generator\Instantiator;
 
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\NotCallableTrait;
 
@@ -30,7 +31,7 @@ class FakeChainableInstantiator implements ChainableInstantiatorInterface
     /**
      * @inheritdoc
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet, GenerationContext $context): ResolvedFixtureSet
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Generator/Instantiator/FakeInstantiator.php
+++ b/fixtures/Generator/Instantiator/FakeInstantiator.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Generator\Instantiator;
 
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\NotCallableTrait;
@@ -23,7 +24,7 @@ class FakeInstantiator implements InstantiatorInterface
     /**
      * @inheritdoc
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet, GenerationContext $context): ResolvedFixtureSet
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Generator/Resolver/Value/FakeChainableValueResolver.php
+++ b/fixtures/Generator/Resolver/Value/FakeChainableValueResolver.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value;
 
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\NotCallableTrait;
@@ -36,7 +37,9 @@ class FakeChainableValueResolver implements ChainableValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []): ResolvedValueWithFixtureSet
+        array $scope,
+        GenerationContext $context
+    ): ResolvedValueWithFixtureSet
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Generator/Resolver/Value/FakeValueResolver.php
+++ b/fixtures/Generator/Resolver/Value/FakeValueResolver.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value;
 
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverInterface;
@@ -29,7 +30,9 @@ class FakeValueResolver implements ValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []): ResolvedValueWithFixtureSet
+        array $scope,
+        GenerationContext $context
+    ): ResolvedValueWithFixtureSet
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/src/Exception/Generator/Resolver/UnresolvableValueDuringGenerationException.php
+++ b/src/Exception/Generator/Resolver/UnresolvableValueDuringGenerationException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Exception\Generator\Resolver;
+
+use Nelmio\Alice\Throwable\GenerationThrowable;
+use Nelmio\Alice\Throwable\ResolutionThrowable;
+
+class UnresolvableValueDuringGenerationException extends UnresolvableValueException  implements GenerationThrowable
+{
+    /**
+     * @return static
+     */
+    public static function createFromResolutionThrowable(ResolutionThrowable $previous, int $code = 0)
+    {
+        return new static('Could not resolve value during the genration process.', $code, $previous);
+    }
+}

--- a/src/Generator/GenerationContext.php
+++ b/src/Generator/GenerationContext.php
@@ -11,6 +11,9 @@
 
 namespace Nelmio\Alice\Generator;
 
+use Nelmio\Alice\Exception\Generator\Resolver\CircularReferenceException;
+use Nelmio\Alice\Generator\Resolver\ResolvingContext;
+
 final class GenerationContext
 {
     /**
@@ -18,9 +21,15 @@ final class GenerationContext
      */
     private $isFirstPass;
 
+    /**
+     * @var ResolvingContext
+     */
+    private $resolving;
+
     public function __construct()
     {
         $this->isFirstPass = true;
+        $this->resolving = new ResolvingContext();
     }
 
     public function isFirstPass(): bool
@@ -31,5 +40,16 @@ final class GenerationContext
     public function setToSecondPass()
     {
         $this->isFirstPass = false;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @throws CircularReferenceException
+     */
+    public function markIsResolvingFixture(string $id)
+    {
+        $this->resolving->add($id);
+        $this->resolving->checkForCircularReference($id);
     }
 }

--- a/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
+++ b/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Exception\Generator\Hydrator\HydrationException;
 use Nelmio\Alice\Exception\Generator\Hydrator\InvalidArgumentException;
 use Nelmio\Alice\Exception\Generator\Hydrator\NoSuchPropertyException;
 use Nelmio\Alice\Exception\Generator\Hydrator\PropertyAccessException;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Hydrator\PropertyHydratorInterface;
 use Nelmio\Alice\NotClonableTrait;
 use Nelmio\Alice\ObjectInterface;
@@ -48,7 +49,7 @@ final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
      * @throws InvalidArgumentException When the typehint does not match for example
      * @throws HydrationException
      */
-    public function hydrate(ObjectInterface $object, Property $property): ObjectInterface
+    public function hydrate(ObjectInterface $object, Property $property, GenerationContext $context): ObjectInterface
     {
         $instance = $object->getInstance();
         try {

--- a/src/Generator/Hydrator/PropertyHydratorInterface.php
+++ b/src/Generator/Hydrator/PropertyHydratorInterface.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Generator\Hydrator;
 
 use Nelmio\Alice\Definition\Property;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\ObjectInterface;
 
 interface PropertyHydratorInterface
@@ -24,5 +25,5 @@ interface PropertyHydratorInterface
      *
      * @return ObjectInterface
      */
-    public function hydrate(ObjectInterface $object, Property $property): ObjectInterface;
+    public function hydrate(ObjectInterface $object, Property $property, GenerationContext $context): ObjectInterface;
 }

--- a/src/Generator/Hydrator/SimpleHydrator.php
+++ b/src/Generator/Hydrator/SimpleHydrator.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Hydrator;
 use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\HydratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
@@ -52,7 +53,11 @@ final class SimpleHydrator implements HydratorInterface, ValueResolverAwareInter
     /**
      * @inheritdoc
      */
-    public function hydrate(ObjectInterface $object, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function hydrate(
+        ObjectInterface $object,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
         if (null === $this->resolver) {
             throw ResolverNotFoundException::createUnexpectedCall(__METHOD__);
@@ -68,13 +73,13 @@ final class SimpleHydrator implements HydratorInterface, ValueResolverAwareInter
             /** @var Property $property */
             $propertyValue = $property->getValue();
             if ($propertyValue instanceof ValueInterface) {
-                $result = $this->resolver->resolve($propertyValue, $fixture, $fixtureSet, $scope);
+                $result = $this->resolver->resolve($propertyValue, $fixture, $fixtureSet, $scope, $context);
                 list($propertyValue, $fixtureSet) = [$result->getValue(), $result->getSet()];
                 $property = $property->withValue($propertyValue);
             }
             $scope[$property->getName()] = $propertyValue;
 
-            $object = $this->hydrator->hydrate($object, $property);
+            $object = $this->hydrator->hydrate($object, $property, $context);
         }
 
         return $fixtureSet->withObjects(

--- a/src/Generator/HydratorInterface.php
+++ b/src/Generator/HydratorInterface.php
@@ -22,10 +22,15 @@ interface HydratorInterface
      *
      * @param ObjectInterface    $object Object to hydrate
      * @param ResolvedFixtureSet $fixtureSet
+     * @param GenerationContext  $context
      *
      * @throws HydrationThrowable
      *
      * @return ResolvedFixtureSet
      */
-    public function hydrate(ObjectInterface $object, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet;
+    public function hydrate(
+        ObjectInterface $object,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet;
 }

--- a/src/Generator/Instantiator/Chainable/AbstractChainableInstantiator.php
+++ b/src/Generator/Instantiator/Chainable/AbstractChainableInstantiator.php
@@ -14,11 +14,15 @@ namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Exception\Generator\Instantiator\InstantiationException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\NotClonableTrait;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
 
+/**
+ * @internal
+ */
 abstract class AbstractChainableInstantiator implements ChainableInstantiatorInterface
 {
     use NotClonableTrait;
@@ -28,7 +32,11 @@ abstract class AbstractChainableInstantiator implements ChainableInstantiatorInt
      *
      * @throws InstantiationException
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
         try {
             $instance = $this->createInstance($fixture);
@@ -45,7 +53,7 @@ abstract class AbstractChainableInstantiator implements ChainableInstantiatorInt
             )
         );
 
-        return $fixtureSet->withObjects($objects);;
+        return $fixtureSet->withObjects($objects);
     }
 
     /**

--- a/src/Generator/Instantiator/ExistingInstanceInstantiator.php
+++ b/src/Generator/Instantiator/ExistingInstanceInstantiator.php
@@ -12,6 +12,7 @@
 namespace Nelmio\Alice\Generator\Instantiator;
 
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
@@ -51,12 +52,16 @@ final class ExistingInstanceInstantiator implements InstantiatorInterface, Value
     /**
      * @inheritdoc
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
         if ($fixtureSet->getObjects()->has($fixture)) {
             return $fixtureSet;
         }
 
-        return $this->instantiator->instantiate($fixture, $fixtureSet);
+        return $this->instantiator->instantiate($fixture, $fixtureSet, $context);
     }
 }

--- a/src/Generator/Instantiator/InstantiatorRegistry.php
+++ b/src/Generator/Instantiator/InstantiatorRegistry.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Instantiator;
 
 use Nelmio\Alice\Exception\Generator\Instantiator\InstantiatorNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
@@ -64,11 +65,15 @@ final class InstantiatorRegistry implements InstantiatorInterface, ValueResolver
      *
      * @throws InstantiatorNotFoundException
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
         foreach ($this->instantiators as $instantiator) {
             if ($instantiator->canInstantiate($fixture)) {
-                return $instantiator->instantiate($fixture, $fixtureSet);
+                return $instantiator->instantiate($fixture, $fixtureSet, $context);
             }
         }
 

--- a/src/Generator/Instantiator/InstantiatorResolver.php
+++ b/src/Generator/Instantiator/InstantiatorResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\MethodCall\NoMethodCall;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
@@ -62,14 +63,22 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
      *
      * {@inheritdoc}
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet
+    public function instantiate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
-        list($fixture, $fixtureSet) = $this->resolveFixtureConstructor($fixture, $fixtureSet);
+        list($fixture, $fixtureSet) = $this->resolveFixtureConstructor($fixture, $fixtureSet, $context);
 
-        return $this->instantiator->instantiate($fixture, $fixtureSet);
+        return $this->instantiator->instantiate($fixture, $fixtureSet, $context);
     }
 
-    private function resolveFixtureConstructor(FixtureInterface $fixture, ResolvedFixtureSet $set): array
+    private function resolveFixtureConstructor(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $set,
+        GenerationContext $context
+    ): array
     {
         $specs = $fixture->getSpecs();
         $constructor = $specs->getConstructor();
@@ -86,7 +95,8 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
             $constructor->getArguments(),
             $this->valueResolver,
             $fixture,
-            $set
+            $set,
+            $context
         );
 
         return [
@@ -112,12 +122,13 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
         array $arguments,
         ValueResolverInterface $resolver,
         FixtureInterface $fixture,
-        ResolvedFixtureSet $fixtureSet
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
     ): array
     {
         foreach ($arguments as $index => $argument) {
             if ($argument instanceof ValueInterface) {
-                $result = $resolver->resolve($argument, $fixture, $fixtureSet);
+                $result = $resolver->resolve($argument, $fixture, $fixtureSet, [], $context);
 
                 $fixtureSet = $result->getSet();
                 $arguments[$index] = $result->getValue();

--- a/src/Generator/Instantiator/InstantiatorResolver.php
+++ b/src/Generator/Instantiator/InstantiatorResolver.php
@@ -61,9 +61,11 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
     }
 
     /**
-     * Resolves the fixture consturctor arguments before instantiating it.
+     * Resolves the fixture constructor arguments before instantiating it.
      *
      * {@inheritdoc}
+     *
+     * @throws UnresolvableValueDuringGenerationException
      */
     public function instantiate(
         FixtureInterface $fixture,
@@ -76,6 +78,15 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
         return $this->instantiator->instantiate($fixture, $fixtureSet, $context);
     }
 
+    /**
+     * @param FixtureInterface   $fixture
+     * @param ResolvedFixtureSet $set
+     * @param GenerationContext  $context
+     *
+     * @throws UnresolvableValueDuringGenerationException
+     *
+     * @return array
+     */
     private function resolveFixtureConstructor(
         FixtureInterface $fixture,
         ResolvedFixtureSet $set,
@@ -116,6 +127,9 @@ final class InstantiatorResolver implements InstantiatorInterface, ValueResolver
      * @param ValueResolverInterface $resolver
      * @param FixtureInterface       $fixture
      * @param ResolvedFixtureSet     $fixtureSet
+     * @param GenerationContext      $context
+     *
+     * @throws UnresolvableValueDuringGenerationException
      *
      * @return array The first element is an array ($arguments) which is the resolved arguments and the second the new
      *               ResolvedFixtureSet which may contains new fixtures (from the arguments resolution)

--- a/src/Generator/InstantiatorInterface.php
+++ b/src/Generator/InstantiatorInterface.php
@@ -22,10 +22,15 @@ interface InstantiatorInterface
      *
      * @param FixtureInterface   $fixture
      * @param ResolvedFixtureSet $fixtureSet
+     * @param GenerationContext  $context
      *
      * @throws InstantiationThrowable
      *
      * @return ResolvedFixtureSet
      */
-    public function instantiate(FixtureInterface $fixture, ResolvedFixtureSet $fixtureSet): ResolvedFixtureSet;
+    public function instantiate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ResolvedFixtureSet;
 }

--- a/src/Generator/ObjectGenerator/SimpleObjectGenerator.php
+++ b/src/Generator/ObjectGenerator/SimpleObjectGenerator.php
@@ -80,18 +80,22 @@ final class SimpleObjectGenerator implements ObjectGeneratorInterface
     ): ObjectBag
     {
         if ($context->isFirstPass()) {
-            return $this->instantiator->instantiate($fixture, $fixtureSet)->getObjects();
+            return $this->instantiator->instantiate($fixture, $fixtureSet, $context)->getObjects();
         }
-        $fixtureSet = $this->completeObject($fixture, $fixtureSet);
+        $fixtureSet = $this->completeObject($fixture, $fixtureSet, $context);
 
         return $fixtureSet->getObjects();
     }
 
-    private function completeObject(FixtureInterface $fixture, ResolvedFixtureSet $set): ResolvedFixtureSet
+    private function completeObject(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $set,
+        GenerationContext $context
+    ): ResolvedFixtureSet
     {
         $instantiatedObject = $set->getObjects()->get($fixture);
 
-        $set = $this->hydrator->hydrate($instantiatedObject, $set);
+        $set = $this->hydrator->hydrate($instantiatedObject, $set, $context);
         $hydratedObject = $set->getObjects()->get($fixture);
 
         return $this->caller->doCallsOn($hydratedObject, $set);

--- a/src/Generator/Resolver/Fixture/TemplateFixtureResolver.php
+++ b/src/Generator/Resolver/Fixture/TemplateFixtureResolver.php
@@ -65,6 +65,7 @@ final class TemplateFixtureResolver
     }
 
     /**
+     * @param TemplatingFixture    $fixture
      * @param FixtureReference[]   $extendedFixtureReferences
      * @param FixtureBag           $unresolvedFixtures
      * @param TemplatingFixtureBag $resolvedFixtures
@@ -86,7 +87,7 @@ final class TemplateFixtureResolver
         $fixtures = new FixtureBag();
         foreach ($extendedFixtureReferences as $reference) {
             $fixtureId = $reference->getId();
-            $context = $context->with($fixtureId);
+            $context->add($fixtureId);
 
             if (false === $unresolvedFixtures->has($fixtureId)) {
                 throw FixtureNotFoundException::create($fixtureId);
@@ -146,8 +147,6 @@ final class TemplateFixtureResolver
             $specs = $specs->mergeWith($extendedFixture->getSpecs());
         }
 
-        return $fixture
-            ->withSpecs($specs)
-        ;
+        return $fixture->withSpecs($specs);
     }
 }

--- a/src/Generator/Resolver/Parameter/Chainable/StringParameterResolver.php
+++ b/src/Generator/Resolver/Parameter/Chainable/StringParameterResolver.php
@@ -126,7 +126,7 @@ final class StringParameterResolver implements ChainableParameterResolverInterfa
         }
 
         $context->checkForCircularReference($key);
-        $context = $context->with($key);
+        $context->add($key);
 
         if (null === $resolver) {
             throw ResolverNotFoundException::createUnexpectedCall(__METHOD__);

--- a/src/Generator/Resolver/Value/Chainable/DynamicArrayValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/DynamicArrayValueResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Value\DynamicArrayValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -75,14 +76,15 @@ final class DynamicArrayValueResolver implements ChainableValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         $this->checkResolver(__METHOD__);
 
         $quantifier = $value->getQuantifier();
         if ($quantifier instanceof ValueInterface) {
-            $result = $this->resolver->resolve($quantifier, $fixture, $fixtureSet, $scope);
+            $result = $this->resolver->resolve($quantifier, $fixture, $fixtureSet, $scope, $context);
             list($quantifier, $fixtureSet) = [$result->getValue(), $result->getSet()];
         }
 
@@ -106,7 +108,7 @@ final class DynamicArrayValueResolver implements ChainableValueResolverInterface
 
         $array = [];
         for ($i = 0; $i < $quantifier; $i++) {
-            $result = $this->resolver->resolve($element, $fixture, $fixtureSet, $scope);
+            $result = $this->resolver->resolve($element, $fixture, $fixtureSet, $scope, $context);
 
             $array[] = $result->getValue();
             $fixtureSet = $result->getSet();

--- a/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Value\EvaluatedValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -43,8 +44,8 @@ final class EvaluatedValueResolver implements ChainableValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         $_scope = $scope;

--- a/src/Generator/Resolver/Value/Chainable/FakerFunctionCallValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FakerFunctionCallValueResolver.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Faker\GeneratorFactory;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -69,8 +70,8 @@ final class FakerFunctionCallValueResolver implements ChainableValueResolverInte
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
@@ -80,7 +81,7 @@ final class FakerFunctionCallValueResolver implements ChainableValueResolverInte
         $arguments = $value->getArguments();
         foreach ($arguments as $index => $argument) {
             if ($argument instanceof ValueInterface) {
-                $resolvedSet = $this->resolver->resolve($argument, $fixture, $fixtureSet, $scope);
+                $resolvedSet = $this->resolver->resolve($argument, $fixture, $fixtureSet, $scope, $context);
 
                 $arguments[$index] = $resolvedSet->getValue();
                 $fixtureSet = $resolvedSet->getSet();

--- a/src/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolver.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Exception\Generator\Resolver\NoSuchPropertyException;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
@@ -78,15 +79,15 @@ final class FixturePropertyReferenceResolver implements ChainableValueResolverIn
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
             throw ResolverNotFoundException::createUnexpectedCall(__METHOD__);
         }
 
-        $fixtureReferenceResult = $this->resolver->resolve($value->getReference(), $fixture, $fixtureSet, $scope);
+        $fixtureReferenceResult = $this->resolver->resolve($value->getReference(), $fixture, $fixtureSet, $scope, $context);
         /** @var ResolvedFixtureSet $fixtureSet */
         list($instance, $fixtureSet) = [$fixtureReferenceResult->getValue(), $fixtureReferenceResult->getSet()];
 

--- a/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
@@ -69,7 +69,8 @@ final class FixtureReferenceResolver implements ChainableValueResolverInterface,
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->generator) {
@@ -83,7 +84,8 @@ final class FixtureReferenceResolver implements ChainableValueResolverInterface,
 
         $referredFixture = $this->getReferredFixture($referredFixtureId, $fixtureSet);
         if (false === $fixtureSet->getObjects()->has($referredFixture)) {
-            $objects = $this->generator->generate($referredFixture, $fixtureSet, new GenerationContext());
+            $context->markIsResolvingFixture($referredFixtureId);
+            $objects = $this->generator->generate($referredFixture, $fixtureSet, $context);
 
             $fixtureSet = $fixtureSet->withObjects($objects);
         }

--- a/src/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolver.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -67,8 +68,8 @@ final class FixtureWildcardReferenceResolver implements ChainableValueResolverIn
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
@@ -90,14 +91,16 @@ final class FixtureWildcardReferenceResolver implements ChainableValueResolverIn
             new FixtureReferenceValue($id),
             $fixture,
             $fixtureSet,
-            $scope
+            $scope,
+            $context
         );
     }
 
     /**
      * Gets all the fixture IDs suitable for the given value.
      *
-     * @param ResolvedFixtureSet $fixtureSet
+     * @param FixtureMatchReferenceValue $value
+     * @param ResolvedFixtureSet         $fixtureSet
      *
      * @return string[]
      */

--- a/src/Generator/Resolver/Value/Chainable/ListValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/ListValueResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -61,8 +62,8 @@ final class ListValueResolver implements ChainableValueResolverInterface, ValueR
         ValueInterface $list,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
@@ -72,7 +73,7 @@ final class ListValueResolver implements ChainableValueResolverInterface, ValueR
         $values = $list->getValue();
         foreach ($values as $index => $value) {
             if ($value instanceof ValueInterface) {
-                $resolvedSet = $this->resolver->resolve($value, $fixture, $fixtureSet, $scope);
+                $resolvedSet = $this->resolver->resolve($value, $fixture, $fixtureSet, $scope, $context);
 
                 $values[$index] = $resolvedSet->getValue();
                 $fixtureSet = $resolvedSet->getSet();

--- a/src/Generator/Resolver/Value/Chainable/OptionalValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/OptionalValueResolver.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -64,8 +65,8 @@ final class OptionalValueResolver implements ChainableValueResolverInterface, Va
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
@@ -74,7 +75,7 @@ final class OptionalValueResolver implements ChainableValueResolverInterface, Va
 
         $quantifier = $value->getQuantifier();
         if ($quantifier instanceof ValueInterface) {
-            $resolvedSet = $this->resolver->resolve($quantifier, $fixture, $fixtureSet, $scope);
+            $resolvedSet = $this->resolver->resolve($quantifier, $fixture, $fixtureSet, $scope, $context);
             list($quantifier, $fixtureSet) = [$resolvedSet->getValue(), $resolvedSet->getSet()];
 
             if (is_int($quantifier)) {
@@ -94,7 +95,7 @@ final class OptionalValueResolver implements ChainableValueResolverInterface, Va
             : $value->getSecondMember()
         ;
         if ($realValue instanceof ValueInterface) {
-            return $this->resolver->resolve($realValue, $fixture, $fixtureSet, $scope);
+            return $this->resolver->resolve($realValue, $fixture, $fixtureSet, $scope, $context);
         }
 
         return new ResolvedValueWithFixtureSet($realValue, $fixtureSet);

--- a/src/Generator/Resolver/Value/Chainable/ParameterValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/ParameterValueResolver.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\Exception\ParameterNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -44,8 +45,8 @@ final class ParameterValueResolver implements ChainableValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         $parameterKey = $value->getValue();

--- a/src/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ObjectGeneratorAwareInterface;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
@@ -80,7 +81,8 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if ('self' === $value->getValue()) {
@@ -90,7 +92,7 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
             );
         }
 
-        return $this->decoratedResolver->resolve($value, $fixture, $fixtureSet, $scope);
+        return $this->decoratedResolver->resolve($value, $fixture, $fixtureSet, $scope, $context);
 
     }
 }

--- a/src/Generator/Resolver/Value/Chainable/UniqueValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/UniqueValueResolver.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\UniqueValuesPool;
@@ -85,7 +86,8 @@ final class UniqueValueResolver implements ChainableValueResolverInterface, Valu
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
+        array $scope,
+        GenerationContext $context,
         int $tryCounter = 0
     ): ResolvedValueWithFixtureSet
     {
@@ -96,10 +98,10 @@ final class UniqueValueResolver implements ChainableValueResolverInterface, Valu
          * @var UniqueValue        $generatedValue
          * @var ResolvedFixtureSet $fixtureSet
          */
-        list($generatedValue, $fixtureSet) = $this->generateValue($value, $fixture, $fixtureSet, $scope);
+        list($generatedValue, $fixtureSet) = $this->generateValue($value, $fixture, $fixtureSet, $scope, $context);
 
         if ($this->pool->has($generatedValue)) {
-            return $this->resolve($value, $fixture, $fixtureSet, $scope, $tryCounter);
+            return $this->resolve($value, $fixture, $fixtureSet, $scope, $context, $tryCounter);
         }
         $this->pool->add($generatedValue);
 
@@ -127,12 +129,13 @@ final class UniqueValueResolver implements ChainableValueResolverInterface, Valu
         UniqueValue $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): array
     {
         $realValue = $value->getValue();
         if ($realValue instanceof ValueInterface) {
-            $result = $this->resolver->resolve($value->getValue(), $fixture, $fixtureSet, $scope);
+            $result = $this->resolver->resolve($value->getValue(), $fixture, $fixtureSet, $scope, $context);
 
             return [$value->withValue($result->getValue()), $result->getSet()];
         }

--- a/src/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceResolver.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ObjectGeneratorAwareInterface;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
@@ -89,7 +90,8 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         if (null === $this->resolver) {
@@ -104,7 +106,13 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
             $scope
         );
 
-        return $this->decoratedResolver->resolve(new FixtureReferenceValue($referredFixtureId), $fixture, $fixtureSet, $scope);
+        return $this->decoratedResolver->resolve(
+            new FixtureReferenceValue($referredFixtureId),
+            $fixture,
+            $fixtureSet,
+            $scope,
+            $context
+        );
     }
 
     private function getReferredFixtureId(

--- a/src/Generator/Resolver/Value/Chainable/ValueForCurrentValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/ValueForCurrentValueResolver.php
@@ -12,10 +12,10 @@
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Nelmio\Alice\Definition\Value\ValueForCurrentValue;
-use Nelmio\Alice\Definition\Value\VariableValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\NoValueForCurrentException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -44,8 +44,8 @@ final class ValueForCurrentValueResolver implements ChainableValueResolverInterf
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         return new ResolvedValueWithFixtureSet(

--- a/src/Generator/Resolver/Value/Chainable/VariableValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/VariableValueResolver.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Value\VariableValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -43,8 +44,8 @@ final class VariableValueResolver implements ChainableValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = [],
-        int $tryCounter = 0
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         $variableName = $value->getValue();

--- a/src/Generator/Resolver/Value/ValueResolverRegistry.php
+++ b/src/Generator/Resolver/Value/ValueResolverRegistry.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ObjectGeneratorAwareInterface;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
@@ -71,12 +72,13 @@ final class ValueResolverRegistry implements ValueResolverInterface, ObjectGener
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet
     {
         foreach ($this->resolvers as $resolver) {
             if ($resolver->canResolve($value)) {
-                return $resolver->resolve($value, $fixture, $fixtureSet, $scope);
+                return $resolver->resolve($value, $fixture, $fixtureSet, $scope, $context);
             }
         }
 

--- a/src/Generator/ValueResolverInterface.php
+++ b/src/Generator/ValueResolverInterface.php
@@ -25,6 +25,7 @@ interface ValueResolverInterface
      * @param FixtureInterface   $fixture Fixture to which belongs the arguments.
      * @param ResolvedFixtureSet $fixtureSet
      * @param array              $scope   List of variables accessible while resolving the arguments.
+     * @param GenerationContext  $context
      *
      * @throws ResolutionThrowable
      *
@@ -34,6 +35,7 @@ interface ValueResolverInterface
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $fixtureSet,
-        array $scope = []
+        array $scope,
+        GenerationContext $context
     ): ResolvedValueWithFixtureSet;
 }

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Entity\DummyWithDate;
 use Nelmio\Alice\Entity\Hydrator\Dummy;
 use Nelmio\Alice\Exception\Symfony\PropertyAccess\RootException as GenericPropertyAccessException;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Hydrator\PropertyHydratorInterface;
 use Prophecy\Argument;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
@@ -68,7 +69,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
         $accessor = $accessorProphecy->reveal();
 
         $hydrator = new SymfonyPropertyAccessorHydrator($accessor);
-        $result = $hydrator->hydrate($object, $property);
+        $result = $hydrator->hydrate($object, $property, new GenerationContext());
 
         $this->assertEquals($object, $result);
 
@@ -91,7 +92,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
         $accessor = $accessorProphecy->reveal();
 
         $hydrator = new SymfonyPropertyAccessorHydrator($accessor);
-        $result = $hydrator->hydrate($object, $property);
+        $result = $hydrator->hydrate($object, $property, new GenerationContext());
 
         $this->assertEquals($object, $result);
     }
@@ -104,7 +105,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new SimpleObject('dummy', new \Nelmio\Alice\Dummy());
         $property = new Property('foo', 'bar');
-        $this->hydrator->hydrate($object, $property);
+        $this->hydrator->hydrate($object, $property, new GenerationContext());
     }
 
     /**
@@ -115,7 +116,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new SimpleObject('dummy', new DummyWithDate());
         $property = new Property('immutableDateTime', 'bar');
-        $this->hydrator->hydrate($object, $property);
+        $this->hydrator->hydrate($object, $property, new GenerationContext());
     }
 
     /**
@@ -136,7 +137,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
         $accessor = $accessorProphecy->reveal();
 
         $hydrator = new SymfonyPropertyAccessorHydrator($accessor);
-        $hydrator->hydrate($object, $property);
+        $hydrator->hydrate($object, $property, new GenerationContext());
     }
 
     public function testCanHydrateStdClassObjects()
@@ -148,7 +149,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
         $std->foo = 'bar';
         $expected = new SimpleObject('dummy', $std);
 
-        $actual = $this->hydrator->hydrate($object, $property);
+        $actual = $this->hydrator->hydrate($object, $property, new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -160,7 +161,7 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
     {
         $instance = new Dummy();
         $object = new SimpleObject('dummy', $instance);
-        $hydratedObject = $this->hydrator->hydrate($object , $property);
+        $hydratedObject = $this->hydrator->hydrate($object , $property, new GenerationContext());
 
         $expected = $property->getValue();
         $actual = $this->propertyAccessor->getValue($hydratedObject->getInstance(), $property->getName());

--- a/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
@@ -12,11 +12,11 @@
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
-use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Dummy;
 use Nelmio\Alice\Exception\Generator\Instantiator\InstantiationException;
 use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
@@ -67,7 +67,7 @@ class AbstractChainableInstantiatorTest extends \PHPUnit_Framework_TestCase
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new ProphecyChainableInstantiator($decoratedInstantiator);
-        $instantiator->instantiate($fixture, $set);
+        $instantiator->instantiate($fixture, $set, new GenerationContext());
     }
 
     /**
@@ -85,7 +85,7 @@ class AbstractChainableInstantiatorTest extends \PHPUnit_Framework_TestCase
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new ProphecyChainableInstantiator($decoratedInstantiator);
-        $instantiator->instantiate($fixture, $set);
+        $instantiator->instantiate($fixture, $set, new GenerationContext());
     }
 
     public function testReturnsNewSetWithInstantiatedObject()
@@ -112,7 +112,7 @@ class AbstractChainableInstantiatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $instantiator = new ProphecyChainableInstantiator($decoratedInstantiator);
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, new GenerationContext());
 
         $this->assertEquals($expected, $actual);
 

--- a/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\Definition\ServiceReference\DummyReference;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Entity\Instantiator\AbstractDummyWithRequiredParameterInConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 
@@ -95,7 +96,7 @@ class NoCallerMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
                 new SimpleMethodCall('__construct', [10])
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = new DummyWithRequiredParameterInConstructor(10);
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -117,7 +118,7 @@ class NoCallerMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
                 new SimpleMethodCall('fake', [10])
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = new DummyWithRequiredParameterInConstructor(10);
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -139,6 +140,6 @@ class NoCallerMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Entity\Instantiator\AbstractDummyWithRequiredParameterInConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 
@@ -69,7 +70,7 @@ class NoMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
             DummyWithRequiredParameterInConstructor::class,
             SpecificationBagFactory::create()
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $instance = $set->getObjects()->get($fixture)->getInstance();
         $this->assertInstanceOf(DummyWithRequiredParameterInConstructor::class, $instance);
@@ -99,6 +100,6 @@ class NoMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithExplicitDefaultConstructorThrowing
 use Nelmio\Alice\Entity\Instantiator\DummyWithPrivateConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithProtectedConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 
@@ -60,7 +61,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testIfCannotGetConstructorReflectionTriesToInstantiateObjectWithoutArguments()
     {
         $fixture = new SimpleFixture('dummy', DummyWithDefaultConstructor::class, SpecificationBagFactory::create());
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = new DummyWithDefaultConstructor();
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -75,7 +76,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfInstantiatingObjectWithoutArgumentsFails()
     {
         $fixture = new SimpleFixture('dummy', AbstractDummy::class, SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -85,7 +86,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfReflectionFailsWithAnotherErrorThanMethodNotExisting()
     {
         $fixture = new SimpleFixture('dummy', 'Unknown', SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -95,7 +96,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfObjectConstructorHasMandatoryParameters()
     {
         $fixture = new SimpleFixture('dummy', DummyWithRequiredParameterInConstructor::class, SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -105,7 +106,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfObjectInstantiationFailsUnderNominalConditions()
     {
         $fixture = new SimpleFixture('dummy', DummyWithExplicitDefaultConstructorThrowingException::class, SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -115,7 +116,7 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfObjectConstructorIsPrivate()
     {
         $fixture = new SimpleFixture('dummy', DummyWithPrivateConstructor::class, SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -125,6 +126,6 @@ class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfObjectConstructorIsProtected()
     {
         $fixture = new SimpleFixture('dummy', DummyWithProtectedConstructor::class, SpecificationBagFactory::create());
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithExplicitDefaultConstructorThrowing
 use Nelmio\Alice\Entity\Instantiator\DummyWithFakeNamedConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructor;
 use Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructorAndOptionalParameters;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 
@@ -101,7 +102,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = DummyWithNamedConstructor::namedConstruct();
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -122,7 +123,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = DummyWithNamedConstructorAndOptionalParameters::namedConstruct(10);
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -147,7 +148,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -167,7 +168,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -187,7 +188,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -208,7 +209,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
     /**
@@ -228,7 +229,7 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
         $expected = DummyWithNamedConstructorAndOptionalParameters::namedConstruct(10);
         $actual = $set->getObjects()->get($fixture)->getInstance();
@@ -253,6 +254,6 @@ class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create());
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
+++ b/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Instantiator;
 
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
@@ -57,7 +58,7 @@ class ExistingInstanceInstantiatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $instantiator = new ExistingInstanceInstantiator(new FakeInstantiator());
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, new GenerationContext());
 
         $this->assertSame($expected, $actual);
     }
@@ -66,10 +67,12 @@ class ExistingInstanceInstantiatorTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new DummyFixture('dummy');
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $decoratedInstantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
         $decoratedInstantiatorProphecy
-            ->instantiate($fixture, $set)
+            ->instantiate($fixture, $set, $context)
             ->willReturn(
                 $expected = $set->withObjects(
                     (new ObjectBag())->with(
@@ -85,7 +88,7 @@ class ExistingInstanceInstantiatorTest extends \PHPUnit_Framework_TestCase
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new ExistingInstanceInstantiator($decoratedInstantiator);
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, $context);
 
         $this->assertSame($expected, $actual);
 

--- a/tests/Generator/Instantiator/InstantiatorRegistryTest.php
+++ b/tests/Generator/Instantiator/InstantiatorRegistryTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Instantiator;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\ObjectBag;
@@ -54,6 +55,8 @@ class InstantiatorRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
         $expected = ResolvedFixtureSetFactory::create(
             null,
             null,
@@ -68,7 +71,7 @@ class InstantiatorRegistryTest extends \PHPUnit_Framework_TestCase
 
         $instantiator2Prophecy = $this->prophesize(ChainableInstantiatorInterface::class);
         $instantiator2Prophecy->canInstantiate($fixture)->willReturn(true);
-        $instantiator2Prophecy->instantiate($fixture, $set)->willReturn($expected);
+        $instantiator2Prophecy->instantiate($fixture, $set, $context)->willReturn($expected);
         /* @var ChainableInstantiatorInterface $instantiator2 */
         $instantiator2 = $instantiator2Prophecy->reveal();
 
@@ -82,7 +85,7 @@ class InstantiatorRegistryTest extends \PHPUnit_Framework_TestCase
             $instantiator2,
             $instantiator3,
         ]);
-        $actual = $registry->instantiate($fixture, $set);
+        $actual = $registry->instantiate($fixture, $set, $context);
 
         $this->assertSame($expected, $actual);
 
@@ -102,6 +105,6 @@ class InstantiatorRegistryTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $registry = new InstantiatorRegistry([]);
-        $registry->instantiate($fixture, $set);
+        $registry->instantiate($fixture, $set, new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/InstantiatorResolverTest.php
+++ b/tests/Generator/Instantiator/InstantiatorResolverTest.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Definition\Value\VariableValue;
 use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
@@ -24,7 +25,6 @@ use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
-use Nelmio\Alice\ParameterBag;
 use Prophecy\Argument;
 
 /**
@@ -75,6 +75,8 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         );
         $fixture = new SimpleFixture('dummy', 'stdClass', $specs);
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $expected = ResolvedFixtureSetFactory::create(
             null,
@@ -89,7 +91,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
             $set->getObjects()
         );
         $resolverProphecy
-            ->resolve($firstArg, $fixture, $set)
+            ->resolve($firstArg, $fixture, $set, [], $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     'resolvedFirstArg',
@@ -103,7 +105,7 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
             $setAfterFirstArgResolution->getObjects()
         );
         $resolverProphecy
-            ->resolve($secondArg, $fixture, $setAfterFirstArgResolution)
+            ->resolve($secondArg, $fixture, $setAfterFirstArgResolution, [], $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     'resolvedSecondArg',
@@ -117,14 +119,14 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $fixtureAfterResolution = $fixture->withSpecs($resolvedSpecs);
         $decoratedInstantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
         $decoratedInstantiatorProphecy
-            ->instantiate($fixtureAfterResolution, $setAfterSecondArgResolution)
+            ->instantiate($fixtureAfterResolution, $setAfterSecondArgResolution, $context)
             ->willReturn($expected)
         ;
         /** @var InstantiatorInterface $decoratedInstantiator */
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new InstantiatorResolver($decoratedInstantiator, $resolver);
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, $context);
 
         $this->assertSame($expected, $actual);
 
@@ -137,6 +139,8 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $specs = SpecificationBagFactory::create();
         $fixture = new SimpleFixture('dummy', 'stdClass', $specs);
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $expected = ResolvedFixtureSetFactory::create(
             null,
@@ -150,12 +154,12 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $resolverProphecy->reveal();
 
         $decoratedInstantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
-        $decoratedInstantiatorProphecy->instantiate($fixture, $set)->willReturn($expected);
+        $decoratedInstantiatorProphecy->instantiate($fixture, $set, $context)->willReturn($expected);
         /** @var InstantiatorInterface $decoratedInstantiator */
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new InstantiatorResolver($decoratedInstantiator, $resolver);
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, $context);
 
         $this->assertSame($expected, $actual);
     }
@@ -165,6 +169,8 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $specs = SpecificationBagFactory::create();
         $fixture = new SimpleFixture('dummy', 'stdClass', $specs);
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $expected = ResolvedFixtureSetFactory::create(
             null,
@@ -178,12 +184,12 @@ class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $resolverProphecy->reveal();
 
         $decoratedInstantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
-        $decoratedInstantiatorProphecy->instantiate($fixture, $set)->willReturn($expected);
+        $decoratedInstantiatorProphecy->instantiate($fixture, $set, $context)->willReturn($expected);
         /** @var InstantiatorInterface $decoratedInstantiator */
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new InstantiatorResolver($decoratedInstantiator, $resolver);
-        $actual = $instantiator->instantiate($fixture, $set);
+        $actual = $instantiator->instantiate($fixture, $set, $context);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Generator\Caller\FakeCaller;
 use Nelmio\Alice\Generator\CallerInterface;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\FakeInstantiator;
 use Nelmio\Alice\Generator\InstantiatorInterface;
 use Nelmio\Alice\Generator\ObjectGeneratorInterface;
@@ -52,12 +53,14 @@ class SimpleObjectGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('TODO');
         $fixture = new SimpleFixture('dummy', \stdClass::class, SpecificationBagFactory::create());
         $set = ResolvedFixtureSetFactory::create();
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
         $instance = new \stdClass();
         $instantiatedObject = new SimpleObject($fixture->getId(), $instance);
 
         $instantiatorProphecy = $this->prophesize(InstantiatorInterface::class);
         $instantiatorProphecy
-            ->instantiate($fixture, $set)
+            ->instantiate($fixture, $set, $context)
             ->willReturn(
                 $setWithInstantiatedObject = ResolvedFixtureSetFactory::create(
                     null,
@@ -76,7 +79,7 @@ class SimpleObjectGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $hydratorProphecy = $this->prophesize(HydratorInterface::class);
         $hydratorProphecy
-            ->hydrate($instantiatedObject, $setWithInstantiatedObject)
+            ->hydrate($instantiatedObject, $setWithInstantiatedObject, $context)
             ->willReturn(
                 $setWithHydratedObject = ResolvedFixtureSetFactory::create(
                     null,
@@ -108,7 +111,7 @@ class SimpleObjectGeneratorTest extends \PHPUnit_Framework_TestCase
         $caller = $callerProphecy->reveal();
 
         $generator = new SimpleObjectGenerator(new FakeValueResolver(), $instantiator, $hydrator, $caller);
-        $objects = $generator->generate($fixture, $set);
+        $objects = $generator->generate($fixture, $set, $context);
 
         $this->assertEquals($setWithObjectAfterCalls->getObjects(), $objects);
 

--- a/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
@@ -106,12 +106,13 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
         $context = new ResolvingContext();
 
         $injectedResolverProphecy = $this->prophesize(ParameterResolverInterface::class);
+        $context->add('array_param');
         $injectedResolverProphecy
             ->resolve(
                 new Parameter('0', 'foo'),
                 $unresolvedParameters,
                 $resolvedParameters,
-                $context->with('array_param')
+                $context
             )
             ->willReturn(
                 new ParameterBag([
@@ -120,12 +121,13 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
                 ])
             )
         ;
+        $context->add('array_param');
         $injectedResolverProphecy
             ->resolve(
                 new Parameter('1', 'bar'),
                 $unresolvedParameters,
                 $resolvedParameters,
-                $context->with('array_param')
+                $context
             )
             ->willReturn(
                 new ParameterBag([
@@ -263,11 +265,26 @@ class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
             ],
             'context that does not contain the parameter being resolved' => [
                 new ResolvingContext('unrelated'),
-                (new ResolvingContext('unrelated'))->with('array_param'),
+                (function () {
+                    $context = new ResolvingContext('unrelated');
+                    $context->add('array_param');
+
+                    return $context;
+                })(),
             ],
             'context that contains the parameter being resolved' => [
-                (new ResolvingContext('unrelated'))->with('array_param'),
-                (new ResolvingContext('unrelated'))->with('array_param'),
+                (function () {
+                    $context = new ResolvingContext('unrelated');
+                    $context->add('array_param');
+
+                    return $context;
+                })(),
+                (function () {
+                    $context = new ResolvingContext('unrelated');
+                    $context->add('array_param');
+
+                    return $context;
+                })()
             ],
         ];
     }

--- a/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
@@ -14,9 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Parameter\Chainable;
 use Nelmio\Alice\Exception\Generator\Resolver\RecursionLimitReachedException;
 use Nelmio\Alice\Generator\Resolver\ChainableParameterResolverInterface;
 use Nelmio\Alice\Generator\Resolver\FakeParameterResolver;
-use Nelmio\Alice\Generator\Resolver\Parameter\ImmutableDummyChainableResolverAwareResolver;
 use Nelmio\Alice\Generator\Resolver\ParameterResolverAwareInterface;
-use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
@@ -96,7 +94,7 @@ class RecursiveParameterResolverTest extends \PHPUnit_Framework_TestCase
         $parameter = new Parameter('foo', null);
         $unresolvedParameters = new ParameterBag(['name' => 'Alice']);
         $resolvedParameters = new ParameterBag(['place' => 'Wonderlands']);
-        $context = new \Nelmio\Alice\Generator\Resolver\ResolvingContext('foo');
+        $context = new ResolvingContext('foo');
         $expected = new ParameterBag(['foo' => 'bar']);
 
         $decoratedResolverProphecy = $this->prophesize(ChainableParameterResolverInterface::class);
@@ -133,7 +131,7 @@ class RecursiveParameterResolverTest extends \PHPUnit_Framework_TestCase
         $parameter = new Parameter('foo', null);
         $unresolvedParameters = new ParameterBag(['name' => 'Alice']);
         $resolvedParameters = new ParameterBag(['place' => 'Wonderlands']);
-        $context = new \Nelmio\Alice\Generator\Resolver\ResolvingContext('foo');
+        $context = new ResolvingContext('foo');
 
         $decoratedResolverProphecy = $this->prophesize(ChainableParameterResolverInterface::class);
         $decoratedResolverProphecy
@@ -320,10 +318,15 @@ class RecursiveParameterResolverTest extends \PHPUnit_Framework_TestCase
                 null,
             ],
             'empty context' => [
-                new \Nelmio\Alice\Generator\Resolver\ResolvingContext(),
+                new ResolvingContext(),
             ],
             'context with random value' => [
-                (new \Nelmio\Alice\Generator\Resolver\ResolvingContext())->with('name'),
+                (function () {
+                    $context = new ResolvingContext();
+                    $context->add('name');
+
+                    return $context;
+                })(),
             ],
         ];
     }

--- a/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
@@ -193,7 +193,12 @@ class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
                 new Parameter('bar', 'unresolved(bar)'),
                 $unresolvedParameters,
                 $resolvedParameters,
-                (new \Nelmio\Alice\Generator\Resolver\ResolvingContext('foo'))->with('bar')
+                (function () {
+                    $context = new ResolvingContext('foo');
+                    $context->add('bar');
+
+                    return $context;
+                })()
             )
             ->willReturn(
                 new ParameterBag([
@@ -223,6 +228,7 @@ class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
         ]);
         $resolvedParameters = new ParameterBag();
         $context = new ResolvingContext('ping');
+        $context->add('foo');
         $expected = new ParameterBag([
             'bar' => 'Mad Hatter',
             'foo' => 'Mad Hatter',
@@ -235,8 +241,6 @@ class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
                 $unresolvedParameters,
                 $resolvedParameters,
                 $context
-                    ->with('foo')
-                    ->with('bar')
             )
             ->willReturn(
                 new ParameterBag([

--- a/tests/Generator/Resolver/ResolvingContextTest.php
+++ b/tests/Generator/Resolver/ResolvingContextTest.php
@@ -27,57 +27,43 @@ class ResolvingContextTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($context->has('foo'));
     }
 
-    public function testWithersReturnNewModifiedInstance()
+    public function testMutator()
     {
         $context = new ResolvingContext();
-        $newContext = $context->with('foo');
 
-        $this->assertInstanceOf(ResolvingContext::class, $newContext);
-        $this->assertNotSame($newContext, $context);
         $this->assertFalse($context->has('foo'));
-        $this->assertTrue($newContext->has('foo'));
+        $context->add('foo');
+        $this->assertTrue($context->has('foo'));
     }
 
-    public function testStaticFactoryMethodCreatesANewInstance()
+    public function testStaticFactoryMethodReturnsExistingInstance()
     {
         $context = ResolvingContext::createFrom(null, 'foo');
         $this->assertTrue($context->has('foo'));
 
-        $newContext = ResolvingContext::createFrom($context->with('bar'), 'ping');
-        $this->assertFalse($context->has('bar'));
-        $this->assertFalse($context->has('ping'));
-        $this->assertTrue($newContext->has('foo'));
-        $this->assertTrue($newContext->has('bar'));
-        $this->assertTrue($newContext->has('ping'));
-        $this->assertNotSame($newContext, $context);
-
-        $newContext = ResolvingContext::createFrom($context, 'bar');
-        $this->assertFalse($context->has('bar'));
-        $this->assertTrue($newContext->has('foo'));
-        $this->assertTrue($newContext->has('bar'));
-        $this->assertNotSame($newContext, $context);
+        $newContext = ResolvingContext::createFrom($context, 'ping');
+        $this->assertSame($context, $newContext);
+        $this->assertTrue($context->has('foo'));
+        $this->assertTrue($context->has('ping'));
     }
 
     public function testFactoryMethodCannotTriggerACircularReference()
     {
         $context = new ResolvingContext('foo');
         $context->checkForCircularReference('foo');
-        $this->assertTrue(true, 'Did not expect exception to be thrown.');
 
         $context = ResolvingContext::createFrom($context, 'foo');
         $context->checkForCircularReference('foo');
-        $this->assertTrue(true, 'Did not expect exception to be thrown.');
 
         $context = ResolvingContext::createFrom($context, 'foo');
         $context->checkForCircularReference('foo');
-        $this->assertTrue(true, 'Did not expect exception to be thrown.');
 
-        $context = $context->with('foo');
+        $context->add('foo');
         try {
             $context->checkForCircularReference('foo');
             $this->fail('Expected exception to be thrown.');
         } catch (CircularReferenceException $exception) {
-            // expected result
+            // Expected result
         }
     }
 
@@ -86,10 +72,10 @@ class ResolvingContextTest extends \PHPUnit_Framework_TestCase
         $context = new ResolvingContext('bar');
         $context->checkForCircularReference('foo');
 
-        $context = $context->with('foo');
+        $context->add('foo');
         $context->checkForCircularReference('foo');
 
-        $context = $context->with('foo');
+        $context->add('foo');
         try {
             $context->checkForCircularReference('foo');
             $this->fail('Expected exception to be thrown.');
@@ -103,7 +89,7 @@ class ResolvingContextTest extends \PHPUnit_Framework_TestCase
         $context = new ResolvingContext('foo');
         $context->checkForCircularReference('foo');
 
-        $context = $context->with('foo');
+        $context->add('foo');
         try {
             $context->checkForCircularReference('foo');
             $this->fail('Expected exception to be thrown.');

--- a/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\EvaluatedValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Exception\Generator\Resolver\UnresolvableValueException;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -50,7 +51,6 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         $value = new EvaluatedValue('"Hello"." "."world!"');
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
-        $scope = ['val' => 'scopie'];
 
         $expected = new ResolvedValueWithFixtureSet(
             'Hello world!',
@@ -58,7 +58,7 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $resolver = new EvaluatedValueResolver();
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -74,7 +74,7 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new EvaluatedValueResolver();
-        $resolver->resolve($value, $fixture, $set);
+        $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
     }
 
     /**
@@ -88,7 +88,7 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new EvaluatedValueResolver();
-        $resolver->resolve($value, $fixture, $set);
+        $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
     }
 
     public function testTheEvaluatedExpressionCanContainScopeFunctions()
@@ -106,7 +106,7 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $resolver = new EvaluatedValueResolver();
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -133,13 +133,13 @@ class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $resolver = new EvaluatedValueResolver();
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, new GenerationContext());
 
         $this->assertEquals($expected, $actual);
 
         $value = new EvaluatedValue('$scope');
         try {
-            $resolver->resolve($value, $fixture, $set, $scope);
+            $resolver->resolve($value, $fixture, $set, $scope, new GenerationContext());
             $this->fail('Expected an exception to be thrown.');
         } catch (UnresolvableValueException $exception) {
             $this->assertEquals(

--- a/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -67,7 +68,7 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
     {
         $value = new FixturePropertyValue(new FakeValue(), '');
         $resolver = new FakerFunctionCallValueResolver(FakerGeneratorFactory::create());
-        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     public function testReturnsSetWithResolvedValue()
@@ -76,6 +77,8 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $fakerGeneratorProphecy = $this->prophesize(FakerGenerator::class);
         $fakerGeneratorProphecy->format('foo', [])->willReturn('bar');
@@ -85,7 +88,7 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $expected = new ResolvedValueWithFixtureSet('bar', $set);
 
         $resolver = new FakerFunctionCallValueResolver($fakerGenerator, new FakeValueResolver());
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals($expected, $actual);
     }
@@ -103,10 +106,12 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve(new FakeValue(), $fixture, $set, $scope)
+            ->resolve(new FakeValue(), $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     $instance = new \stdClass(),
@@ -134,7 +139,7 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $expected = new ResolvedValueWithFixtureSet('bar', $newSet);
 
         $resolver = new FakerFunctionCallValueResolver($fakerGenerator, $valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals($expected, $actual);
     }
@@ -146,7 +151,7 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new FakerFunctionCallValueResolver(FakerGeneratorFactory::create(), new FakeValueResolver());
-        $result = $resolver->resolve($value, $fixture, $set);
+        $result = $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
 
         $this->assertEquals(9, strlen($result->getValue()));
         $this->assertEquals('Hello ', substr($result->getValue(), 0, 6));
@@ -163,6 +168,6 @@ class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCas
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new FakerFunctionCallValueResolver(FakerGeneratorFactory::create(), new FakeValueResolver());
-        $resolver->resolve($value, $fixture, $set);
+        $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 use Nelmio\Alice\Entity\Hydrator\Dummy;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -72,7 +73,7 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
     {
         $value = new FixturePropertyValue(new FakeValue(), '');
         $resolver = new FixturePropertyReferenceResolver(new FakePropertyAccessor());
-        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     public function testReturnsSetWithResolvedValue()
@@ -84,10 +85,12 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve($reference, $fixture, $set, $scope)
+            ->resolve($reference, $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     $instance = new \stdClass(),
@@ -106,7 +109,7 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('yo', $newSet);
 
         $resolver = new FixturePropertyReferenceResolver($propertyAccessor, $valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals($expected, $actual);
 
@@ -145,7 +148,7 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor = $propertyAccessorProphecy->reveal();
 
         $resolver = new FixturePropertyReferenceResolver($propertyAccessor, $valueResolver);
-        $resolver->resolve($value, new FakeFixture(), $set);
+        $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 
     public function testTestResolutionWithSymfonyPropertyAccessor()
@@ -173,7 +176,7 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('foo', $set);
 
         $resolver = new FixturePropertyReferenceResolver(PropertyAccess::createPropertyAccessor(), $valueResolver);
-        $actual = $resolver->resolve($value, new FakeFixture(), $set);
+        $actual = $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -205,7 +208,7 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixturePropertyReferenceResolver(PropertyAccess::createPropertyAccessor(), $valueResolver);
-        $resolver->resolve($value, new FakeFixture(), $set);
+        $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 
     /**
@@ -234,6 +237,12 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixturePropertyReferenceResolver(PropertyAccess::createPropertyAccessor(), $valueResolver);
-        $resolver->resolve($value, new SimpleFixture('dummy', 'Dummy', SpecificationBagFactory::create()), $set);
+        $resolver->resolve(
+            $value,
+            new SimpleFixture('dummy', 'Dummy', SpecificationBagFactory::create()),
+            $set,
+            [],
+            new GenerationContext()
+        );
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixtureMatchReferenceValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -69,7 +70,7 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
     public function testCannotResolveValueIfHasNoResolver()
     {
         $resolver = new FixtureWildcardReferenceResolver();
-        $resolver->resolve(new FakeValue(), new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve(new FakeValue(), new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     public function testReturnsARandomMatchingFixture()
@@ -81,10 +82,12 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
                 ->with($fixture = new DummyFixture('dummy'))
         );
         $scope = ['val' => 'scopie'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, $scope)
+            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, $scope, $context)
             ->willReturn(
                 $expected = new ResolvedValueWithFixtureSet(
                     'dummy',
@@ -99,7 +102,7 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixtureWildcardReferenceResolver($valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertSame($expected, $actual);
 
@@ -115,10 +118,13 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
             (new FixtureBag())
                 ->with(new DummyFixture('dummy'))
         );
+        $scope = ['foo' => 'bar'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, [])
+            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, $scope, $context)
             ->willReturn(
                 $expected = new ResolvedValueWithFixtureSet(
                     'dummy',
@@ -133,7 +139,7 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixtureWildcardReferenceResolver($valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertSame($expected, $actual);
     }
@@ -148,10 +154,12 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
             (new ObjectBag())
                 ->with(new SimpleObject('dummy', new \stdClass()))
         );
+        $scope = [];
+        $context = new GenerationContext();
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, [])
+            ->resolve(new FixtureReferenceValue('dummy'), $fixture, $set, $scope, $context)
             ->willReturn(
                 $expected = new ResolvedValueWithFixtureSet(
                     'dummy',
@@ -166,7 +174,7 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixtureWildcardReferenceResolver($valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertSame($expected, $actual);
     }
@@ -180,8 +188,10 @@ class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $value = FixtureMatchReferenceValue::createWildcardReference('dummy');
         $fixture = new DummyFixture('injected_fixture');
         $set = ResolvedFixtureSetFactory::create();
+        $scope = [];
+        $context = new GenerationContext();
 
         $resolver = new FixtureWildcardReferenceResolver(new FakeValueResolver());
-        $resolver->resolve($value, $fixture, $set);
+        $resolver->resolve($value, $fixture, $set, $scope, $context);
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\ListValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -65,7 +66,7 @@ class ListValueResolverTest extends \PHPUnit_Framework_TestCase
     {
         $value = new ListValue([]);
         $resolver = new ListValueResolver();
-        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     public function testImplodesTheGivenArrayOfValues()
@@ -74,7 +75,7 @@ class ListValueResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('abc', ResolvedFixtureSetFactory::create());
 
         $resolver = new ListValueResolver(new FakeValueResolver());
-        $actual = $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $actual = $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -85,10 +86,12 @@ class ListValueResolverTest extends \PHPUnit_Framework_TestCase
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['scope' => 'epocs'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve(new FakeValue(), $fixture, $set, $scope)
+            ->resolve(new FakeValue(), $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     'b',
@@ -97,7 +100,7 @@ class ListValueResolverTest extends \PHPUnit_Framework_TestCase
             )
         ;
         $valueResolverProphecy
-            ->resolve(new FakeValue(), $fixture, $newSet, $scope)
+            ->resolve(new FakeValue(), $fixture, $newSet, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     'd',
@@ -111,7 +114,7 @@ class ListValueResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('abcd', $newSet2);
 
         $resolver = new ListValueResolver($valueResolver);
-        $actual = $resolver->resolve($value, $fixture, $set, $scope);
+        $actual = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals($expected, $actual);
 

--- a/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 use Nelmio\Alice\Definition\Value\OptionalValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
@@ -62,7 +63,7 @@ class OptionalValueResolverTest extends \PHPUnit_Framework_TestCase
     {
         $value = new FixturePropertyValue(new FakeValue(), '');
         $resolver = new OptionalValueResolver();
-        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     public function testReturnsSetWithResolvedValue()

--- a/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\ParameterValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -54,7 +55,7 @@ class ParameterValueResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('bar', $set);
 
         $resolver = new ParameterValueResolver();
-        $actual = $resolver->resolve($value, new FakeFixture(), $set);
+        $actual = $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -69,6 +70,6 @@ class ParameterValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new ParameterValueResolver();
-        $resolver->resolve($value, new FakeFixture(), $set);
+        $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
@@ -15,6 +15,7 @@ use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 use Nelmio\Alice\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\UniqueValuesPool;
@@ -103,7 +104,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
     public function testCannotResolveValueIfHasNoResolver()
     {
         $resolver = new UniqueValueResolver(new UniqueValuesPool());
-        $resolver->resolve(new UniqueValue('', ''), new FakeFixture(), ResolvedFixtureSetFactory::create());
+        $resolver->resolve(new UniqueValue('', ''), new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
     /**
@@ -117,7 +118,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new UniqueValueResolver(new UniqueValuesPool(), new FakeValueResolver(), 1);
-        $resolver->resolve($value, $fixture, $set, [], 1);
+        $resolver->resolve($value, $fixture, $set, [], new GenerationContext(), 1);
     }
 
     public function testReturnsResultIfResultDoesNotAlreadyExists()
@@ -127,7 +128,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new UniqueValueResolver(new UniqueValuesPool(), new FakeValueResolver());
-        $result = $resolver->resolve($value, $fixture, $set);
+        $result = $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
 
         $this->assertEquals(10, $result->getValue());
         $this->assertEquals($set, $result->getSet());
@@ -139,10 +140,13 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $value = new UniqueValue('uniqid', $realValue);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
+        $scope = ['scope' => 'epocs'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $decoratedResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $decoratedResolverProphecy
-            ->resolve($realValue, $fixture, $set, [])
+            ->resolve($realValue, $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     10,
@@ -154,7 +158,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $decoratedResolver = $decoratedResolverProphecy->reveal();
 
         $resolver = new UniqueValueResolver(new UniqueValuesPool(), $decoratedResolver);
-        $result = $resolver->resolve($value, $fixture, $set);
+        $result = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals(10, $result->getValue());
         $this->assertEquals($newSet, $result->getSet());
@@ -169,6 +173,9 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $value = new UniqueValue($uniqueId, $realValue);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
+        $scope = ['scope' => 'epocs'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $pool = new UniqueValuesPool();
         $pool->add(new UniqueValue($uniqueId, 10));
@@ -179,7 +186,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $setAfterResolution1 = ResolvedFixtureSetFactory::create(new ParameterBag(['iteration' => 1]));
         $setAfterResolution2 = ResolvedFixtureSetFactory::create(new ParameterBag(['iteration' => 2]));
         $decoratedResolverProphecy
-            ->resolve($realValue, $fixture, $set, [])
+            ->resolve($realValue, $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     10,
@@ -188,7 +195,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
             )
         ;
         $decoratedResolverProphecy
-            ->resolve($realValue, $fixture, $setAfterResolution0, [])
+            ->resolve($realValue, $fixture, $setAfterResolution0, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     11,
@@ -197,7 +204,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
             )
         ;
         $decoratedResolverProphecy
-            ->resolve($realValue, $fixture, $setAfterResolution1, [])
+            ->resolve($realValue, $fixture, $setAfterResolution1, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     12,
@@ -210,7 +217,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
 
 
         $resolver = new UniqueValueResolver($pool, $decoratedResolver);
-        $result = $resolver->resolve($value, $fixture, $set);
+        $result = $resolver->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertEquals(12, $result->getValue());
         $this->assertEquals($setAfterResolution2, $result->getSet());
@@ -225,6 +232,9 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
         $value = new UniqueValue($uniqueId, $realValue);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
+        $scope = ['scope' => 'epocs'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
 
         $pool = new UniqueValuesPool();
         $pool->add(new UniqueValue($uniqueId, 10));
@@ -232,7 +242,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
 
         $decoratedResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $decoratedResolverProphecy
-            ->resolve($realValue, $fixture, $set, [])
+            ->resolve($realValue, $fixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(10, $set)
             )
@@ -243,7 +253,7 @@ class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
 
         $resolver = new UniqueValueResolver($pool, $decoratedResolver);
         try {
-            $resolver->resolve($value, $fixture, $set);
+            $resolver->resolve($value, $fixture, $set, $scope, $context);
             $this->fail('Expected exception to be thrown.');
         } catch (UniqueValueGenerationLimitReachedException $exception) {
             $decoratedResolverProphecy->resolve(Argument::cetera())->shouldHaveBeenCalledTimes(150);

--- a/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\VariableValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
@@ -56,7 +57,7 @@ class VariableValueResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new ResolvedValueWithFixtureSet('pong', $set);
 
         $resolver = new VariableValueResolver();
-        $actual = $resolver->resolve($value, new FakeFixture(), $set, $scope);
+        $actual = $resolver->resolve($value, new FakeFixture(), $set, $scope, new GenerationContext());
 
         $this->assertEquals($expected, $actual);
     }
@@ -71,6 +72,6 @@ class VariableValueResolverTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new VariableValueResolver();
-        $resolver->resolve($value, new FakeFixture(), $set);
+        $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
@@ -16,6 +16,7 @@ use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
+use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverInterface;
@@ -59,6 +60,9 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
         $value = new FakeValue();
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
+        $scope = ['scope' => 'epocs'];
+        $context = new GenerationContext();
+        $context->markIsResolvingFixture('foo');
         $expected = new ResolvedValueWithFixtureSet(
             10,
             ResolvedFixtureSetFactory::create(null, null, (new ObjectBag())->with(new SimpleObject('dummy', new \stdClass())))
@@ -71,7 +75,7 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
 
         $instantiator2Prophecy = $this->prophesize(ChainableValueResolverInterface::class);
         $instantiator2Prophecy->canResolve($value)->willReturn(true);
-        $instantiator2Prophecy->resolve($value, $fixture, $set, [])->willReturn($expected);
+        $instantiator2Prophecy->resolve($value, $fixture, $set, $scope, $context)->willReturn($expected);
         /* @var ChainableValueResolverInterface $instantiator2 */
         $instantiator2 = $instantiator2Prophecy->reveal();
 
@@ -85,7 +89,7 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
             $instantiator2,
             $instantiator3,
         ]);
-        $actual = $registry->resolve($value, $fixture, $set);
+        $actual = $registry->resolve($value, $fixture, $set, $scope, $context);
 
         $this->assertSame($expected, $actual);
 
@@ -105,6 +109,6 @@ class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $registry = new ValueResolverRegistry([]);
-        $registry->resolve(new DummyValue('foo'), $fixture, $set);
+        $registry->resolve(new DummyValue('foo'), $fixture, $set, [], new GenerationContext());
     }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1859,17 +1859,6 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        //TODO: check
-//        yield '[templating] cannot extend a non template fixture' => [
-//            [
-//                \stdClass::class => [
-//                    'base_dummy' => [],
-//                    'dummy (extends base_dummy)' => [],
-//                ],
-//            ],
-//            null,
-//        ];
-//
         yield '[templating] nominal' => [
             [
                 \stdClass::class => [
@@ -2117,6 +2106,16 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
+        yield '[parameter] circular reference' => [
+            [
+                'parameters' => [
+                    'foo' => '<{bar}>',
+                    'bar' => '<{foo}>',
+                ],
+            ],
+            null,
+        ];
+
         yield 'dynamic array with scalar value' => [
             [
                 \stdClass::class => [
@@ -2134,7 +2133,30 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-    }
 
-    //TODO: test with circular reference
+        yield 'object circular reference' => [
+            [
+                DummyWithConstructorParam::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            '@another_dummy',
+                        ],
+                    ],
+                    'another_dummy' => [
+                        '__construct' => [
+                            '@dummy',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => StdClassFactory::create([
+                        'foo' => ['bar', 'bar', 'bar', 'bar', 'bar']
+                    ]),
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Add tests for circular references in tests and objects.

The circular dependencies for objects are being solved by introducing a context object passed during the generation.