### PR TITLE
Add support for reference functions

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
@@ -29,6 +29,7 @@ final class ReferenceLexer implements LexerInterface
         '/^(@.*\*)/' => TokenType::WILDCARD_REFERENCE_TYPE,
         '/^(@.*->.*)/' => null,
         '/^(@\S+)/' => TokenType::SIMPLE_REFERENCE_TYPE,
+        '/^(@)/' => TokenType::SIMPLE_REFERENCE_TYPE,
     ];
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
@@ -37,11 +37,12 @@ final class SubPatternsLexer implements LexerInterface
         '/^(<\S+\(.*\)>)/' => TokenType::FUNCTION_TYPE,
         '/^(<\S+>)/' => null,
         '/^(\[[^\[\]]+\])/' => TokenType::STRING_ARRAY_TYPE,
-        '/^(@[^\ @\{\<]+\(.*\))/' => self::REFERENCE_LEXER, // function
-        '/^(@[^\ @\<]+\{.*\}->\S+\(.*\))/' => self::REFERENCE_LEXER, // range or list with function
-        '/^(@[^\ @\<]+\{.*\}->[^\(\)\ \{]+)/' => self::REFERENCE_LEXER, // range or list with property
-        '/^(@[^\ @\<]+\{.*\})/' => self::REFERENCE_LEXER,   // range or list
+        '/^(@[^\ @\{\<]+\(.*\))/' => self::REFERENCE_LEXER, // Function with text
+        '/^(@[^\ @\<]+\{.*\}->\S+\(.*\))/' => self::REFERENCE_LEXER, // Range or list with function
+        '/^(@[^\ @\<]+\{.*\}->[^\(\)\ \{]+)/' => self::REFERENCE_LEXER, // Range or list with property
+        '/^(@[^\ @\<]+\{.*\})/' => self::REFERENCE_LEXER,   // Range or list
         '/^(@[^\ @\{\<]+)/' => self::REFERENCE_LEXER,
+        '/^(@)<\S+\(.*\)>/' => self::REFERENCE_LEXER,
         '/^(\$[\p{L}_]+)/' => TokenType::VARIABLE_TYPE,
         '/^([^\\\<>\[\d\%\$@\]]+)/' => TokenType::STRING_TYPE,
         '/^([^\\\<>\[\%\$@\]]+)/' => TokenType::STRING_TYPE,

--- a/src/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceResolver.php
@@ -103,7 +103,8 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
             $value,
             $fixture,
             $fixtureSet,
-            $scope
+            $scope,
+            $context
         );
 
         return $this->decoratedResolver->resolve(
@@ -120,12 +121,13 @@ implements ChainableValueResolverInterface, ObjectGeneratorAwareInterface, Value
         ValueInterface $value,
         FixtureInterface $fixture,
         ResolvedFixtureSet $set,
-        array $scope
+        array $scope,
+        GenerationContext $context
     ): array
     {
         $referredFixtureId = $value->getValue();
         if ($referredFixtureId instanceof ValueInterface) {
-            $resolvedSet = $resolver->resolve($referredFixtureId, $fixture, $set, $scope);
+            $resolvedSet = $resolver->resolve($referredFixtureId, $fixture, $set, $scope, $context);
 
             list($referredFixtureId, $set) = [$resolvedSet->getValue(), $resolvedSet->getSet()];
             if (false === is_string($referredFixtureId)) {

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -922,6 +922,13 @@ class LexerIntegrationTest extends \PHPUnit_Framework_TestCase
                 new Token('<aliceTokenizedFunction(FUNCTION_START__current__IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
+        yield '[Reference] reference which is entirely a function' => [
+            '@<current()>',
+            [
+                new Token('@', new TokenType(TokenType::SIMPLE_REFERENCE_TYPE)),
+                new Token('<aliceTokenizedFunction(FUNCTION_START__current__IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
         yield '[Reference] surrounded reference function' => [
             'foo @user0<current()> bar',
             [

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -42,15 +42,6 @@ class ReferenceLexerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\LexException
-     * @expectedExceptionMessage Could not lex the value "@ ".
-     */
-    public function testThrowsAnExceptionIfCannotLexValue()
-    {
-        $this->lexer->lex('@ ');
-    }
-
-    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid token "@u->" found.
      */

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -1014,6 +1014,15 @@ class ParserIntegrationTest extends \PHPUnit_Framework_TestCase
                 ])
             ),
         ];
+        yield '[Reference] reference which is entirely a function' => [
+            '@<foo()>',
+            new FixtureReferenceValue(
+                new ListValue([
+                    '',
+                    new FunctionCallValue('foo'),
+                ])
+            ),
+        ];
         yield '[Reference] surrounded reference function' => [
             'foo @user0<foo()> bar',
             new ListValue([

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1297,6 +1297,36 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
+        yield 'reference value with function' => [
+            [
+                \stdClass::class => [
+                    'dummy{1..2}' => [
+                        'name' => '<current()>',
+                    ],
+                    'another_dummy{1..2}' => [
+                        'dummy' => '@dummy<current()>',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy1' => $dummy1 = StdClassFactory::create([
+                        'name' => '1',
+                    ]),
+                    'dummy2' => $dummy2 = StdClassFactory::create([
+                        'name' => '2',
+                    ]),
+                    'another_dummy1' => StdClassFactory::create([
+                        'dummy' => $dummy1,
+                    ]),
+                    'another_dummy2' => StdClassFactory::create([
+                        'dummy' => $dummy2,
+                    ]),
+                ],
+            ],
+        ];
+
         yield 'inverted reference value' => [
             [
                 \stdClass::class => [
@@ -1604,27 +1634,26 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-// TODO
-//        yield '[self reference] alone' => [
-//            [
-//                \stdClass::class => [
-//                    'dummy' => [
-//                        'itself' => '@<("self")>',
-//                    ],
-//                ],
-//            ],
-//            [
-//                'parameters' => [],
-//                'objects' => [
-//                    'dummy' => (function() {
-//                        $dummy = new \stdClass();
-//                        $dummy->itself = $dummy;
-//
-//                        return $dummy;
-//                    })(),
-//                ],
-//            ],
-//        ];
+        yield '[self reference] evaluated with a function' => [
+            [
+                \stdClass::class => [
+                    'dummy' => [
+                        'itself' => '@<("self")>',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => (function() {
+                        $dummy = new \stdClass();
+                        $dummy->itself = $dummy;
+
+                        return $dummy;
+                    })(),
+                ],
+            ],
+        ];
 
         yield '[self reference] property' => [
             [
@@ -1697,28 +1726,6 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-
-// TODO
-//        yield '[self reference] alone' => [
-//            [
-//                \stdClass::class => [
-//                    'dummy' => [
-//                        'itself' => '@<("self")>',
-//                    ],
-//                ],
-//            ],
-//            [
-//                'parameters' => [],
-//                'objects' => [
-//                    'dummy' => (function() {
-//                        $dummy = new \stdClass();
-//                        $dummy->itself = $dummy;
-//
-//                        return $dummy;
-//                    })(),
-//                ],
-//            ],
-//        ];
 
         yield '[self reference] property' => [
             [


### PR DESCRIPTION
The support was actually already provided, `@user0<foo()>` would work, however there was an edge case where `@<foo()>` would not work. This PR fixes that.