### PR TITLE
add support of embedded couchdb document (couchdb-odm)

### DIFF
--- a/src/Nelmio/Alice/Persister/Doctrine.php
+++ b/src/Nelmio/Alice/Persister/Doctrine.php
@@ -88,6 +88,9 @@ class Doctrine implements PersisterInterface
                 if (isset($metadata->isEmbeddedClass) && $metadata->isEmbeddedClass) {
                     continue;
                 }
+                if (isset($metadata->isEmbeddedDocument) && $metadata->isEmbeddedDocument) {
+                    continue;
+                }
 
                 $this->persistableClasses[] = $metadata->getName();
             }


### PR DESCRIPTION
couchdb-odm uses `isEmbeddedDocument` attribute instead of `isEmbeddedClass`.
