### PR TITLE
Remove outdated TODO

### DIFF
--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -338,33 +338,32 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/^\d{3} \d{3} \d{3}$/', $user->siren);
     }
 
-//    public function testLoadFakerFunctionWithPhpArguments()
-//    {
-//        $this->markTestIncomplete('TODO, see https://github.com/nelmio/alice/issues/498#issuecomment-242488332');
-//        $data = [
-//            \stdClass::class => [
-//                'user' => [
-//                    'updatedAt' => '<dateTimeBetween(<("yest"."erday")>, <(strrev("omot")."rrow"))>>',
-//                ],
-//            ],
-//        ];
-//
-//        $set = $this->loader->loadData($data);
-//
-//        $this->assertEquals(0, count($set->getParameters()));
-//
-//        $objects = $set->getObjects();
-//        $this->assertEquals(1, count($objects));
-//
-//        $user = $objects['user'];
-//        $this->assertInstanceOf(\stdClass::class, $user);
-//
-//        $updatedAt = $user->updatedAt;
-//        $this->assertInstanceOf(\DateTimeInterface::class, $updatedAt);
-//        /** @var \DateTimeInterface $updatedAt */
-//        $this->assertGreaterThanOrEqual(strtotime('yesterday'), $updatedAt->getTimestamp());
-//        $this->assertLessThanOrEqual(strtotime('tomorrow'), $updatedAt->getTimestamp());
-//    }
+    public function testLoadFakerFunctionWithPhpArguments()
+    {
+        $data = [
+            \stdClass::class => [
+                'user' => [
+                    'updatedAt' => '<dateTimeBetween(<("yest"."erday")>, <(strrev("omot")."rrow")>)>',
+                ],
+            ],
+        ];
+
+        $set = $this->loader->loadData($data);
+
+        $this->assertEquals(0, count($set->getParameters()));
+
+        $objects = $set->getObjects();
+        $this->assertEquals(1, count($objects));
+
+        $user = $objects['user'];
+        $this->assertInstanceOf(\stdClass::class, $user);
+
+        $updatedAt = $user->updatedAt;
+        $this->assertInstanceOf(\DateTimeInterface::class, $updatedAt);
+        /** @var \DateTimeInterface $updatedAt */
+        $this->assertGreaterThanOrEqual(strtotime('yesterday'), $updatedAt->getTimestamp());
+        $this->assertLessThanOrEqual(strtotime('tomorrow'), $updatedAt->getTimestamp());
+    }
 
     public function testLoadSelfReferencedFixture()
     {


### PR DESCRIPTION
As mentioned in the discussion following https://github.com/nelmio/alice/issues/498#issuecomment-242488332:

>Nested function support has been added in 3.x, so the correct way to write '<dateTimeBetween("yest"."erday", strrev("omot")."rrow")>' in 3.x is '<dateTimeBetween(<("yest"."erday")>, <(strrev("omot")."rrow")>)>'.