### PR TITLE
$current in identity() #374 #360 #492

### DIFF
--- a/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
@@ -51,6 +51,10 @@ final class EvaluatedValueResolver implements ChainableValueResolverInterface
     ): ResolvedValueWithFixtureSet
     {
         $_scope = $scope;
+        try {
+            $_scope['current'] = $fixture->getValueForCurrent();
+        } catch (\Throwable $e) {}
+
         $expression = $this->replacePlaceholders($value->getValue());
         $evaluateExpression = function ($_expression) use ($_scope) {
             foreach ($_scope as $_scopeVariableName => $_scopeVariableValue) {


### PR DESCRIPTION
I wasn't able to use `$current` in identity() like it's described in the [docs](https://github.com/nelmio/alice/blob/master/doc/customizing-data-generation.md#identity)
```field: <($current)>```
