### PR TITLE
Add covers annotations validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
         composer bin symfony require --no-update symfony/symfony "symfony/symfony:${SYMFONY_VERSION}"
     fi
   - composer bin all install
+  - bin/covers-validator -c $PHPUNIT_CONFIG
 
 script: $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.0.0",
+        "ockcyp/covers-validator": "^0.5",
         "php-mock/php-mock": "^1.0",
         "phpunit/phpunit": "^5.5",
         "symfony/phpunit-bridge": "^3.1"

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameDenormalizerTest.php
@@ -22,7 +22,7 @@ use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\ChainableFixtureDenormalizerInterface;
 
 /**
- * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullNullRangeNameDenormalizer
+ * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer
  */
 class NullRangeNameDenormalizerTest extends ChainableDenormalizerTest
 {


### PR DESCRIPTION
Use [ockcyp/covers-validator](https://github.com/oradwell/covers-validator) to check all the `@covers` annotations before running the test suite and fixed a wrong annotation.

Fixes #650