### PR TITLE
Add a context cache

### DIFF
--- a/src/Generator/GenerationContext.php
+++ b/src/Generator/GenerationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use Nelmio\Alice\Throwable\Exception\Generator\Context\CachedValueNotFound;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 
@@ -32,6 +33,11 @@ final class GenerationContext
      * @var bool
      */
     private $needsCompleteResolution = false;
+
+    /**
+     * @var array
+     */
+    private $cache = [];
 
     public function __construct()
     {
@@ -73,5 +79,26 @@ final class GenerationContext
     public function needsCompleteGeneration(): bool
     {
         return $this->needsCompleteResolution;
+    }
+
+    public function cacheValue(string $key, $value)
+    {
+        $this->cache[$key] = $value;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @throws CachedValueNotFound
+     *
+     * @return mixed
+     */
+    public function getCachedValue(string $key)
+    {
+        if (false === array_key_exists($key, $this->cache)) {
+            throw CachedValueNotFound::create($key);
+        }
+
+        return $this->cache[$key];
     }
 }

--- a/src/Throwable/Exception/Generator/Context/CachedValueNotFound.php
+++ b/src/Throwable/Exception/Generator/Context/CachedValueNotFound.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Throwable\Exception\Generator\Context;
+
+use Nelmio\Alice\Throwable\GenerationThrowable;
+
+final class CachedValueNotFound extends \RuntimeException implements GenerationThrowable
+{
+    public static function create(string $key): self
+    {
+        return new self(
+            sprintf(
+                'No value with the key "%s" was found in the cache.',
+                $key
+            )
+        );
+    }
+}

--- a/tests/Generator/GenerationContextTest.php
+++ b/tests/Generator/GenerationContextTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use Nelmio\Alice\Throwable\Exception\Generator\Context\CachedValueNotFound;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException;
 
 /**
@@ -53,6 +54,32 @@ class GenerationContextTest extends \PHPUnit_Framework_TestCase
                 'Circular reference detected for the parameter "foo" while resolving ["bar", "foo"].',
                 $exception->getMessage()
             );
+        }
+    }
+
+    public function testCanSetAnRetrieveAValueFromTheCache()
+    {
+        $context = new GenerationContext();
+
+        $context->cacheValue('foo', $foo = new \stdClass());
+
+        $this->assertSame($foo, $context->getCachedValue('foo'));
+    }
+
+    public function testCannotRetrieveAnInexistingValueFromCache()
+    {
+        $context = new GenerationContext();
+
+        try {
+            $context->getCachedValue('foo');
+            $this->fail('Expected exception to be thrown.');
+        } catch (CachedValueNotFound $exception) {
+            $this->assertEquals(
+                'No value with the key "foo" was found in the cache.',
+                $exception->getMessage()
+            );
+            $this->assertEquals(0, $exception->getCode());
+            $this->assertNull($exception->getPrevious());
         }
     }
 }

--- a/tests/Throwable/Exception/Generator/Context/CachedValueNotFoundTest.php
+++ b/tests/Throwable/Exception/Generator/Context/CachedValueNotFoundTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Throwable\Exception\Generator\Context;
+
+/**
+ * @covers \Nelmio\Alice\Throwable\Exception\Generator\Context\CachedValueNotFound
+ */
+class CachedValueNotFoundTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTestCreate()
+    {
+        $exception = CachedValueNotFound::create('foo');
+
+        $this->assertEquals(
+            'No value with the key "foo" was found in the cache.',
+            $exception->getMessage()
+        );
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}


### PR DESCRIPTION
Add a cache in the GenerationContext. The advantages of that approach is that the cache in question has the same lifespan as the context itself, i.e. a loading. This allow resolvers to remain stateless (unlike the current `FixtureWildcardReferenceResolver`) but still leverage caching. Having another cache pool could be useful but I fear too much side-effects.