### PR TITLE
Fix support for stdClass classes

### DIFF
--- a/src/Bridge/Symfony/Resources/config/generator/hydrator.xml
+++ b/src/Bridge/Symfony/Resources/config/generator/hydrator.xml
@@ -29,8 +29,6 @@
             <argument type="service" id="nelmio_alice.property_accessor" />
         </service>
 
-        <service id="nelmio_alice.property_accessor" alias="property_accessor" />
-
     </services>
 
 </container>

--- a/src/Bridge/Symfony/Resources/config/property_access.xml
+++ b/src/Bridge/Symfony/Resources/config/property_access.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ This file is part of the Alice package.
+  ~
+  ~ (c) Nelmio <hello@nelm.io>
+  ~
+  ~ For the full copyright and license information, please view the LICENSE
+  ~ file that was distributed with this source code.
+  -->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="nelmio_alice.property_accessor" alias="nelmio_alice.property_accessor.std"/>
+
+        <service id="nelmio_alice.property_accessor.std"
+                 class="Nelmio\Alice\PropertyAccess\StdPropertyAccessor">
+           <argument type="service" id="property_accessor" />
+        </service>
+
+    </services>
+
+</container>

--- a/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
+++ b/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
@@ -55,11 +55,7 @@ final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
     {
         $instance = $object->getInstance();
         try {
-            if ($instance instanceof \stdClass) {
-                $instance->{$property->getName()} = $property->getValue();
-            } else {
-                $this->propertyAccessor->setValue($instance, $property->getName(), $property->getValue());
-            }
+            $this->propertyAccessor->setValue($instance, $property->getName(), $property->getValue());
         } catch (SymfonyNoSuchPropertyException $exception) {
             throw NoSuchPropertyException::create($object, $property, 0, $exception);
         } catch (SymfonyAccessException $exception) {

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -136,6 +136,7 @@ use Nelmio\Alice\FileLoaderInterface;
 use Nelmio\Alice\NotClonableTrait;
 use Nelmio\Alice\ObjectSet;
 use Nelmio\Alice\Generator\Resolver\ParameterBagResolverInterface;
+use Nelmio\Alice\PropertyAccess\StdPropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
@@ -265,7 +266,13 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
             new PhpParser(),
         ]);
 
-        return new RuntimeCacheParser($registry, new DefaultFileLocator(), new DefaultIncludeProcessor(new DefaultFileLocator()));
+        return new RuntimeCacheParser(
+            $registry,
+            new DefaultFileLocator(),
+            new DefaultIncludeProcessor(
+                new DefaultFileLocator()
+            )
+        );
     }
 
     protected function createBuiltInDenormalizer(): DenormalizerInterface
@@ -506,7 +513,11 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
 
     protected function createPropertyAccessor(): PropertyAccessorInterface
     {
-        return PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor();
+        return new StdPropertyAccessor(
+            PropertyAccess::createPropertyAccessorBuilder()
+                ->enableMagicCall()
+                ->getPropertyAccessor()
+        );
     }
 
     protected function createBuiltInCaller(): CallerInterface

--- a/src/PropertyAccess/StdPropertyAccessor.php
+++ b/src/PropertyAccess/StdPropertyAccessor.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Nelmio\Alice\PropertyAccess;
+
+use Nelmio\Alice\NotClonableTrait;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class StdPropertyAccessor implements PropertyAccessorInterface
+{
+    use NotClonableTrait;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $decoratedPropertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $decoratedPropertyAccessor)
+    {
+        $this->decoratedPropertyAccessor = $decoratedPropertyAccessor;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setValue(&$objectOrArray, $propertyPath, $value)
+    {
+        if ($objectOrArray instanceof \stdClass) {
+            $objectOrArray->{$propertyPath} = $value;
+
+            return;
+        }
+
+        $this->decoratedPropertyAccessor->setValue($objectOrArray, $propertyPath, $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getValue($objectOrArray, $propertyPath)
+    {
+        if (false === $objectOrArray instanceof \stdClass) {
+            return $this->decoratedPropertyAccessor->getValue($objectOrArray, $propertyPath);
+        }
+
+        if (false === isset($objectOrArray->$propertyPath)) {
+            throw new NoSuchPropertyException(
+                sprintf('Cannot read property "%s" from stdClass.', $propertyPath)
+            );
+        }
+
+        return $objectOrArray->$propertyPath;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isWritable($objectOrArray, $propertyPath)
+    {
+        return ($objectOrArray instanceof \stdClass)
+            ? true
+            : $this->decoratedPropertyAccessor->isWritable($objectOrArray, $propertyPath)
+        ;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isReadable($objectOrArray, $propertyPath)
+    {
+        return ($objectOrArray instanceof \stdClass)
+            ? isset($objectOrArray->$propertyPath)
+            : $this->decoratedPropertyAccessor->isReadable($objectOrArray, $propertyPath)
+        ;
+    }
+}

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -172,20 +172,6 @@ class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testCanHydrateStdClassObjects()
-    {
-        $object = new SimpleObject('dummy', new \stdClass());
-        $property = new Property('foo', 'bar');
-
-        $std = new \stdClass();
-        $std->foo = 'bar';
-        $expected = new SimpleObject('dummy', $std);
-
-        $actual = $this->hydrator->hydrate($object, $property, new GenerationContext());
-
-        $this->assertEquals($expected, $actual);
-    }
-
     /**
      * @dataProvider provideProperties
      */

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -2290,5 +2290,29 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
             null,
         ];
+
+        yield 'has proper stdClass support' => [
+            [
+                \stdClass::class => [
+                    'dummy' => [
+                        'foo' => 'bar',
+                    ],
+                    'another_dummy' => [
+                        'foo' => '@dummy->foo'
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => StdClassFactory::create([
+                        'foo' => 'bar',
+                    ]),
+                    'another_dummy' => StdClassFactory::create([
+                        'foo' => 'bar',
+                    ]),
+                ],
+            ],
+        ];
     }
 }

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\PropertyAccess;
+
+use Nelmio\Alice\Entity\DummyWithPublicProperty;
+use Nelmio\Alice\Entity\StdClassFactory;
+use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
+use Prophecy\Argument;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * @covers \Nelmio\Alice\PropertyAccess\StdPropertyAccessor
+ */
+class StdPropertyAccessorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAPropertyAccessor()
+    {
+        $this->assertTrue(is_a(StdPropertyAccessor::class, PropertyAccessorInterface::class, true));
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testIsNotClonable()
+    {
+        clone new StdPropertyAccessor(new FakePropertyAccessor());
+    }
+
+    public function testSetValueOfAStdClass()
+    {
+        $object = new \stdClass();
+        $property = 'foo';
+        $value = 'bar';
+
+        $expected = StdClassFactory::create(['foo' => 'bar']);
+
+        $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+        $accessor->setValue($object, $property, $value);
+
+        $this->assertEquals($expected, $object);
+    }
+
+    public function testSetValueWithTheDecoratedAccessorWhenTheObjectIsNotAnInstanceOfStdClass()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+        $value = 'bar';
+
+        $expected = new DummyWithPublicProperty();
+        $expected->val = 'bar';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->setValue($object, $property, $value)
+            ->will(
+                function ($args) {
+                    $args[0]->{$args[1]} = $args[2];
+                }
+            )
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new StdPropertyAccessor($decoratedAccessor);
+        $accessor->setValue($object, $property, $value);
+
+        $this->assertEquals($expected, $object);
+
+        $decoratedAccessorProphecy->setValue(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testGetValueOfAStdClass()
+    {
+        $object = StdClassFactory::create([$property = 'foo' => $expected = 'bar']);
+
+        $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+        $actual = $accessor->getValue($object, $property);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessage Cannot read property "foo" from stdClass.
+     */
+    public function testThrowsAnExceptionIfPropertyNotFoundOnStdClass()
+    {
+        $object = new \stdClass();
+
+        $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+        $accessor->getValue($object, 'foo');
+    }
+
+    public function testGetValueWithTheDecoratedAccessorWhenTheObjectIsNotAnInstanceOfStdClass()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+        $object->$property = $expected = 'bar';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->getValue($object, $property)
+            ->will(
+                function ($args) {
+                    return $args[0]->{$args[1]};
+                }
+            )
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new StdPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->getValue($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->getValue(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testStdClassPropertiesAreAlwaysWriteable()
+    {
+        $object = new \stdClass();
+        $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+
+        $this->assertTrue($accessor->isWritable($object, 'foo'));
+    }
+
+    public function testUsesDecoratedAccessorToDertermineIfPropertyIsWritableIfObjectIsNotAnStdClassInstance()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isWritable($object, $property)
+            ->willReturn($expected = true)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new StdPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->isWritable($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->isWritable(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testStdClassPropertiesAreReadableOnlyIfTheyExists()
+    {
+        $object = StdClassFactory::create(['foo' => 'bar']);
+        $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+
+        $this->assertTrue($accessor->isReadable($object, 'foo'));
+        $this->assertFalse($accessor->isReadable($object, 'foz'));
+    }
+
+    public function testUsesDecoratedAccessorToDertermineIfPropertyIsReadbleIfObjectIsNotAnStdClassInstance()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isReadable($object, $property)
+            ->willReturn($expected = true)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new StdPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->isReadable($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->isReadable(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+}


### PR DESCRIPTION
Accessing a value from an stdClass instance with the Symfony property accessor will fail as the class has no public properties neither getters. Besides fixing that, the code has been refactored a bit to introduce a new property accessor properly supporting stdClass instances.