### PR TITLE
Fix performance issues with Wildcard resolver

### DIFF
--- a/src/FixtureBag.php
+++ b/src/FixtureBag.php
@@ -99,6 +99,11 @@ final class FixtureBag implements \IteratorAggregate
      */
     public function getIterator()
     {
-        return new \ArrayIterator(array_values($this->fixtures));
+        return new \ArrayIterator($this->fixtures);
+    }
+
+    public function toArray(): array
+    {
+        return $this->fixtures;
     }
 }

--- a/tests/FixtureBagTest.php
+++ b/tests/FixtureBagTest.php
@@ -173,7 +173,26 @@ class FixtureBagTest extends \PHPUnit_Framework_TestCase
             $fixtures[$key] = $value;
         }
 
-        $this->assertSame($fixtures, array_values($this->propRefl->getValue($bag)));
+        $this->assertSame($fixtures, $this->propRefl->getValue($bag));
+    }
+
+    public function testToArray()
+    {
+        $fixture1 = new DummyFixture('foo');
+        $fixture2 = new DummyFixture('bar');
+
+        $bag = (new FixtureBag())
+            ->with($fixture1)
+            ->with($fixture2)
+        ;
+
+        $this->assertEquals(
+            [
+                'foo' => $fixture1,
+                'bar' => $fixture2,
+            ],
+            $bag->toArray()
+        );
     }
 
     private function assertSameFixtures(array $expected, FixtureBag $actual)


### PR DESCRIPTION
Due to an extremely inefficient algorithm, the usage of wildcard was nearly impractical (14min to generate 4K objects) versus 1min40 now. Measurements based on scenario 3.

<img width="863" alt="screen shot 2016-11-12 at 16 47 03" src="https://cloud.githubusercontent.com/assets/5175937/20239449/f6d814ac-a8f7-11e6-9685-ac44f8be5b16.png">
