### PR TITLE
Fix optional flag boundaries

### DIFF
--- a/src/Definition/Flag/OptionalFlag.php
+++ b/src/Definition/Flag/OptionalFlag.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\Alice\Definition\Flag;
 
 use Nelmio\Alice\Definition\FlagInterface;
+use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
 
 final class OptionalFlag implements FlagInterface
 {
@@ -27,14 +28,8 @@ final class OptionalFlag implements FlagInterface
      */
     public function __construct(int $percentage)
     {
-        if ($percentage < 1 || $percentage > 99) {
-            //TODO: is a valid use case...
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expected optional flag to be an integer element of ]0;100[. Got "%d" instead.',
-                    $percentage
-                )
-            );
+        if ($percentage < 0 || $percentage > 100) {
+            throw InvalidArgumentExceptionFactory::createForInvalidOptionalFlagBoundaries($percentage);
         }
 
         $this->percentage = $percentage;

--- a/src/Throwable/Exception/InvalidArgumentExceptionFactory.php
+++ b/src/Throwable/Exception/InvalidArgumentExceptionFactory.php
@@ -194,4 +194,14 @@ final class InvalidArgumentExceptionFactory
             )
         );
     }
+
+    public static function createForInvalidOptionalFlagBoundaries(int $percentage): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(
+            sprintf(
+                'Expected optional flag to be an integer element of [0;100]. Got "%d" instead.',
+                $percentage
+            )
+        );
+    }
 }

--- a/tests/Definition/Flag/OptionalFlagTest.php
+++ b/tests/Definition/Flag/OptionalFlagTest.php
@@ -56,23 +56,19 @@ class OptionalFlagTest extends \PHPUnit_Framework_TestCase
     {
         yield 'negative value' => [
             -1,
-            'Expected optional flag to be an integer element of ]0;100[. Got "-1" instead.',
-        ];
-        yield 'lower border (out)' => [
-            0,
-            'Expected optional flag to be an integer element of ]0;100[. Got "0" instead.',
+            'Expected optional flag to be an integer element of [0;100]. Got "-1" instead.',
         ];
         yield 'lower border (in)' => [
-            1,
+            0,
             null,
         ];
         yield 'upper border (in)' => [
-            99,
+            100,
             null,
         ];
         yield 'upper border (out)' => [
-            100,
-            'Expected optional flag to be an integer element of ]0;100[. Got "100" instead.',
+            101,
+            'Expected optional flag to be an integer element of [0;100]. Got "101" instead.',
         ];
     }
 }

--- a/tests/Throwable/Exception/InvalidArgumentExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/InvalidArgumentExceptionFactoryTest.php
@@ -232,4 +232,16 @@ class InvalidArgumentExceptionFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }
+
+    public function testTestCreateForInvalidOptionalFlagBoundaries()
+    {
+        $exception = InvalidArgumentExceptionFactory::createForInvalidOptionalFlagBoundaries(200);
+
+        $this->assertEquals(
+            'Expected optional flag to be an integer element of [0;100]. Got "200" instead.',
+            $exception->getMessage()
+        );
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
 }


### PR DESCRIPTION
The limits are valid values. Although it doesn't make sense to use them directly, they can be the result of an evaluated expression for which including those limits can make sense.