### PR TITLE
[WIP] Better handling of references to inexistent fixtures

### DIFF
--- a/src/Definition/Fixture/FixtureId.php
+++ b/src/Definition/Fixture/FixtureId.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Definition\Fixture;
+
+use Nelmio\Alice\FixtureIdInterface;
+
+final class FixtureId implements FixtureIdInterface
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/FixtureIdInterface.php
+++ b/src/FixtureIdInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice;
+
+/**
+ * A fixture is a value object representing an object to be built.
+ */
+interface FixtureIdInterface
+{
+    /**
+     * @return string e.g. 'dummy0'. May contain flags e.g. 'dummy (extends base_dummy)' depending of the implementation.
+     */
+    public function getId(): string;
+}

--- a/src/FixtureInterface.php
+++ b/src/FixtureInterface.php
@@ -19,13 +19,8 @@ use Nelmio\Alice\Exception\NoValueForCurrentException;
 /**
  * A fixture is a value object representing an object to be built.
  */
-interface FixtureInterface
+interface FixtureInterface extends FixtureIdInterface
 {
-    /**
-     * @return string e.g. 'dummy0'. May contain flags e.g. 'dummy (extends base_dummy)' depending of the implementation.
-     */
-    public function getId(): string;
-
     /**
      * @return string FQCN. May contain flags depending of the implementation.
      */

--- a/src/ObjectBag.php
+++ b/src/ObjectBag.php
@@ -97,25 +97,28 @@ final class ObjectBag implements \IteratorAggregate, \Countable
         return $clone;
     }
     
-    public function has(FixtureInterface $fixture): bool
+    public function has(FixtureIdInterface $fixture): bool
     {
         return isset($this->objects[$fixture->getId()]);
     }
 
     /**
-     * @param FixtureInterface $fixture
+     * @param FixtureIdInterface $fixture
      *
      * @throws ObjectNotFoundException
      * 
      * @return ObjectInterface
      */
-    public function get(FixtureInterface $fixture): ObjectInterface
+    public function get(FixtureIdInterface $fixture): ObjectInterface
     {
         if ($this->has($fixture)) {
             return $this->objects[$fixture->getId()];
         }
         
-        throw ObjectNotFoundException::create($fixture->getId(), $fixture->getClassName());
+        throw ObjectNotFoundException::create(
+            $fixture->getId(),
+            $fixture instanceof FixtureInterface ? $fixture->getClassName() : 'no class given'
+        );
     }
 
     /**

--- a/tests/Definition/Fixture/FixtureIdTest.php
+++ b/tests/Definition/Fixture/FixtureIdTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Definition\Fixture;
+
+use Nelmio\Alice\FixtureIdInterface;
+
+/**
+ * @covers \Nelmio\Alice\Definition\Fixture\FixtureId
+ */
+class FixtureIdTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAFixtureId()
+    {
+        $this->assertTrue(is_a(FixtureId::class, FixtureIdInterface::class, true));
+    }
+
+    public function testAccessor()
+    {
+        $id = new FixtureId('foo');
+        $this->assertEquals('foo', $id->getId());
+    }
+}

--- a/tests/Definition/Fixture/SimpleFixtureTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\Definition\Fixture;
 use Nelmio\Alice\Definition\MethodCall\DummyMethodCall;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Exception\NoValueForCurrentException;
+use Nelmio\Alice\FixtureIdInterface;
 use Nelmio\Alice\FixtureInterface;
 
 /**
@@ -23,6 +24,11 @@ use Nelmio\Alice\FixtureInterface;
  */
 class SimpleFixtureTest extends \PHPUnit_Framework_TestCase
 {
+    public function testIsAFixtureId()
+    {
+        $this->assertTrue(is_a(SimpleFixture::class, FixtureIdInterface::class, true));
+    }
+
     public function testIsAFixture()
     {
         $this->assertTrue(is_a(SimpleFixture::class, FixtureInterface::class, true));

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -820,7 +820,7 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Nelmio\Alice\Exception\ObjectNotFoundException
+     * @expectedException \Nelmio\Alice\Exception\FixtureNotFoundException
      */
     public function testLoadParsesReferencesInQuotes()
     {


### PR DESCRIPTION
As of now if a reference to an inexistent fixture in a constructor is made, as no object is found for it, the reference resolver will try to instantiate that fixture. However as it is a temporary fixture, it has no class leading to this obscure error:

`Class  does not exist in /path/to/alice/src/Generator/Instantiator/Chainable/NullConstructorInstantiator.php:36`

A solution is to check if this fixture exist when no object is found to thrown an error before trying to generate it.