### PR TITLE
Add support for named parameters in constructor and functions

### DIFF
--- a/fixtures/Entity/Instantiator/AmbiguousDummyWithConstructorWithArrayParameter.php
+++ b/fixtures/Entity/Instantiator/AmbiguousDummyWithConstructorWithArrayParameter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity\Instantiator;
+
+class AmbiguousDummyWithConstructorWithArrayParameter
+{
+    /**
+     * @var bool
+     */
+    private $constructor = false;
+
+    /**
+     * @var array
+     */
+    private $value;
+
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+        $this->constructor = true;
+    }
+
+    // Static constructor which has the same name as the constructor parameter
+    public static function value(array $value): self
+    {
+        $instance = new static($value);
+        $instance->constructor = false;
+
+        return $instance;
+    }
+}

--- a/fixtures/Entity/Instantiator/DummyWithConstructor.php
+++ b/fixtures/Entity/Instantiator/DummyWithConstructor.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity\Instantiator;
+
+class DummyWithConstructor
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    private $age;
+
+    /**
+     * @var bool
+     */
+    private $isAdult;
+
+    /**
+     * @var bool
+     */
+    private $constructor = false;
+
+    public function __construct(string $name, int $age = 10, bool $isAdult)
+    {
+        $this->name = $name;
+        $this->age = $age;
+        $this->isAdult = $isAdult;
+        $this->constructor = true;
+    }
+
+    public static function create(string $name, int $age = 10, bool $isAdult): self
+    {
+        $instance = new static($name, $age, $isAdult);
+        $instance->constructor = false;
+
+        return $instance;
+    }
+}

--- a/fixtures/Entity/Instantiator/DummyWithConstructorWithArrayParameter.php
+++ b/fixtures/Entity/Instantiator/DummyWithConstructorWithArrayParameter.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity\Instantiator;
+
+class DummyWithConstructorWithArrayParameter
+{
+    /**
+     * @var bool
+     */
+    private $constructor = false;
+
+    /**
+     * @var array
+     */
+    private $value;
+
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+        $this->constructor = true;
+    }
+
+    public static function create(array $value): self
+    {
+        $instance = new static($value);
+        $instance->constructor = false;
+
+        return $instance;
+    }
+}

--- a/src/Exception/FixtureBuilder/Denormalizer/UnsupportedScenarioException.php
+++ b/src/Exception/FixtureBuilder/Denormalizer/UnsupportedScenarioException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Exception\FixtureBuilder\Denormalizer;
+
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Throwable\DenormalizationThrowable;
+
+class UnsupportedScenarioException extends \UnexpectedValueException implements DenormalizationThrowable
+{
+    /**
+     * @return static
+     */
+    public static function createForAmbiguousConstructor(
+        FixtureInterface $fixture,
+        string $parameterOrFunction,
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
+        return new static(
+            sprintf(
+                'Could not denormalize the constructor of the fixture "%s" (%s) as it has both a constructor named'
+                .' parameter and factory method "%s" and cannot determine which one to use.',
+                $fixture->getId(),
+                $fixture->getClassName(),
+                $parameterOrFunction
+            )
+        );
+    }
+}

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/NamedArgumentsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/NamedArgumentsDenormalizer.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments;
+
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\NotClonableTrait;
+
+final class NamedArgumentsDenormalizer implements ArgumentsDenormalizerInterface
+{
+    use NotClonableTrait;
+
+    /**
+     * @var ArgumentsDenormalizerInterface
+     */
+    private $argumentsDenormalizer;
+
+    public function __construct(ArgumentsDenormalizerInterface $argumentsDenormalizer)
+    {
+        $this->argumentsDenormalizer = $argumentsDenormalizer;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function denormalize(
+        FixtureInterface $scope,
+        FlagParserInterface $parser,
+        array $unparsedArguments
+    ): array
+    {
+        $arguments = $this->argumentsDenormalizer->denormalize($scope, $parser, $unparsedArguments);
+        if (false === $this->arrayHasOnlyNumericalKeys($arguments)) {
+            $arguments = $this->reorganizeArguments($scope, $arguments);
+        }
+        ksort($arguments);
+
+        return $arguments;
+    }
+
+    private function arrayHasOnlyNumericalKeys(array $arguments): bool
+    {
+        foreach ($arguments as $key => $argument) {
+            if (false === is_numeric($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function reorganizeArguments(FixtureInterface $fixture, array $arguments): array
+    {
+        $constructorRefl = (new \ReflectionClass($fixture->getClassName()))->getMethod('__construct');
+        $parameters = $constructorRefl->getParameters();
+
+        $orderedArguments = [];
+        foreach ($parameters as $parameter) {
+            if (array_key_exists($parameterName = $parameter->getName(), $arguments)) {
+                $orderedArguments[$parameter->getPosition()] = $arguments[$parameterName];
+                continue;
+            }
+
+            if (array_key_exists($position = $parameter->getPosition(), $arguments)) {
+                $orderedArguments[$position] = $arguments[$position];
+                continue;
+            }
+
+            if (false === $parameter->isDefaultValueAvailable()) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'The parameter "%s" for "%s" (%s) is required but no value was given.',
+                        $parameter->getName(),
+                        $fixture->getId(),
+                        $fixture->getClassName()
+                    )
+                );
+            }
+
+            $orderedArguments[$position] = $parameter->getDefaultValue();
+        }
+
+        return $orderedArguments;
+    }
+}

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments;
 
+use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ValueDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
@@ -44,8 +45,11 @@ final class SimpleArgumentsDenormalizer implements ArgumentsDenormalizerInterfac
     {
         $arguments = [];
         foreach ($unparsedArguments as $unparsedIndex => $argument) {
-            $argumentFlags = (is_string($unparsedIndex)) ? $parser->parse($unparsedIndex) : null;
-            $arguments[] = $this->valueDenormalizer->denormalize($scope, $argumentFlags, $argument);
+            $argumentFlags = (is_string($unparsedIndex))
+                ? $parser->parse($unparsedIndex)
+                : new FlagBag((string) $unparsedIndex)
+            ;
+            $arguments[$argumentFlags->getKey()] = $this->valueDenormalizer->denormalize($scope, $argumentFlags, $argument);
         }
 
         return $arguments;

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/SimpleConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/SimpleConstructorDenormalizer.php
@@ -47,19 +47,9 @@ final class SimpleConstructorDenormalizer implements ConstructorDenormalizerInte
         array $unparsedConstructor
     ): MethodCallInterface
     {
-        /** @var int|string|null $firstKey */
-        $firstKey = key($unparsedConstructor);
-        if (null === $firstKey
-            || is_int($firstKey)
-            || count($unparsedConstructor) > 1
-            || (is_string($firstKey) && preg_match('/\(.*\)/', $firstKey))
-        ) {
-            return new SimpleMethodCall(
-                '__construct',
-                $this->argumentDenormalizer->denormalize($scope, $parser, $unparsedConstructor)
-            );
-        }
-
-        throw new UnexpectedValueException('Could not denormalize the given constructor.');
+        return new SimpleMethodCall(
+            '__construct',
+            $this->argumentDenormalizer->denormalize($scope, $parser, $unparsedConstructor)
+        );
     }
 }

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -17,6 +17,7 @@ use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Faker\Provider\AliceProvider;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\NamedArgumentsDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Value\SimpleValueDenormalizer;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\EmptyValueLexer;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\FunctionLexer;
@@ -347,8 +348,10 @@ final class NativeLoader implements FileLoaderInterface, DataLoaderInterface
 
     protected function createBuiltInArgumentsDenormalizer(): ArgumentsDenormalizerInterface
     {
-        return new SimpleArgumentsDenormalizer(
-            $this->getBuiltInValueDenormalizer()
+        return new NamedArgumentsDenormalizer(
+            new SimpleArgumentsDenormalizer(
+                $this->getBuiltInValueDenormalizer()
+            )
         );
     }
 


### PR DESCRIPTION
Closes #594.

- [ ] Add tests for the support in functions
- [ ] Add tests for support with the usage of flags
- [ ] Finish the PR (add missing tests + cleanup)

@tshelburne could you please double check the integration tests (in `LoaderIntegrationTest` to see if that makes sense to your or if I'm missing something? Cheers