### PR TITLE
Mark the expression language as internal

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexer.php
@@ -18,6 +18,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class EmptyValueLexer implements LexerInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexer.php
@@ -17,6 +17,9 @@ use Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\MalformedFunctionEx
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class FunctionLexer implements LexerInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexer.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class GlobalPatternsLexer implements LexerInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
@@ -20,6 +20,8 @@ use Nelmio\Alice\NotClonableTrait;
 /**
  * Escapes references found in a string to avoid the user to have to manually escape references. For
  * example will automatically escape the @ in "email@example.com".
+ *
+ * @internal
  */
 final class ReferenceEscaperLexer implements LexerInterface
 {

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class ReferenceLexer implements LexerInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class SubPatternsLexer implements LexerInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/LexerInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/LexerInterface.php
@@ -15,6 +15,9 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
+/**
+ * @internal
+ */
 interface LexerInterface
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/ChainableTokenParserInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/ChainableTokenParserInterface.php
@@ -15,6 +15,9 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser;
 
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 
+/**
+ * @internal
+ */
 interface ChainableTokenParserInterface extends TokenParserInterface
 {
     public function canParse(Token $token): bool;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParser.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class FunctionFixtureReferenceParser implements ParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/SimpleParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/SimpleParser.php
@@ -22,6 +22,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class SimpleParser implements ParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParser.php
@@ -17,6 +17,9 @@ use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class StringMergerParser implements ParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 abstract class AbstractChainableParserAwareParser implements ChainableTokenParserInterface, ParserAwareInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
@@ -18,9 +18,12 @@ use Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class DynamicArrayTokenParser extends AbstractChainableParserAwareParser
 {
-    /** @interval */
+    /** @private */
     const REGEX = '/^(?<quantifier>\d+|<.*>)x (?<elements>.*)/';
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class EscapedValueTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParser.php
@@ -22,6 +22,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class FixtureListReferenceTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParser.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class FixtureMethodReferenceTokenParser extends AbstractChainableParserAwareParser
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParser.php
@@ -23,6 +23,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class FixtureRangeReferenceTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -21,9 +21,12 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class FunctionTokenParser extends AbstractChainableParserAwareParser
 {
-    /** @interval */
+    /** @private */
     const REGEX = '/^<(?<function>.+?)\((?<arguments>.*)\)>$/';
 
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
@@ -22,6 +22,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class IdentityTokenParser implements ChainableTokenParserInterface, ParserAwareInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class MethodReferenceTokenParser extends AbstractChainableParserAwareParser
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParser.php
@@ -18,6 +18,9 @@ use Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class OptionalTokenParser extends AbstractChainableParserAwareParser
 {
     /** @private */

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class ParameterTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParser.php
@@ -19,6 +19,9 @@ use Nelmio\Alice\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class PropertyReferenceTokenParser extends AbstractChainableParserAwareParser
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class SimpleReferenceTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
@@ -18,6 +18,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
+/**
+ * @internal
+ */
 final class StringArrayTokenParser extends AbstractChainableParserAwareParser
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParser.php
@@ -18,6 +18,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class StringTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
@@ -24,6 +24,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class TolerantFunctionTokenParser extends AbstractChainableParserAwareParser
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class VariableTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/WildcardReferenceTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/WildcardReferenceTokenParser.php
@@ -20,6 +20,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class WildcardReferenceTokenParser implements ChainableTokenParserInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistry.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistry.php
@@ -21,6 +21,9 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\NotClonableTrait;
 
+/**
+ * @internal
+ */
 final class TokenParserRegistry implements TokenParserInterface, ParserAwareInterface
 {
     use NotClonableTrait;

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParserInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParserInterface.php
@@ -19,6 +19,8 @@ use Nelmio\Alice\Throwable\ParseThrowable;
 
 /**
  * More specific version of {@see \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface}.
+ *
+ * @internal
  */
 interface TokenParserInterface
 {

--- a/src/FixtureBuilder/ExpressionLanguage/ParserAwareInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/ParserAwareInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+/**
+ * @internal
+ */
 interface ParserAwareInterface
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/ParserInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/ParserInterface.php
@@ -16,6 +16,9 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
+/**
+ * @internal
+ */
 interface ParserInterface
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/Token.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Token.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+/**
+ * @internal
+ */
 final class Token
 {
     /**

--- a/src/FixtureBuilder/ExpressionLanguage/TokenType.php
+++ b/src/FixtureBuilder/ExpressionLanguage/TokenType.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+/**
+ * @internal
+ */
 final class TokenType
 {
     const STRING_TYPE = 'STRING_TYPE';


### PR DESCRIPTION
The Expression Language is still relatively new and in-house. It may be possible that another library like https://github.com/hoaproject/Compiler may help a lot and replace a huge chunk of it. As such, I don't think I want to make this part of the library public and be potentially able to change it even after a stable release.

That said, this part of the API leaks to the [ValueResolvers](https://github.com/nelmio/alice/tree/master/src/Generator/Resolver/Value/Chainable), which makes them rather unstable. So I am not sure if this is actually doable.

@tshelburne thoughts?