### PR TITLE
Add Faker providers to the doc and remove cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ documentation for 2.x, head [this way](https://github.com/nelmio/alice/tree/2.x)
   1. [Localized Fake Data](doc/customizing-data-generation.md#localized-fake-data) **TODO: port that change to v2**
   1. [Default Providers](doc/customizing-data-generation.md#default-providers)
     1. [Identity](doc/customizing-data-generation.md#identity)
+    1. [Current](doc/customizing-data-generation.md#current)
+    1. [Cast](doc/customizing-data-generation.md#cast)
   1. [Reuse generated data using objects value](doc/customizing-data-generation.md#reuse-generated-data-using-objects-value)
   1. [Custom Faker Data Providers](doc/customizing-data-generation.md#custom-faker-data-providers)
 1. [Advanced Guide](doc/advanced-guide.md#advanced-guide)

--- a/doc/customizing-data-generation.md
+++ b/doc/customizing-data-generation.md
@@ -4,6 +4,8 @@
 1. [Localized Fake Data](#localized-fake-data) **TODO: port that change to v2**
 1. [Default Providers](#default-providers)
   1. [Identity](#identity)
+  1. [Current](#current)
+  1. [Cast](#cast)
 1. [Reuse generated data using objects value](#reuse-generated-data-using-objects-value)
 1. [Custom Faker Data Providers](#custom-faker-data-providers)
 
@@ -44,6 +46,8 @@ i.e. `<fr_FR:phoneNumber()>` or `<de_DE:firstName()>`.
 
 ### Default Providers
 
+Alice default Faker provider can be found in [AliceProvider](../src/Faker/Provider/AliceProvider.php).
+
 ### Identity
 
 Alice includes a default identity provider, `<identity()>`, that evaluates whatever
@@ -57,6 +61,28 @@ usually used with `<current()>`, is accessible via the `$current` variable.
 
 Some syntactic sugar is provided for this as well, and `<($whatever)>` is an alias
 for `<identity($whatever)>`.
+
+
+### Current
+
+Returns the current value in the context of a collection:
+
+```yaml
+stdClass:
+    dummy{1..2}:
+        currentValue: <current()> # is equivalent to '$current'
+```
+
+
+### Cast
+
+The cast method was added at some point, but you should use PHP `settype` instead:
+
+```yaml
+stdClass:
+    dummy{1..2}:
+        val: <settype('int', $current)>
+```
 
 
 ## Custom Faker Data Providers

--- a/src/Faker/Provider/AliceProvider.php
+++ b/src/Faker/Provider/AliceProvider.php
@@ -39,17 +39,4 @@ final class AliceProvider
     {
         return $fixture->getValueForCurrent();
     }
-
-    /**
-     * @param string $type
-     * @param mixed  $value
-     *
-     * @return mixed
-     */
-    public static function cast(string $type, $value)
-    {
-        settype($value, $type);
-
-        return $value;
-    }
 }

--- a/tests/Faker/Provider/AliceProviderTest.php
+++ b/tests/Faker/Provider/AliceProviderTest.php
@@ -55,23 +55,4 @@ class AliceProviderTest extends \PHPUnit_Framework_TestCase
             $this->assertNull($exception->getPrevious());
         }
     }
-
-    /**
-     * @dataProvider provideValuesToCast
-     */
-    public function testCastReturnsCastedValue(string $type, $value, $expected)
-    {
-        $actual = AliceProvider::cast($type, $value);
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    public function provideValuesToCast()
-    {
-        yield '"-1" to int' => [
-            'int',
-            '-1',
-            -1,
-        ];
-    }
 }


### PR DESCRIPTION
- Referenced `AliceProvider` in the built-in Faker provider
- Removed `cast` in favour of PHP native `settype`, usable since #640