### PR TITLE
Corrects Symfony bundle link

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -122,7 +122,7 @@ $objectSet = $loader->loadFile(
 ### Symfony
 
 Alice comes with a Symfony Bundle
-[`NelmioAliceBundle`](src/Bridge/Symfony/NelmioAliceBundle.php). To enabled it,
+[`NelmioAliceBundle`](/src/Bridge/Symfony/NelmioAliceBundle.php). To enabled it,
 update your application kernel:
 
 ```php


### PR DESCRIPTION
**Summary**
The link for the Symfony bundle was pointing to the wrong place