### PR TITLE
Lowered dynamic array quantifier minimal value

### DIFF
--- a/src/Definition/Value/DynamicArrayValue.php
+++ b/src/Definition/Value/DynamicArrayValue.php
@@ -39,9 +39,7 @@ final class DynamicArrayValue implements ValueInterface
     {
         if ($quantifier instanceof ValueInterface) {
             $quantifier = clone $quantifier;
-        } elseif (is_scalar($quantifier)) {
-            $quantifier = (int) $quantifier;
-        } else {
+        } elseif (false === is_int($quantifier)) {
             throw TypeErrorFactory::createForDynamicArrayQuantifier($quantifier);
         }
 

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParser.php
@@ -51,7 +51,7 @@ final class DynamicArrayTokenParser extends AbstractChainableParserAwareParser
         }
 
         return new DynamicArrayValue(
-            $this->parser->parse($matches['quantifier']),
+            (int) $this->parser->parse($matches['quantifier']),
             $this->parser->parse($matches['elements'])
         );
     }

--- a/src/Generator/Resolver/Value/Chainable/DynamicArrayValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/DynamicArrayValueResolver.php
@@ -86,16 +86,8 @@ final class DynamicArrayValueResolver implements ChainableValueResolverInterface
             list($quantifier, $fixtureSet) = [$result->getValue(), $result->getSet()];
         }
 
-        if ($quantifier < 2) {
-            //TODO: should be a valid case
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expected quantifier to be an integer superior or equal to 2. Got "%d" for "%s", check you dynamic'
-                    .' arrays declarations (e.g. "<numberBetween(1, 2)>x @user*").',
-                    $quantifier,
-                    $fixture->getId()
-                )
-            );
+        if ($quantifier < 0) {
+            throw InvalidArgumentExceptionFactory::createForInvalidDynamicArrayQuantifier($fixture, $quantifier);
         }
 
         $element = $value->getElement();

--- a/src/Throwable/Error/TypeErrorFactory.php
+++ b/src/Throwable/Error/TypeErrorFactory.php
@@ -36,7 +36,7 @@ final class TypeErrorFactory
     {
         return new \TypeError(
             sprintf(
-                'Expected quantifier to be either a scalar value or a "%s" object. Got "%s" instead.',
+                'Expected quantifier to be either an integer or a "%s" object. Got "%s" instead.',
                 ValueInterface::class,
                 is_object($quantifier) ? get_class($quantifier) : gettype($quantifier)
             )

--- a/src/Throwable/Exception/InvalidArgumentExceptionFactory.php
+++ b/src/Throwable/Exception/InvalidArgumentExceptionFactory.php
@@ -204,4 +204,16 @@ final class InvalidArgumentExceptionFactory
             )
         );
     }
+
+    public static function createForInvalidDynamicArrayQuantifier(FixtureInterface $fixture, int $quantifier): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(
+            sprintf(
+                'Expected quantifier to be a positive integer. Got "%d" for "%s", check you dynamic  arrays '
+                .'declarations (e.g. "<numberBetween(1, 2)>x @user*").',
+                $quantifier,
+                $fixture->getId()
+            )
+        );
+    }
 }

--- a/tests/Definition/Value/DynamicArrayValueTest.php
+++ b/tests/Definition/Value/DynamicArrayValueTest.php
@@ -86,39 +86,101 @@ class DynamicArrayValueTest extends \PHPUnit_Framework_TestCase
 
     public function provideInputTypes()
     {
-        yield 'null/string' => [
+        yield 'null/array' => [
             null,
             'dummy_element',
-            'Expected quantifier to be either a scalar value or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
             .'"NULL" instead.'
         ];
 
-        yield 'array/string' => [
+        yield 'bool/array' => [
+            true,
+            'dummy_element',
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"boolean" instead.'
+        ];
+
+        yield 'string/array' => [
+            '',
+            'dummy_element',
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"string" instead.'
+        ];
+
+        yield 'float/array' => [
+            .5,
+            'dummy_element',
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"double" instead.'
+        ];
+
+        yield 'array/array' => [
             [],
             'dummy_element',
-            'Expected quantifier to be either a scalar value or a "Nelmio\Alice\Definition\ValueInterface" object. Got'
-            .' "array" instead.'
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"array" instead.'
         ];
 
-        yield 'string/null' => [
-            'dummy_quantifier',
-            null,
-            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got "NULL" '
-            .'instead.'
-        ];
-
-        yield 'string/stdClass' => [
-            'dummy_quantifier',
+        yield 'object/array' => [
             new \stdClass(),
-            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got "stdClass" '
-            .'instead.'
+            'dummy_element',
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"stdClass" instead.'
+        ];
+
+        yield 'closure/array' => [
+            function () {},
+            'dummy_element',
+            'Expected quantifier to be either an integer or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"Closure" instead.'
+        ];
+
+        yield 'int/null' => [
+            -1,
+            null,
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"NULL" instead.'
+        ];
+
+        yield 'int/bool' => [
+            -1,
+            true,
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"boolean" instead.'
+        ];
+
+        yield 'int/float' => [
+            -1,
+            .5,
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"double" instead.'
+        ];
+
+        yield 'int/int' => [
+            1,
+            1,
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"integer" instead.'
+        ];
+
+        yield 'int/closure' => [
+            -1,
+            function () {},
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"Closure" instead.'
+        ];
+
+        yield 'int/non value interface object' => [
+            -1,
+            new \stdClass(),
+            'Expected element to be either string, an array or a "Nelmio\Alice\Definition\ValueInterface" object. Got '
+            .'"stdClass" instead.'
         ];
     }
 
     public function provideValues()
     {
-        yield 'string value' => ['string', 'string', 0];
-        yield 'string numeric value' => ['100', 'string', 100];
+        yield 'int value' => [-1, 'string', -1];
         yield 'object value' => [new FakeValue(), new FakeValue(), new FakeValue()];
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -439,7 +439,7 @@ class ParserIntegrationTest extends \PHPUnit_Framework_TestCase
         yield '[Array] nominal string array' => [
             '10x @user',
             new DynamicArrayValue(
-                '10',
+                10,
                 new FixtureReferenceValue('user')
             ),
         ];
@@ -454,7 +454,7 @@ class ParserIntegrationTest extends \PHPUnit_Framework_TestCase
         yield '[Array] string array with right member' => [
             '10x @user bar',
             new DynamicArrayValue(
-                '10',
+                10,
                 new ListValue([
                     new FixtureReferenceValue('user'),
                     ' bar',
@@ -468,7 +468,7 @@ class ParserIntegrationTest extends \PHPUnit_Framework_TestCase
         yield '[Array] string array with string array' => [
             '10x [@user->name, @group->getName()]',
             new DynamicArrayValue(
-                '10',
+                10,
                 [
                     new FixturePropertyValue(
                         new FixtureReferenceValue('user'),

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
@@ -78,12 +78,12 @@ class DynamicArrayTokenParserTest extends \PHPUnit_Framework_TestCase
         $token = new Token('10x @user', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE));
 
         $decoratedParserProphecy = $this->prophesize(ParserInterface::class);
-        $decoratedParserProphecy->parse('10')->willReturn('parsed_quantifier');
+        $decoratedParserProphecy->parse('10')->willReturn('0');
         $decoratedParserProphecy->parse('@user')->willReturn('parsed_element');
         /** @var ParserInterface $decoratedParser */
         $decoratedParser = $decoratedParserProphecy->reveal();
 
-        $expected = new DynamicArrayValue('parsed_quantifier', 'parsed_element');
+        $expected = new DynamicArrayValue(0, 'parsed_element');
 
         $parser = new DynamicArrayTokenParser($decoratedParser);
         $actual = $parser->parse($token);

--- a/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
@@ -70,7 +70,7 @@ class DynamicArrayValueResolverTest extends \PHPUnit_Framework_TestCase
     {
         $resolver = new DynamicArrayValueResolver();
 
-        $this->assertTrue($resolver->canResolve(new DynamicArrayValue('', '')));
+        $this->assertTrue($resolver->canResolve(new DynamicArrayValue(1, '')));
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
@@ -80,7 +80,7 @@ class DynamicArrayValueResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testCannotResolveValueIfHasNoResolver()
     {
-        $value = new DynamicArrayValue('', '');
+        $value = new DynamicArrayValue(1, '');
         $resolver = new DynamicArrayValueResolver();
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
@@ -120,7 +120,7 @@ class DynamicArrayValueResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected quantifier to be an integer superior or equal to 2. Got "1" for "dummy", check you dynamic arrays declarations (e.g. "<numberBetween(1, 2)>x @user*").
+     * @expectedExceptionMessage Expected quantifier to be a positive integer. Got "-1" for "dummy", check you dynamic  arrays declarations (e.g. "<numberBetween(1, 2)>x @user*").
      */
     public function testThrowsExceptionIfAnInvalidQuantifierIsGiven()
     {
@@ -136,7 +136,7 @@ class DynamicArrayValueResolverTest extends \PHPUnit_Framework_TestCase
         $decoratedResolverProphecy
             ->resolve($quantifier, $fixture, $set, $scope, $context)
             ->willReturn(
-                new ResolvedValueWithFixtureSet(1, ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar'])))
+                new ResolvedValueWithFixtureSet(-1, ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar'])))
             )
         ;
         /** @var ValueResolverInterface $decoratedResolver */


### PR DESCRIPTION
As a dynamic array quantifier can be an evaluated value, it makes sense to allow down to 0 elements.

Closes #570.