### PR TITLE
Increase min version of symfony/property-access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
 
 before_install:
   - set -eo pipefail
-  - curl -O -L https://github.com/oradwell/covers-validator/releases/download/v0.5.0/covers-validator.phar
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
   - |
@@ -54,7 +53,7 @@ install:
         composer bin symfony require --no-update symfony/symfony "symfony/symfony:${SYMFONY_VERSION}"
     fi
   - composer bin all update $COMPOSER_FLAGS
-  - php ./covers-validator.phar -c $PHPUNIT_CONFIG
+  - vendor-bin/covers-validator/bin/covers-validator -c $PHPUNIT_CONFIG
 
 script: $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 
 before_install:
   - set -eo pipefail
+  - curl -O -L https://github.com/oradwell/covers-validator/releases/download/v0.5.0/covers-validator.phar
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
   - |
@@ -53,7 +54,7 @@ install:
         composer bin symfony require --no-update symfony/symfony "symfony/symfony:${SYMFONY_VERSION}"
     fi
   - composer bin all update $COMPOSER_FLAGS
-  - bin/covers-validator -c $PHPUNIT_CONFIG
+  - php ./covers-validator.phar -c $PHPUNIT_CONFIG
 
 script: $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - php: '7.0'
       env: COVERAGE='true'
     - php: '7.0'
+      env: COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.0'
       env: SYMFONY_VERSION='~3.2.0'
     - php: '7.0'
       env: SYMFONY_VERSION='~3.3.0@dev'
@@ -45,12 +47,12 @@ before_install:
     fi
 
 install:
-  - composer install --prefer-dist $COMPOSER_FLAGS
+  - composer update --prefer-dist $COMPOSER_FLAGS
   - |
     if [ -n "$SYMFONY_VERSION" ]; then
         composer bin symfony require --no-update symfony/symfony "symfony/symfony:${SYMFONY_VERSION}"
     fi
-  - composer bin all install
+  - composer bin all update $COMPOSER_FLAGS
   - bin/covers-validator -c $PHPUNIT_CONFIG
 
 script: $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,9 @@
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.0.0",
         "fzaninotto/faker": "^1.4",
-        "ockcyp/covers-validator": "^0.5",
         "php-mock/php-mock": "^1.0",
         "phpspec/prophecy": "^1.6",
         "phpunit/phpunit": "^5.5",
-        "symfony/console": "^2.7|^3.0",
         "symfony/phpunit-bridge": "^3.1"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.0",
         "fzaninotto/faker": "^1.0",
         "myclabs/deep-copy": "^1.5.2",
-        "symfony/property-access": "^2.2||^3.0",
+        "symfony/property-access": "^2.3||^3.0",
         "symfony/yaml": "^2.0||^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,17 @@
         "php": "^7.0",
         "fzaninotto/faker": "^1.0",
         "myclabs/deep-copy": "^1.5.2",
-        "symfony/property-access": "^2.3||^3.0",
+        "symfony/property-access": "^2.7.11||^3.0",
         "symfony/yaml": "^2.0||^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.0.0",
+        "fzaninotto/faker": "^1.4",
         "ockcyp/covers-validator": "^0.5",
         "php-mock/php-mock": "^1.0",
+        "phpspec/prophecy": "^1.6",
         "phpunit/phpunit": "^5.5",
+        "symfony/console": "^2.7|^3.0",
         "symfony/phpunit-bridge": "^3.1"
     },
     "scripts": {

--- a/vendor-bin/covers-validator/composer.json
+++ b/vendor-bin/covers-validator/composer.json
@@ -1,0 +1,10 @@
+{
+    "require-dev": {
+        "symfony/console": "^2.7",
+        "ockcyp/covers-validator": "^0.5"
+    },
+    "config": {
+        "bin-dir": "bin",
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
`symfony/property-access` dependency version should be increased to at least 2.3, since `PropertyAccess::createPropertyAccessorBuilder()` (used in NativeLoader) does not exists in 2.2.

Maybe we should add a `--prefer-lowest` build in test matrix?