### PR TITLE
Nested PHP statement failing test

### DIFF
--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1929,6 +1929,24 @@ class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
+        yield '[function] call nested PHP native function' => [
+            [
+                \stdClass::class => [
+                    'dummy' => [
+                        'foo' => '<strtolower(<(implode(" ", ["HELLO", "WORLD", \<foo()>]))>)> \<bar()>'
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => StdClassFactory::create([
+                        'foo' => 'hello world <bar()>',
+                    ]),
+                ],
+            ],
+        ];
+
         yield '[self reference] alone' => [
             [
                 \stdClass::class => [


### PR DESCRIPTION
Discovered this issue when trying to do `<json_encode([])>`, which issues:

```
Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\MalformedFunctionException: The value "<(implode(" "" contains an unclosed function.
```

The example in the test is from the documentation: https://github.com/nelmio/alice/blob/master/doc/advanced-guide.md#functions