### PR TITLE
Fix wildcard resolver cache

### DIFF
--- a/fixtures/Loader/NonIsolatedSymfonyLoader.php
+++ b/fixtures/Loader/NonIsolatedSymfonyLoader.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Loader;
+
+use Nelmio\Alice\DataLoaderInterface;
+use Nelmio\Alice\FileLoaderInterface;
+use Nelmio\Alice\ObjectSet;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class NonIsolatedSymfonyLoader implements FileLoaderInterface, DataLoaderInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function loadData(array $data, array $parameters = [], array $objects = []): ObjectSet
+    {
+        return $this->container->get('nelmio_alice.data_loader')->loadData($data, $parameters, $objects);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function loadFile(string $file, array $parameters = [], array $objects = []): ObjectSet
+    {
+        return $this->container->get('nelmio_alice.file_loader')->loadFile($file, $parameters, $objects);
+    }
+}

--- a/tests/Bridge/Symfony/Loader/LoaderIntegrationTest.php
+++ b/tests/Bridge/Symfony/Loader/LoaderIntegrationTest.php
@@ -13,15 +13,52 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Bridge\Symfony\Loader;
 
-use Nelmio\Alice\Loader\IsolatedSymfonyLoader;
+use Nelmio\Alice\Loader\NonIsolatedSymfonyLoader;
+use Nelmio\Alice\Symfony\KernelFactory;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @group integration
  */
 class LoaderIntegrationTest extends \Nelmio\Alice\Loader\LoaderIntegrationTest
 {
+    /**
+     * @var KernelInterface
+     */
+    private static $kernel;
+
+    /**
+     * @inheritdoc
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        static::$kernel = KernelFactory::createKernel();
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setUp()
     {
-        $this->loader = new IsolatedSymfonyLoader();
+        static::$kernel->boot();
+
+        $this->nonIsolatedLoader = $this->loader = new NonIsolatedSymfonyLoader(static::$kernel->getContainer());
+    }
+
+    public function tearDown()
+    {
+        static::$kernel->shutdown();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function tearDownAfterClass()
+    {
+        static::$kernel = null;
+
+        parent::tearDownAfterClass();
     }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -56,9 +56,15 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     protected $loader;
 
+    /**
+     * @var FileLoaderInterface|DataLoaderInterface
+     */
+    protected $nonIsolatedLoader;
+
     public function setUp()
     {
         $this->loader = new IsolatedLoader();
+        $this->nonIsolatedLoader = new NativeLoader();
     }
 
     /**
@@ -905,6 +911,45 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @testdox The cache of the loader
+     */
+    public function testGenerationCache()
+    {
+        // This loading will trigger the caching part of the FixtureWildcardReferenceResolver to
+        // cache the pattern for `@another*`
+        $this->nonIsolatedLoader->loadData(
+            [
+                'parameters' => [],
+                \stdClass::class => [
+                    'another_dummy' => [],
+                    'dummy' => [
+                        'related' => '@another*',
+                    ],
+                ],
+            ],
+            [],
+            []
+        );
+
+        // This loading will also the caching part of the FixtureWildcardReferenceResolver. The
+        // cache having the same lifetime as the generation context is what ensures the cache from
+        // the previous loading will not interfer with this one
+        $this->nonIsolatedLoader->loadData(
+            [
+                'parameters' => [],
+                \stdClass::class => [
+                    'another_dummy_new' => [],
+                    'dummy' => [
+                        'related' => '@another*',
+                    ],
+                ],
+            ],
+            [],
+            []
+        );
     }
 
     public function provideFixturesToInstantiate()


### PR DESCRIPTION
As of now the `FixtureWildcardReferenceResolver` was not stateless as it has a cache which had a lifetime of a PHP process. Thanks to #656, it is now possible to make this service stateless and be able to leverage cache without corrupting data between loading.