### PR TITLE
Make benchmark scneario easier

### DIFF
--- a/profiling/scenario0/blackfire.php
+++ b/profiling/scenario0/blackfire.php
@@ -41,40 +41,40 @@ $objects = [];
 
 for ($i = 0; $i <= 1000; $i++) {
     $objects['immutable_user_'.$i] = new ImmutableUser(
-        $faker->unique()->userName,
-        $faker->unique()->name,
-        $faker->unique()->dateTime,
-        $faker->unique()->email,
-        $faker->unique()->randomNumber
+        $faker->userName,
+        $faker->name,
+        $faker->dateTime,
+        $faker->email,
+        $faker->randomNumber
     );
 }
 for ($i = 0; $i <= 1000; $i++) {
     $user = new MutableUser();
-    $user->setUsername($faker->unique()->userName);
-    $user->setFullname($faker->unique()->name);
-    $user->setBirthDate($faker->unique()->dateTime);
-    $user->setEmail($faker->unique()->email);
-    $user->setFavoriteNumber($faker->unique()->randomNumber);
+    $user->setUsername($faker->userName);
+    $user->setFullname($faker->name);
+    $user->setBirthDate($faker->dateTime);
+    $user->setEmail($faker->email);
+    $user->setFavoriteNumber($faker->randomNumber);
 
     $objects['mutable_user_'.$i] = $user;
 }
 for ($i = 0; $i <= 1000; $i++) {
     $user = new PublicUser();
-    $user->username = $faker->unique()->userName;
-    $user->fullname = $faker->unique()->name;
-    $user->birthDate = $faker->unique()->dateTime;
-    $user->email = $faker->unique()->email;
-    $user->favoriteNumber = $faker->unique()->randomNumber;
+    $user->username = $faker->userName;
+    $user->fullname = $faker->name;
+    $user->birthDate = $faker->dateTime;
+    $user->email = $faker->email;
+    $user->favoriteNumber = $faker->randomNumber;
 
     $objects['public_user_'.$i] = $user;
 }
 for ($i = 0; $i <= 1000; $i++) {
     $user = new \stdClass();
-    $user->username = $faker->unique()->userName;
-    $user->fullname = $faker->unique()->name;
-    $user->birthDate = $faker->unique()->dateTime;
-    $user->email = $faker->unique()->email;
-    $user->favoriteNumber = $faker->unique()->randomNumber;
+    $user->username = $faker->userName;
+    $user->fullname = $faker->name;
+    $user->birthDate = $faker->dateTime;
+    $user->email = $faker->email;
+    $user->favoriteNumber = $faker->randomNumber;
 
     $objects['public_user_'.$i] = $user;
 }

--- a/profiling/scenario2/blackfire.php
+++ b/profiling/scenario2/blackfire.php
@@ -21,20 +21,20 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 require_once __DIR__.'/../../vendor-bin/profiling/vendor/autoload.php';
 
 $loader = new NativeLoader();
-$blackfire = new \Blackfire\Client();
+//$blackfire = new \Blackfire\Client();
+//
+//$config = new \Blackfire\Profile\Configuration();
+//$config->setTitle('Scenario 2');
+//$config->setSamples(10);
+//$config->setReference(2);
+//
+//$probe = $blackfire->createProbe($config, false);
 
-$config = new \Blackfire\Profile\Configuration();
-$config->setTitle('Scenario 2');
-$config->setSamples(10);
-$config->setReference(2);
-
-$probe = $blackfire->createProbe($config, false);
-
-$probe->enable();
+//$probe->enable();
 $loader->loadFile(__DIR__.'/fixtures.yml');
-$probe->disable();
-
-$blackfire->endProbe($probe);
-
-$output = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
-$output->success('Finished!');
+//$probe->disable();
+//
+//$blackfire->endProbe($probe);
+//
+//$output = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
+//$output->success('Finished!');

--- a/profiling/scenario2/fixtures.yml
+++ b/profiling/scenario2/fixtures.yml
@@ -5,32 +5,32 @@
 Nelmio\Alice\scenario2\ImmutableUser:
     immutable_user_{0..1000}:
         __construct:
-            0 (unique): <userName()>
-            1 (unique): <name()>
-            2 (unique): <dateTime()>
-            3 (unique): <email()>
-            4 (unique): <randomNumber()>
+            0: <userName()>
+            1: <name()>
+            2: <dateTime()>
+            3: <email()>
+            4: <randomNumber()>
 
 Nelmio\Alice\scenario2\MutableUser:
     mutable_user_{0..1000}:
-        username (unique): <userName()>
-        fullname (unique): <name()>
-        birthDate (unique): <dateTime()>
-        email (unique): <email()>
-        favoriteNumber (unique): <randomNumber()>
+        username: <userName()>
+        fullname: <name()>
+        birthDate: <dateTime()>
+        email: <email()>
+        favoriteNumber: <randomNumber()>
 
 Nelmio\Alice\scenario2\PublicUser:
     public_user_{0..1000}:
-        username (unique): <userName()>
-        fullname (unique): <name()>
-        birthDate (unique): <dateTime()>
-        email (unique): <email()>
-        favoriteNumber (unique): <randomNumber()>
+        username: <userName()>
+        fullname: <name()>
+        birthDate: <dateTime()>
+        email: <email()>
+        favoriteNumber: <randomNumber()>
 
 stdClass:
     std_user_{0..1000}:
-        username (unique): <userName()>
-        fullname (unique): <name()>
-        birthDate (unique): <dateTime()>
-        email (unique): <email()>
-        favoriteNumber (unique): <randomNumber()>
+        username: <userName()>
+        fullname: <name()>
+        birthDate: <dateTime()>
+        email: <email()>
+        favoriteNumber: <randomNumber()>


### PR DESCRIPTION
Removing the unique makes it easier to have comparable scenarios as the unique handling involves a part of randomness and the faker unique and alice unique are different so not completely comparable either.