### PR TITLE
Remove deep immutability of the flag bag

### DIFF
--- a/src/Definition/FlagBag.php
+++ b/src/Definition/FlagBag.php
@@ -38,7 +38,7 @@ final class FlagBag implements \IteratorAggregate, \Countable
 
     public function withKey(string $key): self
     {
-        $clone = deep_clone($this);
+        $clone = clone ($this);
         $clone->key = $key;
 
         return $clone;
@@ -54,7 +54,7 @@ final class FlagBag implements \IteratorAggregate, \Countable
      */
     public function withFlag(FlagInterface $flag): self
     {
-        $clone = deep_clone($this);
+        $clone = clone ($this);
         $clone->flags[$flag->__toString()] = deep_clone($flag);
         
         return $clone;
@@ -74,17 +74,17 @@ final class FlagBag implements \IteratorAggregate, \Countable
     public function mergeWith(self $flags, bool $override = true): self
     {
         if ($override) {
-            $clone = deep_clone($this);
+            $clone = clone ($this);
             foreach ($flags as $stringFlag => $flag) {
                 /** @var FlagInterface $flag */
-                $clone->flags[$flag->__toString()] = deep_clone($flag);
+                $clone->flags[$flag->__toString()] = clone ($flag);
             }
         } else {
-            $clone = deep_clone($flags);
+            $clone = clone ($flags);
             $clone->key = $this->key;
             foreach ($this as $stringFlag => $flag) {
                 /** @var FlagInterface $flag */
-                $clone->flags[$flag->__toString()] = deep_clone($flag);
+                $clone->flags[$flag->__toString()] = clone ($flag);
             }
         }
 
@@ -101,7 +101,7 @@ final class FlagBag implements \IteratorAggregate, \Countable
      */
     public function getIterator()
     {
-        return new \ArrayIterator(array_values(deep_clone($this->flags)));
+        return new \ArrayIterator(array_values($this->flags));
     }
 
     /**

--- a/tests/Definition/FlagBagTest.php
+++ b/tests/Definition/FlagBagTest.php
@@ -87,34 +87,8 @@ class FlagBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(FlagBag::class, $mergedBag);
 
-        // Mutate injected value
-        $flag1->setStringValue('flagA');
-        $flag1->getObject()->foo = 'bar';
-
-        $flag2->setStringValue('flagB');
-        $flag2->getObject()->foo = 'baz';
-
-
-        // Mutate return value
-        foreach ($bag1 as $flag) {
-            /** @var MutableFlag $flag */
-            $flag->setStringValue('flagAA');
-            $flag->getObject()->foo = 'rab';
-        }
-        foreach ($bag2 as $flag) {
-            /** @var MutableFlag $flag */
-            $flag->setStringValue('flagBB');
-            $flag->getObject()->foo = 'zab';
-        }
-        foreach ($mergedBag as $index => $flag) {
-            /** @var MutableFlag $flag */
-            $flag->setStringValue('flagM'.$index);
-            $flag->getObject()->foo = $index;
-        }
-
-
         $this->assertEquals(
-            (new FlagBag('bag1'))->withFlag(new MutableFlag('flag1', new \stdClass())),
+            (new FlagBag('bag1'))->withFlag($flag1),
             $bag1
         );
         $this->assertEquals(


### PR DESCRIPTION
This allows a perf gain of +3% and immutability is still kept as long as the implemented flags are immutable. As custom flags are fairly rare (mutable ones even more), this change is acceptable IMO.