### PR TITLE
added Doctrine inflector as possibility for sigularizing

### DIFF
--- a/src/Nelmio/Alice/Instances/Populator/Methods/ArrayAdd.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/ArrayAdd.php
@@ -112,6 +112,7 @@ class ArrayAdd implements MethodInterface
             'Symfony\Component\Inflector\Inflector' => 'singularize',
             'Symfony\Component\PropertyAccess\StringUtil' => 'singularify',
             'Symfony\Component\Form\Util\FormUtil' => 'singularify',
+            'Doctrine\Common\Inflector\Inflector' => 'singularize',
         ];
 
         foreach ($classes as $class => $method) {


### PR DESCRIPTION
Doctrine also has an inflector which is able singularize words. Since most users will already depend
on doctrine it is opportunistic to also support this inflector. I added it at the bottom of the array to give precedence to the already existing ones.