### PR TITLE
Fix blackfire profile (scenario 3)

### DIFF
--- a/profiling/scenario3/blackfire.php
+++ b/profiling/scenario3/blackfire.php
@@ -25,7 +25,7 @@ $blackfire = new \Blackfire\Client();
 
 $config = new \Blackfire\Profile\Configuration();
 $config->setTitle('Scenario 3');
-$config->setSamples(10);
+$config->setSamples(1);
 $config->setReference(6);
 
 $probe = $blackfire->createProbe($config, false);

--- a/profiling/scenario3/fixtures.yml
+++ b/profiling/scenario3/fixtures.yml
@@ -18,8 +18,6 @@ Nelmio\Alice\scenario3\MutableUser:
         createdAt (unique): <dateTimeBetween("-200 days", "now")>
         updatedAt (unique): <dateTimeBetween($createdAt, "now")>
         email (unique): <email()>
-        favoriteNumber (unique): '@immutable_user_*->favoriteNumber'
-        owner (unique): '@immutable_user*'
         members (unique): '3x @immutable_user_*'
 
 Nelmio\Alice\scenario3\PublicUser:


### PR DESCRIPTION
The scenario3 was making failing too often because of too many attemps to generate some unique values. As this scenario is also fairly slower, the number of samples used has been reduced to 1.