### PR TITLE
Fix complete generation process

### DIFF
--- a/fixtures/Definition/Object/ImmutableByCloneObject.php
+++ b/fixtures/Definition/Object/ImmutableByCloneObject.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Nelmio\Alice\Definition\Object;
+
+use Nelmio\Alice\ObjectInterface;
+
+class ImmutableByCloneObject implements ObjectInterface
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var object
+     */
+    private $instance;
+
+    /**
+     * @param string $id
+     * @param object $instance
+     */
+    public function __construct(string $id, $instance)
+    {
+        $this->id = $id;
+        $this->instance = $instance;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInstance()
+    {
+        return $this->instance;
+    }
+
+    public function __clone()
+    {
+        $this->instance = clone $this->instance;
+    }
+}

--- a/fixtures/Definition/Object/ImmutableObject.php
+++ b/fixtures/Definition/Object/ImmutableObject.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Nelmio\Alice\Definition\Object;
+
+use Nelmio\Alice\ObjectInterface;
+
+class ImmutableObject implements ObjectInterface
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var object
+     */
+    private $instance;
+
+    /**
+     * @param string $id
+     * @param object $instance
+     */
+    public function __construct(string $id, $instance)
+    {
+        $this->id = $id;
+        $this->instance = deep_clone($instance);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInstance()
+    {
+        return deep_clone($this->instance);
+    }
+}

--- a/src/Bridge/Symfony/Resources/config/generator.xml
+++ b/src/Bridge/Symfony/Resources/config/generator.xml
@@ -23,7 +23,12 @@
         </service>
 
         <service id="nelmio_alice.generator.object_generator"
-                 alias="nelmio_alice.generator.object_generator.simple" />
+                 alias="nelmio_alice.generator.object_generator.complete" />
+
+        <service id="nelmio_alice.generator.object_generator.complete"
+                 class="Nelmio\Alice\Generator\ObjectGenerator\CompleteObjectGenerator">
+            <argument type="service" id="nelmio_alice.generator.object_generator.simple" />
+        </service>
 
         <service id="nelmio_alice.generator.object_generator.simple"
                  class="Nelmio\Alice\Generator\ObjectGenerator\SimpleObjectGenerator">

--- a/src/Definition/MethodCallBag.php
+++ b/src/Definition/MethodCallBag.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
-/**
- * TODO: review this class (i.e. immutability) after Caller is implemented
- */
 final class MethodCallBag
 {
     /**
@@ -47,5 +44,10 @@ final class MethodCallBag
         }
 
         return $clone;
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->methodCalls;
     }
 }

--- a/src/Definition/Object/CompleteObject.php
+++ b/src/Definition/Object/CompleteObject.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Definition\Object;
+
+use Nelmio\Alice\ObjectInterface;
+
+/**
+ * Representation of a fixture object for which the instance has been completed.
+ */
+final class CompleteObject implements ObjectInterface
+{
+    /**
+     * @var ObjectInterface
+     */
+    private $object;
+
+    public function __construct(ObjectInterface $object)
+    {
+        $this->object = $object;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId(): string
+    {
+        return $this->object->getId();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInstance()
+    {
+        return $this->object->getInstance();
+    }
+
+    public function __clone()
+    {
+        $this->object = clone $this->object;
+    }
+}

--- a/src/Definition/PropertyBag.php
+++ b/src/Definition/PropertyBag.php
@@ -46,6 +46,11 @@ final class PropertyBag implements \IteratorAggregate, \Countable
         return $clone;
     }
 
+    public function isEmpty(): bool
+    {
+        return [] === $this->properties;
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Generator/GenerationContext.php
+++ b/src/Generator/GenerationContext.php
@@ -28,6 +28,11 @@ final class GenerationContext
      */
     private $resolving;
 
+    /**
+     * @var bool
+     */
+    private $needsCompleteResolution = false;
+
     public function __construct()
     {
         $this->isFirstPass = true;
@@ -53,5 +58,20 @@ final class GenerationContext
     {
         $this->resolving->add($id);
         $this->resolving->checkForCircularReference($id);
+    }
+
+    public function markAsNeedsCompleteGeneration()
+    {
+        $this->needsCompleteResolution = true;
+    }
+
+    public function unmarkAsNeedsCompleteGeneration()
+    {
+        $this->needsCompleteResolution = false;
+    }
+
+    public function needsCompleteGeneration(): bool
+    {
+        return $this->needsCompleteResolution;
     }
 }

--- a/src/Generator/ObjectGenerator/CompleteObjectGenerator.php
+++ b/src/Generator/ObjectGenerator/CompleteObjectGenerator.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Generator\ObjectGenerator;
+
+use Nelmio\Alice\Definition\Object\CompleteObject;
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\GenerationContext;
+use Nelmio\Alice\Generator\ObjectGeneratorInterface;
+use Nelmio\Alice\Generator\ResolvedFixtureSet;
+use Nelmio\Alice\NotClonableTrait;
+use Nelmio\Alice\ObjectBag;
+use Nelmio\Alice\ObjectInterface;
+
+final class CompleteObjectGenerator implements ObjectGeneratorInterface
+{
+    use NotClonableTrait;
+    
+    /**
+     * @var ObjectGeneratorInterface
+     */
+    private $objectGenerator;
+
+    public function __construct(ObjectGeneratorInterface $objectGenerator)
+    {
+        $this->objectGenerator = $objectGenerator;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function generate(
+        FixtureInterface $fixture,
+        ResolvedFixtureSet $fixtureSet,
+        GenerationContext $context
+    ): ObjectBag
+    {
+        if ($fixtureSet->getObjects()->has($fixture)
+            && $fixtureSet->getObjects()->get($fixture) instanceof CompleteObject
+        ) {
+            return $fixtureSet->getObjects();
+        }
+
+        $objects = $this->objectGenerator->generate($fixture, $fixtureSet, $context);
+        $generatedObject = $objects->get($fixture);
+
+        if (false === $this->isObjectComplete($fixture, $generatedObject, $context)) {
+            return $objects;
+        }
+
+        return $objects->with(new CompleteObject($generatedObject));
+    }
+
+    private function isObjectComplete(FixtureInterface $fixture, ObjectInterface $object, GenerationContext $context): bool
+    {
+        return (
+            $object instanceof CompleteObject
+            || $context->needsCompleteGeneration()
+            || false === $context->isFirstPass()
+            || (
+                false === $context->needsCompleteGeneration()
+                && $fixture->getSpecs()->getProperties()->isEmpty()
+                && $fixture->getSpecs()->getMethodCalls()->isEmpty()
+            )
+        );
+    }
+}

--- a/src/Generator/ObjectGenerator/SimpleObjectGenerator.php
+++ b/src/Generator/ObjectGenerator/SimpleObjectGenerator.php
@@ -82,7 +82,10 @@ final class SimpleObjectGenerator implements ObjectGeneratorInterface
     ): ObjectBag
     {
         if ($context->isFirstPass()) {
-            return $this->instantiator->instantiate($fixture, $fixtureSet, $context)->getObjects();
+            $fixtureSet = $this->instantiator->instantiate($fixture, $fixtureSet, $context)->getObjects();
+            if (false === $context->needsCompleteGeneration()) {
+                return $fixtureSet;
+            }
         }
         $fixtureSet = $this->completeObject($fixture, $fixtureSet, $context);
 

--- a/src/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolver.php
@@ -85,7 +85,10 @@ final class FixturePropertyReferenceResolver implements ChainableValueResolverIn
             throw ResolverNotFoundException::createUnexpectedCall(__METHOD__);
         }
 
+        $context->markAsNeedsCompleteGeneration();
         $fixtureReferenceResult = $this->resolver->resolve($value->getReference(), $fixture, $fixtureSet, $scope, $context);
+        $context->unmarkAsNeedsCompleteGeneration();
+
         /** @var ResolvedFixtureSet $fixtureSet */
         list($instance, $fixtureSet) = [$fixtureReferenceResult->getValue(), $fixtureReferenceResult->getSet()];
 

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -90,6 +90,7 @@ use Nelmio\Alice\Generator\Instantiator\ExistingInstanceInstantiator;
 use Nelmio\Alice\Generator\Instantiator\InstantiatorRegistry;
 use Nelmio\Alice\Generator\Instantiator\InstantiatorResolver;
 use Nelmio\Alice\Generator\InstantiatorInterface;
+use Nelmio\Alice\Generator\ObjectGenerator\CompleteObjectGenerator;
 use Nelmio\Alice\Generator\ObjectGenerator\SimpleObjectGenerator;
 use Nelmio\Alice\Generator\Hydrator\SimpleHydrator;
 use Nelmio\Alice\Generator\HydratorInterface;
@@ -417,11 +418,13 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
 
     protected function createBuiltInObjectGenerator(): ObjectGeneratorInterface
     {
-        return new SimpleObjectGenerator(
-            $this->getBuiltInValueResolver(),
-            $this->getBuiltInInstantiator(),
-            $this->getBuiltInHydrator(),
-            $this->getBuiltInCaller()
+        return new CompleteObjectGenerator(
+            new SimpleObjectGenerator(
+                $this->getBuiltInValueResolver(),
+                $this->getBuiltInInstantiator(),
+                $this->getBuiltInHydrator(),
+                $this->getBuiltInCaller()
+            )
         );
     }
 

--- a/src/ObjectBag.php
+++ b/src/ObjectBag.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use Nelmio\Alice\Definition\Object\CompleteObject;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Exception\ObjectNotFoundException;
 
@@ -44,7 +45,9 @@ final class ObjectBag implements \IteratorAggregate, \Countable
                 continue;
             }
 
-            $this->objects[$id] = new SimpleObject($id, $object);
+            $this->objects[$id] = new CompleteObject(
+                new SimpleObject($id, $object)
+            );
         }
     }
 

--- a/tests/Definition/MethodCallBagTest.php
+++ b/tests/Definition/MethodCallBagTest.php
@@ -35,12 +35,7 @@ class MethodCallBagTest extends \PHPUnit_Framework_TestCase
         $this->propRefl = $propRefl;
     }
 
-    public function testIsImmutable()
-    {
-        //TODO
-    }
-
-    public function testMutatorsAreImmutable()
+    public function testAddingACallCreatesANewBagWithTheAddedInstance()
     {
         $methodCall1 = new DummyMethodCall('mc1');
         $methodCall2 = new DummyMethodCall('mc2');
@@ -143,5 +138,14 @@ class MethodCallBagTest extends \PHPUnit_Framework_TestCase
             ],
             $this->propRefl->getValue($bag)
         );
+    }
+
+    public function testIsEmpty()
+    {
+        $bag = new MethodCallBag();
+        $this->assertTrue($bag->isEmpty());
+
+        $bag = $bag->with(new FakeMethodCall());
+        $this->assertFalse($bag->isEmpty());
     }
 }

--- a/tests/Definition/Object/CompleteObjectTest.php
+++ b/tests/Definition/Object/CompleteObjectTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\Definition\Object;
+
+use Nelmio\Alice\Entity\StdClassFactory;
+use Nelmio\Alice\ObjectInterface;
+
+/**
+ * @covers \Nelmio\Alice\Definition\Object\CompleteObject
+ */
+class CompleteObjectTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAnObject()
+    {
+        $this->assertTrue(is_a(CompleteObject::class, ObjectInterface::class, true));
+    }
+
+    public function testDecoratesAnObject()
+    {
+        $decoratedObjectProphecy = $this->prophesize(ObjectInterface::class);
+        $decoratedObjectProphecy->getId()->willReturn('dummy');
+        $decoratedObjectProphecy->getInstance()->willReturn(new \stdClass());
+        /** @var ObjectInterface $decoratedObject */
+        $decoratedObject = $decoratedObjectProphecy->reveal();
+
+        $object = new CompleteObject($decoratedObject);
+
+        $this->assertEquals('dummy', $object->getId());
+        $decoratedObjectProphecy->getId()->shouldHaveBeenCalledTimes(1);
+        $decoratedObjectProphecy->getInstance()->shouldHaveBeenCalledTimes(0);
+
+        $this->assertEquals(new \stdClass(), $object->getInstance());
+        $decoratedObjectProphecy->getId()->shouldHaveBeenCalledTimes(1);
+        $decoratedObjectProphecy->getInstance()->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testDelegatesImmutabilityToTheDecoratedObject()
+    {
+        // Case where the decorated object is mutable
+        $decoratedObject = new SimpleObject('dummy', $instance = new \stdClass());
+
+        $object = new CompleteObject($decoratedObject);
+        $instance->foo = 'bar';
+        $object->getInstance()->foz = 'baz';
+
+        $clone = clone $object;
+        $instance->fao = 'bor';
+        $clone->getInstance()->faz = 'boz';
+
+        $this->assertEquals(
+            StdClassFactory::create([
+                'foo' => 'bar',
+                'foz' => 'baz',
+                'fao' => 'bor',
+                'faz' => 'boz',
+            ]),
+            $object->getInstance()
+        );
+        $this->assertEquals(
+            $object->getInstance(),
+            $clone->getInstance()
+        );
+
+
+        // Case where the decorated object is partially immutable: cloning does create a new instance
+        $decoratedObject = new ImmutableByCloneObject('dummy', $instance = new \stdClass());
+
+        $object = new CompleteObject($decoratedObject);
+        $instance->foo = 'bar';
+        $object->getInstance()->foz = 'baz';
+
+        $clone = clone $object;
+        $instance->fao = 'bor';
+        $clone->getInstance()->faz = 'boz';
+
+        $this->assertEquals(
+            StdClassFactory::create([
+                'foo' => 'bar',
+                'foz' => 'baz',
+                'fao' => 'bor',
+            ]),
+            $object->getInstance()
+        );
+        $this->assertEquals(
+            StdClassFactory::create([
+                'foo' => 'bar',
+                'foz' => 'baz',
+                'faz' => 'boz',
+            ]),
+            $clone->getInstance()
+        );
+
+
+        // Case where the decorated object is truly immutable
+        $decoratedObject = new ImmutableObject('dummy', $instance = new \stdClass());
+
+        $object = new CompleteObject($decoratedObject);
+        $instance->foo = 'bar';
+        $object->getInstance()->foz = 'baz';
+
+        $clone = clone $object;
+        $instance->fao = 'bor';
+        $clone->getInstance()->faz = 'boz';
+
+        $this->assertEquals(new \stdClass(), $object->getInstance());
+        $this->assertEquals(new \stdClass(), $clone->getInstance());
+    }
+}

--- a/tests/Definition/PropertyBagTest.php
+++ b/tests/Definition/PropertyBagTest.php
@@ -129,4 +129,13 @@ class PropertyBagTest extends \PHPUnit_Framework_TestCase
         $bag = $bag->with(new Property('ping', 'pong'));
         $this->assertEquals(2, count($bag));
     }
+
+    public function testIsEmpty()
+    {
+        $bag = new PropertyBag();
+        $this->assertTrue($bag->isEmpty());
+
+        $bag = $bag->with(new Property('foo', null));
+        $this->assertFalse($bag->isEmpty());
+    }
 }

--- a/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Generator\ObjectGenerator;
+
+use Nelmio\Alice\Definition\Fixture\DummyFixture;
+use Nelmio\Alice\Definition\Fixture\SimpleFixture;
+use Nelmio\Alice\Definition\Object\CompleteObject;
+use Nelmio\Alice\Definition\Object\SimpleObject;
+use Nelmio\Alice\Definition\Property;
+use Nelmio\Alice\Definition\PropertyBag;
+use Nelmio\Alice\Definition\SpecificationBagFactory;
+use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Generator\FakeObjectGenerator;
+use Nelmio\Alice\Generator\GenerationContext;
+use Nelmio\Alice\Generator\ObjectGeneratorInterface;
+use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
+use Nelmio\Alice\ObjectBag;
+use Prophecy\Argument;
+
+/**
+ * @covers \Nelmio\Alice\Generator\ObjectGenerator\CompleteObjectGenerator
+ */
+class CompleteObjectGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAnObjectGenerator()
+    {
+        $this->assertTrue(is_a(CompleteObjectGenerator::class, ObjectGeneratorInterface::class, true));
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testIsNotClonable()
+    {
+        clone new CompleteObjectGenerator(new FakeObjectGenerator());
+    }
+
+    public function testReturnsFixtureSetObjectsIfObjectIsAlreadyCompletelyGenerated()
+    {
+        $fixture = new DummyFixture('dummy');
+        $set = ResolvedFixtureSetFactory::create(
+            null,
+            (new FixtureBag())->with($fixture),
+            $expected = new ObjectBag(['dummy' => new \stdClass()])
+        );
+        $context = new GenerationContext();
+
+        $generator = new CompleteObjectGenerator(new FakeObjectGenerator());
+        $actual = $generator->generate($fixture, $set, $context);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUsesDecoratedGeneratorToGenerateTheObjectAndReturnsTheResultIfDoesNotRequireACompleteObject()
+    {
+        $fixture = new SimpleFixture(
+            'dummy',
+            'Dummy',
+            SpecificationBagFactory::create(
+                null,
+                (new PropertyBag())->with(new Property('foo', 'bar'))
+            )
+        );
+        $set = ResolvedFixtureSetFactory::create(
+            null,
+            (new FixtureBag())->with($fixture)
+        );
+        $context = new GenerationContext();
+
+        $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+        $decoratedGeneratorProphecy
+            ->generate($fixture, $set, $context)
+            ->willReturn(
+                $expected = (new ObjectBag())->with(new SimpleObject('dummy', new \stdClass()))
+            )
+        ;
+        /** @var ObjectGeneratorInterface $decoratedGenerator */
+        $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+        $generator = new CompleteObjectGenerator($decoratedGenerator);
+        $actual = $generator->generate($fixture, $set, $context);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedGeneratorProphecy->generate(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    /**
+     * @dataProvider provideSets
+     */
+    public function testReturnsCompleteObjectWheneverItIsPossible(
+        FixtureInterface $fixture,
+        GenerationContext $context,
+        ObjectGeneratorInterface $decoratedGenerator,
+        ObjectBag $expected
+    ) {
+        $set = ResolvedFixtureSetFactory::create(
+            null,
+            (new FixtureBag())->with($fixture)
+        );
+
+        $generator = new CompleteObjectGenerator($decoratedGenerator);
+        $actual = $generator->generate($fixture, $set, $context);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function provideSets()
+    {
+        yield 'decorated generator generates a complete object => complete object' =>
+            (function () {
+                $fixture = new SimpleFixture(
+                    'dummy',
+                    'Dummy',
+                    SpecificationBagFactory::create(
+                        null,
+                        (new PropertyBag())->with(new Property('foo', 'bar'))
+                    )
+                );
+
+                $context = new GenerationContext();
+
+                $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+                $decoratedGeneratorProphecy
+                    ->generate(Argument::cetera())
+                    ->willReturn(
+                        (new ObjectBag())->with(
+                            new CompleteObject(
+                                new SimpleObject('dummy', new \stdClass())
+                            )
+                        )
+                    )
+                ;
+                /** @var ObjectGeneratorInterface $decoratedGenerator */
+                $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+                $expected = (new ObjectBag())->with(
+                    new CompleteObject(
+                        new CompleteObject(
+                            new SimpleObject('dummy', new \stdClass())
+                        )
+                    )
+                );
+
+                return [
+                    $fixture,
+                    $context,
+                    $decoratedGenerator,
+                    $expected,
+                ];
+            })()
+        ;
+
+        yield 'object has been generated during the second pass => complete object' =>
+            (function () {
+                $fixture = new SimpleFixture(
+                    'dummy',
+                    'Dummy',
+                    SpecificationBagFactory::create(
+                        null,
+                        (new PropertyBag())->with(new Property('foo', 'bar'))
+                    )
+                );
+
+                $context = new GenerationContext();
+                $context->setToSecondPass();
+
+                $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+                $decoratedGeneratorProphecy
+                    ->generate(Argument::cetera())
+                    ->willReturn(
+                        (new ObjectBag())->with(
+                            new SimpleObject('dummy', new \stdClass())
+                        )
+                    )
+                ;
+                /** @var ObjectGeneratorInterface $decoratedGenerator */
+                $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+                $expected = (new ObjectBag())->with(
+                    new CompleteObject(
+                        new SimpleObject('dummy', new \stdClass())
+                    )
+                );
+
+                return [
+                    $fixture,
+                    $context,
+                    $decoratedGenerator,
+                    $expected,
+                ];
+            })()
+        ;
+
+        yield 'object was generated with "complete object" generation context => complete object' =>
+            (function () {
+                $fixture = new SimpleFixture(
+                    'dummy',
+                    'Dummy',
+                    SpecificationBagFactory::create(
+                        null,
+                        (new PropertyBag())->with(new Property('foo', 'bar'))
+                    )
+                );
+
+                $context = new GenerationContext();
+                $context->markAsNeedsCompleteGeneration();
+
+                $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+                $decoratedGeneratorProphecy
+                    ->generate(Argument::cetera())
+                    ->willReturn(
+                        (new ObjectBag())->with(
+                            new SimpleObject('dummy', new \stdClass())
+                        )
+                    )
+                ;
+                /** @var ObjectGeneratorInterface $decoratedGenerator */
+                $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+                $expected = (new ObjectBag())->with(
+                    new CompleteObject(
+                        new SimpleObject('dummy', new \stdClass())
+                    )
+                );
+
+                return [
+                    $fixture,
+                    $context,
+                    $decoratedGenerator,
+                    $expected,
+                ];
+            })()
+        ;
+
+        yield 'object generated needed only instantiation => complete object' =>
+            (function () {
+                $fixture = new SimpleFixture(
+                    'dummy',
+                    'Dummy',
+                    SpecificationBagFactory::create()
+                );
+
+                $context = new GenerationContext();
+
+                $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+                $decoratedGeneratorProphecy
+                    ->generate(Argument::cetera())
+                    ->willReturn(
+                        (new ObjectBag())->with(
+                            new SimpleObject('dummy', new \stdClass())
+                        )
+                    )
+                ;
+                /** @var ObjectGeneratorInterface $decoratedGenerator */
+                $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+                $expected = (new ObjectBag())->with(
+                    new CompleteObject(
+                        new SimpleObject('dummy', new \stdClass())
+                    )
+                );
+
+                return [
+                    $fixture,
+                    $context,
+                    $decoratedGenerator,
+                    $expected,
+                ];
+            })()
+        ;
+
+        yield 'object generated during first pass => unchanged' =>
+            (function () {
+                $fixture = new SimpleFixture(
+                    'dummy',
+                    'Dummy',
+                    SpecificationBagFactory::create(
+                        null,
+                        (new PropertyBag())->with(new Property('foo', 'bar'))
+                    )
+                );
+
+                $context = new GenerationContext();
+
+                $decoratedGeneratorProphecy = $this->prophesize(ObjectGeneratorInterface::class);
+                $decoratedGeneratorProphecy
+                    ->generate(Argument::cetera())
+                    ->willReturn(
+                        $expected = (new ObjectBag())->with(
+                            new SimpleObject('dummy', new \stdClass())
+                        )
+                    )
+                ;
+                /** @var ObjectGeneratorInterface $decoratedGenerator */
+                $decoratedGenerator = $decoratedGeneratorProphecy->reveal();
+
+                return [
+                    $fixture,
+                    $context,
+                    $decoratedGenerator,
+                    $expected,
+                ];
+            })()
+        ;
+    }
+}

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -92,9 +92,13 @@ class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
         $context = new GenerationContext();
         $context->markIsResolvingFixture('foo');
 
+        $valueResolverContext = new GenerationContext();
+        $valueResolverContext->markIsResolvingFixture('foo');
+        $valueResolverContext->markAsNeedsCompleteGeneration();
+
         $valueResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $valueResolverProphecy
-            ->resolve($reference, $fixture, $set, $scope, $context)
+            ->resolve($reference, $fixture, $set, $scope, $valueResolverContext)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
                     $instance = new \stdClass(),

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1376,7 +1376,31 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        yield 'reference value with function' => [
+        yield 'inverted reference value' => [
+            [
+                \stdClass::class => [
+                    'another_dummy' => [
+                        'dummy' => '@dummy',
+                    ],
+                    'dummy' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => $dummy = StdClassFactory::create([
+                        'foo' => 'bar',
+                    ]),
+                    'another_dummy' => StdClassFactory::create([
+                        'dummy' => $dummy,
+                    ]),
+                ],
+            ],
+        ];
+
+        yield 'dynamic reference' => [
             [
                 \stdClass::class => [
                     'dummy{1..2}' => [
@@ -1406,25 +1430,31 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        yield 'inverted reference value' => [
+        yield 'inverted dynamic reference' => [
             [
                 \stdClass::class => [
-                    'another_dummy' => [
-                        'dummy' => '@dummy',
+                    'dummy{1..2}' => [
+                        'relatedDummy' => '@another_dummy<current()>',
                     ],
-                    'dummy' => [
-                        'foo' => 'bar',
+                    'another_dummy{1..2}' => [
+                        'name' => '<current()>',
                     ],
                 ],
             ],
             [
                 'parameters' => [],
                 'objects' => [
-                    'dummy' => $dummy = StdClassFactory::create([
-                        'foo' => 'bar',
+                    'another_dummy1' => $anotherDummy1 = StdClassFactory::create([
+                        'name' => '1',
                     ]),
-                    'another_dummy' => StdClassFactory::create([
-                        'dummy' => $dummy,
+                    'another_dummy2' => $anotherDummy2 = StdClassFactory::create([
+                        'name' => '2',
+                    ]),
+                    'dummy1' => StdClassFactory::create([
+                        'relatedDummy' => $anotherDummy1,
+                    ]),
+                    'dummy2' => StdClassFactory::create([
+                        'relatedDummy' => $anotherDummy2,
                     ]),
                 ],
             ],
@@ -1449,6 +1479,30 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                     ]),
                     'another_dummy' => StdClassFactory::create([
                         'foo' => 'bar',
+                    ]),
+                ],
+            ],
+        ];
+
+        yield 'inverted property reference value' => [
+            [
+                \stdClass::class => [
+                    'dummy' => [
+                        'name' => '@another_dummy->name',
+                    ],
+                    'another_dummy' => [
+                        'name' => 'foo',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => StdClassFactory::create([
+                        'name' => 'foo',
+                    ]),
+                    'another_dummy' => StdClassFactory::create([
+                        'name' => 'foo',
                     ]),
                 ],
             ],
@@ -1484,6 +1538,26 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 'objects' => [
                     'dummy' => $dummy = (new DummyWithGetter())->setName('foo'),
                     'another_dummy' => (new DummyWithGetter())->setName('__get__foo'),
+                ],
+            ]
+        ];
+
+        yield 'inverted property reference value with a getter' => [
+            [
+                DummyWithGetter::class => [
+                    'dummy' => [
+                        'name' => '@another_dummy->name',
+                    ],
+                    'another_dummy' => [
+                        'name' => 'foo',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => $dummy = (new DummyWithGetter())->setName('__get__foo'),
+                    'another_dummy' => (new DummyWithGetter())->setName('foo'),
                 ],
             ]
         ];

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use Nelmio\Alice\Definition\Object\CompleteObject;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 
 /**
@@ -43,8 +44,8 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSameObjects(
             [
-                'user1' => new SimpleObject('user1', $u1),
-                'user2' => new SimpleObject('user2', $u2),
+                'user1' => new CompleteObject(new SimpleObject('user1', $u1)),
+                'user2' => new CompleteObject(new SimpleObject('user2', $u2)),
             ],
             $bag
         );
@@ -58,14 +59,14 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $u2->name = 'alice';
 
         $bag = new ObjectBag([
-            'user1' => new SimpleObject('user1', $u1),
-            'user2' => new SimpleObject('user2', $u2),
+            'user1' => new CompleteObject(new SimpleObject('user1', $u1)),
+            'user2' => new CompleteObject(new SimpleObject('user2', $u2)),
         ]);
 
         $this->assertSameObjects(
             [
-                'user1' => new SimpleObject('user1', $u1),
-                'user2' => new SimpleObject('user2', $u2),
+                'user1' => new CompleteObject(new SimpleObject('user1', $u1)),
+                'user2' => new CompleteObject(new SimpleObject('user2', $u2)),
             ],
             $bag
         );
@@ -78,7 +79,7 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
     public function testThrowsAnExceptionIfAReferenceMismatchIsFound()
     {
         new ObjectBag([
-            'foo' => new SimpleObject('bar', new \stdClass()),
+            'foo' => new CompleteObject(new SimpleObject('bar', new \stdClass())),
         ]);
     }
 
@@ -104,13 +105,13 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($bag->has($user1Fixture));
         $this->assertEquals(
-            new SimpleObject('user1', new \stdClass()),
+            new CompleteObject(new SimpleObject('user1', new \stdClass())),
             $bag->get($user1Fixture)
         );
 
         $this->assertTrue($bag->has($group1Fixture));
         $this->assertEquals(
-            new SimpleObject('group1', new \stdClass()),
+            new CompleteObject(new SimpleObject('group1', new \stdClass())),
             $bag->get($group1Fixture)
         );
 
@@ -132,7 +133,7 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $bag = new ObjectBag(['foo' => new \stdClass()]);
         $std = new \stdClass();
         $std->ping = 'pong';
-        $newBag = $bag->with(new SimpleObject('bar', $std));
+        $newBag = $bag->with(new CompleteObject(new SimpleObject('bar', $std)));
 
         $this->assertEquals(
             new ObjectBag(['foo' => new \stdClass()]),
@@ -141,7 +142,7 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             new ObjectBag([
                 'foo' => new \stdClass(),
-                'bar' => new SimpleObject('bar', $std),
+                'bar' => new CompleteObject(new SimpleObject('bar', $std)),
             ]),
             $newBag
         );
@@ -160,10 +161,10 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
         $std4 = new Dummy();
 
-        $object1 = new SimpleObject('foo', $std1);
-        $object2 = new SimpleObject('bar', $std2);
-        $object3 = new SimpleObject('bar', $std3);
-        $object4 = new SimpleObject('baz', $std4);
+        $object1 = new CompleteObject(new SimpleObject('foo', $std1));
+        $object2 = new CompleteObject(new SimpleObject('bar', $std2));
+        $object3 = new CompleteObject(new SimpleObject('bar', $std3));
+        $object4 = new CompleteObject(new SimpleObject('baz', $std4));
 
         $bag1 = (new ObjectBag())->with($object1)->with($object2);
         $bag2 = (new ObjectBag())->with($object3)->with($object4);
@@ -196,8 +197,8 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
     public function testIsTraversable()
     {
-        $object1 = new SimpleObject('foo', new \stdClass());
-        $object2 = new SimpleObject('bar', new \stdClass());
+        $object1 = new CompleteObject(new SimpleObject('foo', new \stdClass()));
+        $object2 = new CompleteObject(new SimpleObject('bar', new \stdClass()));
         $bag = (new ObjectBag())->with($object1)->with($object2);
 
         $traversed = [];
@@ -216,8 +217,8 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
 
     public function testToArray()
     {
-        $object1 = new SimpleObject('foo', new \stdClass());
-        $object2 = new SimpleObject('bar', new \stdClass());
+        $object1 = new CompleteObject(new SimpleObject('foo', new \stdClass()));
+        $object2 = new CompleteObject(new SimpleObject('bar', new \stdClass()));
         $bag = (new ObjectBag())->with($object1)->with($object2);
 
         $this->assertEquals(
@@ -243,13 +244,13 @@ class ObjectBagTest extends \PHPUnit_Framework_TestCase
         ]);
         $this->assertEquals(2, $bag->count());
 
-        $object1 = new SimpleObject('foo', new \stdClass());
-        $object2 = new SimpleObject('bar', new \stdClass());
+        $object1 = new CompleteObject(new SimpleObject('foo', new \stdClass()));
+        $object2 = new CompleteObject(new SimpleObject('bar', new \stdClass()));
         $bag = (new ObjectBag())->with($object1)->with($object2);
         $this->assertEquals(2, $bag->count());
 
-        $object3 = new SimpleObject('foz', new \stdClass());
-        $object4 = new SimpleObject('baz', new \stdClass());
+        $object3 = new CompleteObject(new SimpleObject('foz', new \stdClass()));
+        $object4 = new CompleteObject(new SimpleObject('baz', new \stdClass()));
         $anotherBag = (new ObjectBag())->with($object3)->with($object4);
         $bag = $bag->mergeWith($anotherBag);
         $this->assertEquals(4, $bag->count());


### PR DESCRIPTION
Fix of  a major bug putted in light by the new tests in `LoaderIntegrationTest`: referencing to a property or a call on a fixture that is not fully generated yet.

Solving this problem slightly complexify the generation of the objects and brings the notion of 1. requiring to fully generate an object in one go and 2. introduce the notion of "complete object". This complexification is entirely justified in the sense that it is necessary to fulfil the promised made in #257 which is that the fixture order will have no importance in 3.x.