### PR TITLE
[2.x] avoid using the GLOB_BRACE flag when it is not supported

### DIFF
--- a/src/Nelmio/Alice/Fixtures.php
+++ b/src/Nelmio/Alice/Fixtures.php
@@ -117,7 +117,7 @@ class Fixtures
 
         // glob strings to filenames
         if (!is_array($files)) {
-            $matches = glob($files, GLOB_BRACE);
+            $matches = glob($files, (defined('GLOB_BRACE') ? GLOB_BRACE : 0));
             if (!$matches && !file_exists($files)) {
                 throw new \InvalidArgumentException('The file could not be found: '.$files);
             }


### PR DESCRIPTION
The GLOB_BRACE flag is not defined in the PHP runtime of musl-based Linux distributions, such as Alpine[1]. This PR avoids using it when it is not available, and the concrete fix has been based on one from the Symfony Finder component[2].

This issue does not affect the upcoming 3.x release as this flag is not used there anymore.


[1] https://github.com/zendframework/zend-stdlib/issues/58
[2] https://github.com/symfony/finder/commit/a0c9d353abe5698ef2cba586b1e1601fc211cb75