### PR TITLE
Prepare for PHPUnit 6

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,12 @@
   -->
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.0/phpunit.xsd"
          backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          enforceTimeLimit="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
 >
 
     <testsuites>

--- a/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Bridge\Symfony\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Symfony\KernelFactory;
 use Symfony\Component\Config\Definition\Processor;
 
@@ -20,7 +21,7 @@ use Symfony\Component\Config\Definition\Processor;
  * @covers \Nelmio\Alice\Bridge\Symfony\DependencyInjection\Configuration
  * @group integration
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testDefaultValues()
     {

--- a/tests/Bridge/Symfony/DependencyInjection/DynamicServicesConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/DynamicServicesConfigurationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Bridge\Symfony\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\Bridge\Symfony\Application\AppKernel;
 use Nelmio\Alice\Faker\Provider\AliceProvider;
@@ -26,7 +27,7 @@ use Nelmio\Alice\Symfony\KernelFactory;
  *
  * @group integration
  */
-class DynamicServicesConfigurationTest extends \PHPUnit_Framework_TestCase
+class DynamicServicesConfigurationTest extends TestCase
 {
     /**
      * @var AppKernel

--- a/tests/Definition/Fixture/FixtureIdTest.php
+++ b/tests/Definition/Fixture/FixtureIdTest.php
@@ -11,12 +11,13 @@
 
 namespace Nelmio\Alice\Definition\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureIdInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\FixtureId
  */
-class FixtureIdTest extends \PHPUnit_Framework_TestCase
+class FixtureIdTest extends TestCase
 {
     public function testIsAFixtureId()
     {

--- a/tests/Definition/Fixture/SimpleFixtureTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCall\DummyMethodCall;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Throwable\Exception\NoValueForCurrentException;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureInterface;
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\SimpleFixture
  */
-class SimpleFixtureTest extends \PHPUnit_Framework_TestCase
+class SimpleFixtureTest extends TestCase
 {
     public function testIsAFixtureId()
     {

--- a/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\FixtureWithFlagsInterface;
 use Nelmio\Alice\Definition\FlagBag;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureInterface;
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\SimpleFixtureWithFlags
  */
-class SimpleFixtureWithFlagsTest extends \PHPUnit_Framework_TestCase
+class SimpleFixtureWithFlagsTest extends TestCase
 {
     public function testIsAFixtureWithFlags()
     {

--- a/tests/Definition/Fixture/TemplatingFixtureTest.php
+++ b/tests/Definition/Fixture/TemplatingFixtureTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\Flag\DummyFlag;
 use Nelmio\Alice\Definition\Flag\ExtendFlag;
@@ -25,7 +26,7 @@ use Nelmio\Alice\FixtureInterface;
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\TemplatingFixture
  */
-class TemplatingFixtureTest extends \PHPUnit_Framework_TestCase
+class TemplatingFixtureTest extends TestCase
 {
     public function testIsAFixture()
     {

--- a/tests/Definition/Fixture/TemplatingTest.php
+++ b/tests/Definition/Fixture/TemplatingTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Flag\DummyFlag;
 use Nelmio\Alice\Definition\Flag\ExtendFlag;
 use Nelmio\Alice\Definition\Flag\TemplateFlag;
@@ -23,7 +24,7 @@ use Nelmio\Alice\Definition\SpecificationBagFactory;
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\Templating
  */
-class TemplatingTest extends \PHPUnit_Framework_TestCase
+class TemplatingTest extends TestCase
 {
     /**
      * @depends Nelmio\Alice\Definition\ServiceReference\FixtureReferenceTest::testIsImmutable

--- a/tests/Definition/Flag/ExtendFlagTest.php
+++ b/tests/Definition/Flag/ExtendFlagTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Flag;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagInterface;
 use Nelmio\Alice\Definition\ServiceReference\FixtureReference;
 
 /**
  * @covers \Nelmio\Alice\Definition\Flag\ExtendFlag
  */
-class ExtendFlagTest extends \PHPUnit_Framework_TestCase
+class ExtendFlagTest extends TestCase
 {
     public function testIsAFlag()
     {

--- a/tests/Definition/Flag/OptionalFlagTest.php
+++ b/tests/Definition/Flag/OptionalFlagTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Flag;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Flag\OptionalFlag
  */
-class OptionalFlagTest extends \PHPUnit_Framework_TestCase
+class OptionalFlagTest extends TestCase
 {
     public function testIsAFlag()
     {

--- a/tests/Definition/Flag/TemplateFlagTest.php
+++ b/tests/Definition/Flag/TemplateFlagTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Flag;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Flag\TemplateFlag
  */
-class TemplateFlagTest extends \PHPUnit_Framework_TestCase
+class TemplateFlagTest extends TestCase
 {
     public function testIsAFlag()
     {

--- a/tests/Definition/Flag/UniqueFlagTest.php
+++ b/tests/Definition/Flag/UniqueFlagTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Flag;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Flag\UniqueFlag
  */
-class UniqueFlagTest extends \PHPUnit_Framework_TestCase
+class UniqueFlagTest extends TestCase
 {
     public function testIsAFlag()
     {

--- a/tests/Definition/FlagBagTest.php
+++ b/tests/Definition/FlagBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Flag\AnotherDummyFlag;
 use Nelmio\Alice\Definition\Flag\DummyFlag;
 use Nelmio\Alice\Definition\Flag\ElementFlag;
@@ -27,7 +28,7 @@ use Nelmio\Alice\Definition\ServiceReference\FixtureReference;
 /**
  * @covers \Nelmio\Alice\Definition\FlagBag
  */
-class FlagBagTest extends \PHPUnit_Framework_TestCase
+class FlagBagTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Definition/MethodCall/MethodCallWithReferenceTest.php
+++ b/tests/Definition/MethodCall/MethodCallWithReferenceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\MethodCall;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\MutableReference;
@@ -21,7 +22,7 @@ use Nelmio\Alice\Entity\StdClassFactory;
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\MethodCallWithReference
  */
-class MethodCallWithReferenceTest extends \PHPUnit_Framework_TestCase
+class MethodCallWithReferenceTest extends TestCase
 {
     public function testIsAMethodCall()
     {

--- a/tests/Definition/MethodCall/NoMethodCallTest.php
+++ b/tests/Definition/MethodCall/NoMethodCallTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\MethodCall;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCallInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\NoMethodCall
  */
-class NoMethodCallTest extends \PHPUnit_Framework_TestCase
+class NoMethodCallTest extends TestCase
 {
     public function testIsAMethodCall()
     {

--- a/tests/Definition/MethodCall/OptionalMethodCallTest.php
+++ b/tests/Definition/MethodCall/OptionalMethodCallTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\MethodCall;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Flag\OptionalFlag;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
@@ -22,7 +23,7 @@ use Nelmio\Alice\Entity\StdClassFactory;
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\OptionalMethodCall
  */
-class OptionalMethodCallTest extends \PHPUnit_Framework_TestCase
+class OptionalMethodCallTest extends TestCase
 {
     public function testIsAMethodCall()
     {

--- a/tests/Definition/MethodCall/SimpleMethodCallTest.php
+++ b/tests/Definition/MethodCall/SimpleMethodCallTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\MethodCall;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\SimpleMethodCall
  */
-class SimpleMethodCallTest extends \PHPUnit_Framework_TestCase
+class SimpleMethodCallTest extends TestCase
 {
     public function testIsAMethodCall()
     {

--- a/tests/Definition/MethodCallBagTest.php
+++ b/tests/Definition/MethodCallBagTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCall\DummyMethodCall;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 
 /**
  * @covers \Nelmio\Alice\Definition\MethodCallBag
  */
-class MethodCallBagTest extends \PHPUnit_Framework_TestCase
+class MethodCallBagTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/Definition/Object/CompleteObjectTest.php
+++ b/tests/Definition/Object/CompleteObjectTest.php
@@ -11,13 +11,14 @@
 
 namespace Nelmio\Alice\Definition\Object;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\ObjectInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Object\CompleteObject
  */
-class CompleteObjectTest extends \PHPUnit_Framework_TestCase
+class CompleteObjectTest extends TestCase
 {
     public function testIsAnObject()
     {

--- a/tests/Definition/Object/SimpleObjectTest.php
+++ b/tests/Definition/Object/SimpleObjectTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Object;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\ObjectInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Object\SimpleObject
  */
-class SimpleObjectTest extends \PHPUnit_Framework_TestCase
+class SimpleObjectTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/Definition/PropertyBagTest.php
+++ b/tests/Definition/PropertyBagTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Definition\PropertyBag
  */
-class PropertyBagTest extends \PHPUnit_Framework_TestCase
+class PropertyBagTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/Definition/PropertyTest.php
+++ b/tests/Definition/PropertyTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers \Nelmio\Alice\Definition\Property
  */
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Definition/RangeNameTest.php
+++ b/tests/Definition/RangeNameTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Definition\RangeName
  */
-class RangeNameTest extends \PHPUnit_Framework_TestCase
+class RangeNameTest extends TestCase
 {
     /**
      * @dataProvider provideRanges

--- a/tests/Definition/ServiceReference/FixtureReferenceTest.php
+++ b/tests/Definition/ServiceReference/FixtureReferenceTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\ServiceReference;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ServiceReferenceInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\ServiceReference\FixtureReference
  */
-class FixtureReferenceTest extends \PHPUnit_Framework_TestCase
+class FixtureReferenceTest extends TestCase
 {
     public function testIsAReference()
     {

--- a/tests/Definition/ServiceReference/InstantiatedReferenceTest.php
+++ b/tests/Definition/ServiceReference/InstantiatedReferenceTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\ServiceReference;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ServiceReferenceInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\ServiceReference\InstantiatedReference
  */
-class InstantiatedReferenceTest extends \PHPUnit_Framework_TestCase
+class InstantiatedReferenceTest extends TestCase
 {
     public function testIsAReference()
     {

--- a/tests/Definition/ServiceReference/StaticReferenceTest.php
+++ b/tests/Definition/ServiceReference/StaticReferenceTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\ServiceReference;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ServiceReferenceInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\ServiceReference\StaticReference
  */
-class StaticReferenceTest extends \PHPUnit_Framework_TestCase
+class StaticReferenceTest extends TestCase
 {
     public function testIsAReference()
     {

--- a/tests/Definition/SpecificationBagTest.php
+++ b/tests/Definition/SpecificationBagTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 
 /**
  * @covers \Nelmio\Alice\Definition\SpecificationBag
  */
-class SpecificationBagTest extends \PHPUnit_Framework_TestCase
+class SpecificationBagTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Definition/Value/ArrayValueTest.php
+++ b/tests/Definition/Value/ArrayValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\ArrayValue
  */
-class ArrayValueTest extends \PHPUnit_Framework_TestCase
+class ArrayValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/ChoiceListValueTest.php
+++ b/tests/Definition/Value/ChoiceListValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\ChoiceListValue
  */
-class ChoiceListValueTest extends \PHPUnit_Framework_TestCase
+class ChoiceListValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/DynamicArrayValueTest.php
+++ b/tests/Definition/Value/DynamicArrayValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\DynamicArrayValue
  */
-class DynamicArrayValueTest extends \PHPUnit_Framework_TestCase
+class DynamicArrayValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/EvaluatedValueTest.php
+++ b/tests/Definition/Value/EvaluatedValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\EvaluatedValue
  */
-class EvaluatedValueTest extends \PHPUnit_Framework_TestCase
+class EvaluatedValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/FixtureMatchReferenceValueTest.php
+++ b/tests/Definition/Value/FixtureMatchReferenceValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\FixtureMatchReferenceValue
  */
-class FixtureMatchReferenceValueTest extends \PHPUnit_Framework_TestCase
+class FixtureMatchReferenceValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/FixtureMethodCallValueTest.php
+++ b/tests/Definition/Value/FixtureMethodCallValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\FixtureMethodCallValue
  */
-class FixtureMethodCallValueTest extends \PHPUnit_Framework_TestCase
+class FixtureMethodCallValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/FixturePropertyValueTest.php
+++ b/tests/Definition/Value/FixturePropertyValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\FixturePropertyValue
  */
-class FixturePropertyValueTest extends \PHPUnit_Framework_TestCase
+class FixturePropertyValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/FixtureReferenceValueTest.php
+++ b/tests/Definition/Value/FixtureReferenceValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\FixtureReferenceValue
  */
-class FixtureReferenceValueTest extends \PHPUnit_Framework_TestCase
+class FixtureReferenceValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/FunctionCallValueTest.php
+++ b/tests/Definition/Value/FunctionCallValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\FunctionCallValue
  */
-class FunctionCallValueTest extends \PHPUnit_Framework_TestCase
+class FunctionCallValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/ListValueTest.php
+++ b/tests/Definition/Value/ListValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\ListValue
  */
-class ListValueTest extends \PHPUnit_Framework_TestCase
+class ListValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/NestedValueTest.php
+++ b/tests/Definition/Value/NestedValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\NestedValue
  */
-class NestedValueTest extends \PHPUnit_Framework_TestCase
+class NestedValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/OptionalValueTest.php
+++ b/tests/Definition/Value/OptionalValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\OptionalValue
  */
-class OptionalValueTest extends \PHPUnit_Framework_TestCase
+class OptionalValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/ParameterValueTest.php
+++ b/tests/Definition/Value/ParameterValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\ParameterValue
  */
-class ParameterValueTest extends \PHPUnit_Framework_TestCase
+class ParameterValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/UniqueValueTest.php
+++ b/tests/Definition/Value/UniqueValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\UniqueValue
  */
-class UniqueValueTest extends \PHPUnit_Framework_TestCase
+class UniqueValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/ValueForCurrentValueTest.php
+++ b/tests/Definition/Value/ValueForCurrentValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\ValueForCurrentValue
  */
-class ValueForCurrentValueTest extends \PHPUnit_Framework_TestCase
+class ValueForCurrentValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Definition/Value/VariableValueTest.php
+++ b/tests/Definition/Value/VariableValueTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * @covers \Nelmio\Alice\Definition\Value\VariableValue
  */
-class VariableValueTest extends \PHPUnit_Framework_TestCase
+class VariableValueTest extends TestCase
 {
     public function testIsAValue()
     {

--- a/tests/Faker/GeneratorFactoryTest.php
+++ b/tests/Faker/GeneratorFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Faker;
 
+use PHPUnit\Framework\TestCase;
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\Faker\Provider\DummyProvider;
@@ -21,7 +22,7 @@ use Nelmio\Alice\Faker\Provider\DummyProvider;
  * @covers \Nelmio\Alice\Faker\GeneratorFactory
  * @group integration
  */
-class GeneratorFactoryTest extends \PHPUnit_Framework_TestCase
+class GeneratorFactoryTest extends TestCase
 {
     public function testAssertGeneratorLocaleMethod()
     {

--- a/tests/Faker/Provider/AliceProviderTest.php
+++ b/tests/Faker/Provider/AliceProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Faker\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Throwable\Exception\NoValueForCurrentException;
@@ -20,7 +21,7 @@ use Nelmio\Alice\Throwable\Exception\NoValueForCurrentException;
 /**
  * @covers \Nelmio\Alice\Faker\Provider\AliceProvider
  */
-class AliceProviderTest extends \PHPUnit_Framework_TestCase
+class AliceProviderTest extends TestCase
 {
     public function testIdentityReturnsTheValueUnchanged()
     {

--- a/tests/FileLocator/DefaultFileLocatorTest.php
+++ b/tests/FileLocator/DefaultFileLocatorTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FileLocator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FileLocatorInterface;
 
 /**
  * @covers \Nelmio\Alice\FileLocator\DefaultFileLocator
  */
-class DefaultFileLocatorTest extends \PHPUnit_Framework_TestCase
+class DefaultFileLocatorTest extends TestCase
 {
     /**
      * @var DefaultFileLocator

--- a/tests/FixtureBagTest.php
+++ b/tests/FixtureBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\MutableFixture;
@@ -23,7 +24,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureNotFoundException;
 /**
  * @covers \Nelmio\Alice\FixtureBag
  */
-class FixtureBagTest extends \PHPUnit_Framework_TestCase
+class FixtureBagTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/FixtureBuilder/BareFixtureSetTest.php
+++ b/tests/FixtureBuilder/BareFixtureSetTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\Parameter;
@@ -21,7 +22,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\BareFixtureSet
  */
-class BareFixtureSetTest extends \PHPUnit_Framework_TestCase
+class BareFixtureSetTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\ChainableFixtureDenormalizerInterface;
@@ -21,7 +22,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\ReferenceProviderTrait;
 use Prophecy\Argument;
 
-abstract class ChainableDenormalizerTest extends \PHPUnit_Framework_TestCase
+abstract class ChainableDenormalizerTest extends TestCase
 {
     use ReferenceProviderTrait;
 

--- a/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\DummyChainableParserAwareDenormalizer;
@@ -27,7 +28,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerRegistry
  */
-class FixtureDenormalizerRegistryTest extends \PHPUnit_Framework_TestCase
+class FixtureDenormalizerRegistryTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Flag\ElementFlag;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBag;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SimpleFixtureBagDenormalizer
  */
-class SimpleFixtureBagDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleFixtureBagDenormalizerTest extends TestCase
 {
     public function testIsAFixtureBagDenormalizer()
     {

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Flag\ElementFlag;
 use Nelmio\Alice\Definition\FlagBag;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\SimpleArgumentsDenormalizer
  */
-class SimpleArgumentsDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleArgumentsDenormalizerTest extends TestCase
 {
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/OptionalCallsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/OptionalCallsDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Calls;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Flag\DummyFlag;
 use Nelmio\Alice\Definition\Flag\OptionalFlag;
@@ -27,7 +28,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Calls\OptionalCallsDenormalizer
  */
-class OptionalCallsDenormalizerTest extends \PHPUnit_Framework_TestCase
+class OptionalCallsDenormalizerTest extends TestCase
 {
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
@@ -27,7 +28,7 @@ use Nelmio\Alice\FixtureInterface;
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\SimpleConstructorDenormalizer
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorWithCallerDenormalizer
  */
-class ConstructorWithCallerDenormalizerTest extends \PHPUnit_Framework_TestCase
+class ConstructorWithCallerDenormalizerTest extends TestCase
 {
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Property/SimplePropertyDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Property/SimplePropertyDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Property;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\Definition\Property;
@@ -23,7 +24,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Property\SimplePropertyDenormalizer
  */
-class SimplePropertyDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimplePropertyDenormalizerTest extends TestCase
 {
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\FlagBag;
@@ -31,7 +32,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\SimpleSpecificationsDenormalizer
  */
-class SimpleSpecificationsDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleSpecificationsDenormalizerTest extends TestCase
 {
     public function testIsNotClonable()
     {

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\Definition\Value\ArrayValue;
@@ -26,7 +27,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Value\SimpleValueDenormalizer
  */
-class SimpleValueDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleValueDenormalizerTest extends TestCase
 {
     public function testIsAValueDenormalizer()
     {

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Flag\DummyFlag;
@@ -29,7 +30,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Value\UniqueValueDenormalizer
  */
-class UniqueValueDenormalizerTest extends \PHPUnit_Framework_TestCase
+class UniqueValueDenormalizerTest extends TestCase
 {
     public function testIsAValueDenormalizer()
     {

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\Chainable\FakeChainableFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FlagParserRegistry
  */
-class FlagParserRegistryTest extends \PHPUnit_Framework_TestCase
+class FlagParserRegistryTest extends TestCase
 {
     public function testIsAFlagParser()
     {

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserTestCase.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserTestCase.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 
-abstract class FlagParserTestCase extends \PHPUnit_Framework_TestCase
+abstract class FlagParserTestCase extends TestCase
 {
     /**
      * @var FlagParserInterface|ChainableFlagParserInterface

--- a/tests/FixtureBuilder/Denormalizer/Parameter/SimpleParameterBagDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Parameter/SimpleParameterBagDenormalizerTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\ParameterBagDenormalizerInterface;
 use Nelmio\Alice\ParameterBag;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Parameter\SimpleParameterBagDenormalizer
  */
-class SimpleParameterBagDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleParameterBagDenormalizerTest extends TestCase
 {
     /**
      * @var SimpleParameterBagDenormalizer

--- a/tests/FixtureBuilder/Denormalizer/SimpleDenormalizerTestTest.php
+++ b/tests/FixtureBuilder/Denormalizer/SimpleDenormalizerTestTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureBuilder\BareFixtureSet;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\SimpleDenormalizer
  */
-class SimpleDenormalizerTest extends \PHPUnit_Framework_TestCase
+class SimpleDenormalizerTest extends TestCase
 {
     public function testIsADenormalizer()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\EmptyValueLexer
  */
-class EmptyValueLexerTest extends \PHPUnit_Framework_TestCase
+class EmptyValueLexerTest extends TestCase
 {
     public function testIsALexer()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\FunctionLexer
  */
-class FunctionLexerTest extends \PHPUnit_Framework_TestCase
+class FunctionLexerTest extends TestCase
 {
     /**
      * @var FunctionLexer

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizerTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\MalformedFunctionException;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\FunctionTokenizer
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\FunctionTreeTokenizer
  */
-class FunctionTokenizerTest extends \PHPUnit_Framework_TestCase
+class FunctionTokenizerTest extends TestCase
 {
     /**
      * @var FunctionTokenizer

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\GlobalPatternsLexer
  */
-class GlobalPatternsLexerTest extends \PHPUnit_Framework_TestCase
+class GlobalPatternsLexerTest extends TestCase
 {
     public function testIsALexer()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\LexException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
@@ -22,7 +23,7 @@ use Nelmio\Alice\Loader\NativeLoader;
 /**
  * @group integration
  */
-class LexerIntegrationTest extends \PHPUnit_Framework_TestCase
+class LexerIntegrationTest extends TestCase
 {
     /**
      * @var LexerInterface

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
@@ -11,13 +11,14 @@
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Prophecy\Argument;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\ReferenceEscaperLexer
  */
-class ReferenceEscaperLexerTest extends \PHPUnit_Framework_TestCase
+class ReferenceEscaperLexerTest extends TestCase
 {
     public function testIsALexer()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -20,7 +21,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\ReferenceLexer
  */
-class ReferenceLexerTest extends \PHPUnit_Framework_TestCase
+class ReferenceLexerTest extends TestCase
 {
     /**
      * @var ReferenceLexer

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\SubPatternsLexer
  */
-class SubPatternsLexerTest extends \PHPUnit_Framework_TestCase
+class SubPatternsLexerTest extends TestCase
 {
     public function testIsALexer()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/LexerParserSynchronizationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/LexerParserSynchronizationTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\LexerIntegrationTest;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ParserIntegrationTest;
 
 /**
  * @coversNothing
  */
-class LexerParserSynchronizationTest extends \PHPUnit_Framework_TestCase
+class LexerParserSynchronizationTest extends TestCase
 {
     public function testProvidesAreSynchronized()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
@@ -23,7 +24,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FunctionFixtureReferenceParser
  */
-class FunctionFixtureReferenceParserTest extends \PHPUnit_Framework_TestCase
+class FunctionFixtureReferenceParserTest extends TestCase
 {
     public function testIsAParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCall\IdentityFactory;
 use Nelmio\Alice\Definition\Value\ChoiceListValue;
 use Nelmio\Alice\Definition\Value\DynamicArrayValue;
@@ -33,7 +34,7 @@ use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 /**
  * @group integration
  */
-class ParserIntegrationTest extends \PHPUnit_Framework_TestCase
+class ParserIntegrationTest extends TestCase
 {
     /** @var ParserInterface */
     protected $parser;

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\NestedValue;
 use Nelmio\Alice\Definition\Value\ParameterValue;
 use Nelmio\Alice\Definition\Value\ListValue;
@@ -28,7 +29,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\SimpleParser
  */
-class SimpleParserTest extends \PHPUnit_Framework_TestCase
+class SimpleParserTest extends TestCase
 {
     public function testIsAParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\StringMergerParser
  */
-class StringMergerParserTest extends \PHPUnit_Framework_TestCase
+class StringMergerParserTest extends TestCase
 {
     public function testIsAParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -20,7 +21,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser
  */
-class AbstractChainableParserAwareParserTest extends \PHPUnit_Framework_TestCase
+class AbstractChainableParserAwareParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\DynamicArrayValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\DynamicArrayTokenParser
  */
-class DynamicArrayTokenParserTest extends \PHPUnit_Framework_TestCase
+class DynamicArrayTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -20,7 +21,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\EscapedValueTokenParser
  */
-class EscapedValueTokenParserTest extends \PHPUnit_Framework_TestCase
+class EscapedValueTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\ChoiceListValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\FixtureListReferenceTokenParser
  */
-class FixtureListReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class FixtureListReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FixtureMethodCallValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
@@ -26,7 +27,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\FixtureMethodReferenceTokenParser
  */
-class FixtureMethodReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class FixtureMethodReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\ChoiceListValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\FixtureRangeReferenceTokenParser
  */
-class FixtureRangeReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class FixtureRangeReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\MethodCall\IdentityFactory;
 use Nelmio\Alice\Definition\Value\EvaluatedValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
@@ -27,7 +28,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\FunctionTokenParser
  */
-class FunctionTokenParserTest extends \PHPUnit_Framework_TestCase
+class FunctionTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\IdentityTokenParser
  */
-class IdentityTokenParserTest extends \PHPUnit_Framework_TestCase
+class IdentityTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FixtureMethodCallValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
@@ -26,7 +27,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\MethodReferenceTokenParser
  */
-class MethodReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class MethodReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\OptionalValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\OptionalTokenParser
  */
-class OptionalTokenParserTest extends \PHPUnit_Framework_TestCase
+class OptionalTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/ParameterTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\ParameterValue;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\ParameterTokenParser
  */
-class ParameterTokenParserTest extends \PHPUnit_Framework_TestCase
+class ParameterTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\PropertyReferenceTokenParser
  */
-class PropertyReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class PropertyReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/SimpleReferenceTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -22,7 +23,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\SimpleReferenceTokenParser
  */
-class SimpleReferenceTokenParserTest extends \PHPUnit_Framework_TestCase
+class SimpleReferenceTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\StringArrayTokenParser
  */
-class StringArrayTokenParserTest extends \PHPUnit_Framework_TestCase
+class StringArrayTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -20,7 +21,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\StringTokenParser
  */
-class StringTokenParserTest extends \PHPUnit_Framework_TestCase
+class StringTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\VariableValue;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
@@ -23,7 +24,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\VariableTokenParser
  */
-class VariableTokenParserTest extends \PHPUnit_Framework_TestCase
+class VariableTokenParserTest extends TestCase
 {
     public function testIsAChainableTokenParser()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\ProphecyChainableTokenParserAware;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\FakeChainableTokenParser;
@@ -26,7 +27,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\TokenParserRegistry
  */
-class TokenParserRegistryTest extends \PHPUnit_Framework_TestCase
+class TokenParserRegistryTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token
  */
-class TokenTest extends \PHPUnit_Framework_TestCase
+class TokenTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType
  */
-class TokenTypeTest extends \PHPUnit_Framework_TestCase
+class TokenTypeTest extends TestCase
 {
     /**
      * @var string[]

--- a/tests/FixtureBuilder/SimpleBuilderTest.php
+++ b/tests/FixtureBuilder/SimpleBuilderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FakeDenormalizer;
 use Nelmio\Alice\FixtureBuilderInterface;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\SimpleBuilder
  */
-class SimpleBuilderTest extends \PHPUnit_Framework_TestCase
+class SimpleBuilderTest extends TestCase
 {
     public function testIsAFixtureBuilder()
     {

--- a/tests/FixtureSetTest.php
+++ b/tests/FixtureSetTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\FixtureSet
  */
-class FixtureSetTest extends \PHPUnit_Framework_TestCase
+class FixtureSetTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase
 {
     /**
      * @dataProvider provideScalarValues

--- a/tests/Generator/Caller/SimpleCallerTest.php
+++ b/tests/Generator/Caller/SimpleCallerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Caller;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 use Nelmio\Alice\Definition\MethodCallBag;
@@ -39,7 +40,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Caller\SimpleCaller
  */
-class SimpleCallerTest extends \PHPUnit_Framework_TestCase
+class SimpleCallerTest extends TestCase
 {
     public function testIsACaller()
     {

--- a/tests/Generator/DoublePassGeneratorTest.php
+++ b/tests/Generator/DoublePassGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Entity\StdClassFactory;
@@ -29,7 +30,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\DoublePassGenerator
  */
-class DoublePassGeneratorTest extends \PHPUnit_Framework_TestCase
+class DoublePassGeneratorTest extends TestCase
 {
     public function testIsAGenerator()
     {

--- a/tests/Generator/GenerationContextTest.php
+++ b/tests/Generator/GenerationContextTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\Generator\Context\CachedValueNotFound;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException;
 
 /**
  * @covers \Nelmio\Alice\Generator\GenerationContext
  */
-class GenerationContextTest extends \PHPUnit_Framework_TestCase
+class GenerationContextTest extends TestCase
 {
     public function testAccessors()
     {

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Hydrator\Property;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Entity\DummyWithDate;
@@ -32,7 +33,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 /**
  * @covers \Nelmio\Alice\Generator\Hydrator\Property\SymfonyPropertyAccessorHydrator
  */
-class SymfonyPropertyAccessorHydratorTest extends \PHPUnit_Framework_TestCase
+class SymfonyPropertyAccessorHydratorTest extends TestCase
 {
     /**
      * @var SymfonyPropertyAccessorHydrator

--- a/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Dummy;
@@ -29,7 +30,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\Chainable\AbstractChainableInstantiator
  */
-class AbstractChainableInstantiatorTest extends \PHPUnit_Framework_TestCase
+class AbstractChainableInstantiatorTest extends TestCase
 {
     /**
      * @var AbstractChainableInstantiator

--- a/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCall\NoMethodCall;
@@ -28,7 +29,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\Chainable\NoCallerMethodCallInstantiator
  */
-class NoCallerMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
+class NoCallerMethodCallInstantiatorTest extends TestCase
 {
     /**
      * @var NoCallerMethodCallInstantiator

--- a/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCall\NoMethodCall;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
@@ -26,7 +27,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\Chainable\NoMethodCallInstantiator
  */
-class NoMethodCallInstantiatorTest extends \PHPUnit_Framework_TestCase
+class NoMethodCallInstantiatorTest extends TestCase
 {
     /**
      * @var NoMethodCallInstantiator

--- a/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Entity\Instantiator\AbstractDummy;
@@ -29,7 +30,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\Chainable\NullConstructorInstantiator
  */
-class NullConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
+class NullConstructorInstantiatorTest extends TestCase
 {
     /**
      * @var NullConstructorInstantiator

--- a/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCall\NoMethodCall;
@@ -31,7 +32,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\Chainable\StaticFactoryInstantiator
  */
-class StaticFactoryInstantiatorTest extends \PHPUnit_Framework_TestCase
+class StaticFactoryInstantiatorTest extends TestCase
 {
     /**
      * @var StaticFactoryInstantiator

--- a/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
+++ b/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Generator\GenerationContext;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\ExistingInstanceInstantiator
  */
-class ExistingInstanceInstantiatorTest extends \PHPUnit_Framework_TestCase
+class ExistingInstanceInstantiatorTest extends TestCase
 {
     public function testIsAnInstantiator()
     {

--- a/tests/Generator/Instantiator/InstantiatorRegistryTest.php
+++ b/tests/Generator/Instantiator/InstantiatorRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -27,7 +28,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\InstantiatorRegistry
  */
-class InstantiatorRegistryTest extends \PHPUnit_Framework_TestCase
+class InstantiatorRegistryTest extends TestCase
 {
     public function testIsAnInstantiator()
     {

--- a/tests/Generator/Instantiator/InstantiatorResolverTest.php
+++ b/tests/Generator/Instantiator/InstantiatorResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
@@ -35,7 +36,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Instantiator\InstantiatorResolver
  */
-class InstantiatorResolverTest extends \PHPUnit_Framework_TestCase
+class InstantiatorResolverTest extends TestCase
 {
     public function testIsAnInstantiator()
     {

--- a/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\ObjectGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Object\CompleteObject;
@@ -32,7 +33,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\ObjectGenerator\CompleteObjectGenerator
  */
-class CompleteObjectGeneratorTest extends \PHPUnit_Framework_TestCase
+class CompleteObjectGeneratorTest extends TestCase
 {
     public function testIsAnObjectGenerator()
     {

--- a/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\ObjectGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
@@ -32,7 +33,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\ObjectGenerator\SimpleObjectGenerator
  */
-class SimpleObjectGeneratorTest extends \PHPUnit_Framework_TestCase
+class SimpleObjectGeneratorTest extends TestCase
 {
     public function testIsAnObjectGenerator()
     {

--- a/tests/Generator/Populator/SimpleHydratorTest.php
+++ b/tests/Generator/Populator/SimpleHydratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\MethodCallBag;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -38,7 +39,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Hydrator\SimpleHydrator
  */
-class SimpleHydratorTest extends \PHPUnit_Framework_TestCase
+class SimpleHydratorTest extends TestCase
 {
     public function testIsAnHydrator()
     {

--- a/tests/Generator/ResolvedFixtureSetTest.php
+++ b/tests/Generator/ResolvedFixtureSetTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\ObjectBag;
@@ -21,7 +22,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\ResolvedFixtureSet
  */
-class ResolvedFixtureSetTest extends \PHPUnit_Framework_TestCase
+class ResolvedFixtureSetTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Generator/ResolvedValueWithFixtureSetTest.php
+++ b/tests/Generator/ResolvedValueWithFixtureSetTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Generator\ResolvedValueWithFixtureSet
  */
-class ResolvedValueWithFixtureSetTest extends \PHPUnit_Framework_TestCase
+class ResolvedValueWithFixtureSetTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixtureWithFlags;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Fixture\TemplatingFixture;
@@ -30,7 +31,7 @@ use Nelmio\Alice\FixtureBag;
  * @covers \Nelmio\Alice\Generator\Resolver\Fixture\TemplateFixtureBagResolver
  * @covers \Nelmio\Alice\Generator\Resolver\Fixture\TemplateFixtureResolver
  */
-class TemplateFixtureBagResolverTest extends \PHPUnit_Framework_TestCase
+class TemplateFixtureBagResolverTest extends TestCase
 {
     /**
      * @var TemplateFixtureBagResolver

--- a/tests/Generator/Resolver/Fixture/TemplateFixtureResolverTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplateFixtureResolverTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Fixture;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Fixture\TemplateFixtureResolver
  *
@@ -20,7 +22,7 @@ namespace Nelmio\Alice\Generator\Resolver\Fixture;
  *
  * @see \Nelmio\Alice\Generator\Resolver\Fixture\TemplateFixtureBagResolverTest
  */
-class TemplateFixtureResolverTest extends \PHPUnit_Framework_TestCase
+class TemplateFixtureResolverTest extends TestCase
 {
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException

--- a/tests/Generator/Resolver/Fixture/TemplatingFixtureBagTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplatingFixtureBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Fixture;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixtureWithFlags;
@@ -28,7 +29,7 @@ use Nelmio\Alice\FixtureBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Fixture\TemplatingFixtureBag
  */
-class TemplatingFixtureBagTest extends \PHPUnit_Framework_TestCase
+class TemplatingFixtureBagTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Generator/Resolver/FixtureSet/RemoveConflictingObjectsResolverTest.php
+++ b/tests/Generator/Resolver/FixtureSet/RemoveConflictingObjectsResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\FixtureSet;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\FixtureBag;
@@ -25,7 +26,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\FixtureSet\RemoveConflictingObjectsResolver
  */
-class RemoveConflictingObjectsResolverTest extends \PHPUnit_Framework_TestCase
+class RemoveConflictingObjectsResolverTest extends TestCase
 {
     public function testIsAFixtureResolver()
     {

--- a/tests/Generator/Resolver/FixtureSet/SimpleFixtureSetResolverTest.php
+++ b/tests/Generator/Resolver/FixtureSet/SimpleFixtureSetResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\FixtureSet;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\FixtureBag;
@@ -29,7 +30,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\FixtureSet\SimpleFixtureSetResolver
  */
-class SimpleFixtureSetResolverTest extends \PHPUnit_Framework_TestCase
+class SimpleFixtureSetResolverTest extends TestCase
 {
     public function testIsAFixtureResolver()
     {

--- a/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Generator\Resolver\FakeParameterResolver;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 use Nelmio\Alice\Parameter;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\Chainable\ArrayParameterResolver
  */
-class ArrayParameterResolverTest extends \PHPUnit_Framework_TestCase
+class ArrayParameterResolverTest extends TestCase
 {
     public function testIsAChainableParameterResolver()
     {

--- a/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\RecursionLimitReachedException;
 use Nelmio\Alice\Generator\Resolver\ChainableParameterResolverInterface;
 use Nelmio\Alice\Generator\Resolver\FakeParameterResolver;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\Chainable\RecursiveParameterResolver
  */
-class RecursiveParameterResolverTest extends \PHPUnit_Framework_TestCase
+class RecursiveParameterResolverTest extends TestCase
 {
     public function testIsAChainableParameterResolver()
     {

--- a/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\ParameterNotFoundException;
 use Nelmio\Alice\Generator\Resolver\FakeParameterResolver;
 use Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StringParameterResolver;
@@ -27,7 +28,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StringParameterResolver
  */
-class StringParameterResolverTest extends \PHPUnit_Framework_TestCase
+class StringParameterResolverTest extends TestCase
 {
     public function testIsAChainableParameterResolver()
     {

--- a/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Generator\Resolver\Parameter\Chainable\DummyChainableParameterResolverAwareResolver;
 use Nelmio\Alice\Generator\Resolver\Parameter\Chainable\FakeChainableParameterResolver;
 use Nelmio\Alice\Parameter;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\ParameterResolverRegistry
  */
-class ParameterResolverRegistryTest extends \PHPUnit_Framework_TestCase
+class ParameterResolverRegistryTest extends TestCase
 {
     public function testIsAParameterResolver()
     {

--- a/tests/Generator/Resolver/Parameter/RemoveConflictingParametersParameterBagResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/RemoveConflictingParametersParameterBagResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Generator\Resolver\FakeParameterBagResolver;
 use Nelmio\Alice\Generator\Resolver\ParameterBagResolverInterface;
 use Nelmio\Alice\ParameterBag;
@@ -21,7 +22,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\RemoveConflictingParametersParameterBagResolver
  */
-class RemoveConflictingParametersParameterBagResolverTest extends \PHPUnit_Framework_TestCase
+class RemoveConflictingParametersParameterBagResolverTest extends TestCase
 {
     public function testIsAParameterBagResolver()
     {

--- a/tests/Generator/Resolver/Parameter/SimpleParameterBagResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/SimpleParameterBagResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Generator\Resolver\FakeParameterResolver;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 use Nelmio\Alice\Parameter;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\SimpleParameterBagResolver
  */
-class SimpleParameterBagResolverTest extends \PHPUnit_Framework_TestCase
+class SimpleParameterBagResolverTest extends TestCase
 {
     public function testIsAParameterBagResolver()
     {

--- a/tests/Generator/Resolver/Parameter/StaticParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/StaticParameterResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Parameter;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StaticParameterResolver;
 use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
@@ -21,7 +22,7 @@ use Nelmio\Alice\Generator\Resolver\ChainableParameterResolverInterface;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StaticParameterResolver
  */
-class StaticParameterResolverTest extends \PHPUnit_Framework_TestCase
+class StaticParameterResolverTest extends TestCase
 {
     public function testIsAChainableParameterResolver()
     {

--- a/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
+++ b/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Loader\NativeLoader;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Generator\Resolver\Parameter\SimpleParameterBagResolver;
@@ -20,7 +21,7 @@ use Nelmio\Alice\Generator\Resolver\Parameter\SimpleParameterBagResolver;
 /**
  * @group integration
  */
-class ParameterResolverIntegrationTest extends \PHPUnit_Framework_TestCase
+class ParameterResolverIntegrationTest extends TestCase
 {
     /**
      * @var SimpleParameterBagResolver

--- a/tests/Generator/Resolver/ResolvingContextTest.php
+++ b/tests/Generator/Resolver/ResolvingContextTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException;
 
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\ResolvingContext
  */
-class ResolvingContextTest extends \PHPUnit_Framework_TestCase
+class ResolvingContextTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/Generator/Resolver/SimpleResolverTest.php
+++ b/tests/Generator/Resolver/SimpleResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\FixtureSet;
@@ -26,7 +27,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\FixtureSet\SimpleFixtureSetResolver
  */
-class SimpleResolverTest extends \PHPUnit_Framework_TestCase
+class SimpleResolverTest extends TestCase
 {
     public function testIsAResolver()
     {

--- a/tests/Generator/Resolver/UniqueValuesPoolTest.php
+++ b/tests/Generator/Resolver/UniqueValuesPoolTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 use Nelmio\Alice\Entity\StdClassFactory;
 
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\UniqueValuesPool
  */
-class UniqueValuesPoolTest extends \PHPUnit_Framework_TestCase
+class UniqueValuesPoolTest extends TestCase
 {
     public function testDoesNotHaveValueIfValueIsNotCached()
     {

--- a/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\DynamicArrayValue;
@@ -29,7 +30,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\DynamicArrayValueResolver
  */
-class DynamicArrayValueResolverTest extends \PHPUnit_Framework_TestCase
+class DynamicArrayValueResolverTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Definition\Value\EvaluatedValue;
@@ -26,7 +27,7 @@ use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\EvaluatedValueResolver
  */
-class EvaluatedValueResolverTest extends \PHPUnit_Framework_TestCase
+class EvaluatedValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
@@ -28,7 +29,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FakerFunctionCallValueResolver
  */
-class FakerFunctionCallValueResolverValueTest extends \PHPUnit_Framework_TestCase
+class FakerFunctionCallValueResolverValueTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
@@ -35,7 +36,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureMethodCallReferenceResolver
  */
-class FixtureMethodCallReferenceResolverTest extends \PHPUnit_Framework_TestCase
+class FixtureMethodCallReferenceResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
@@ -37,7 +38,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FixturePropertyReferenceResolver
  */
-class FixturePropertyReferenceResolverTest extends \PHPUnit_Framework_TestCase
+class FixturePropertyReferenceResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -34,7 +35,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureReferenceResolver
  */
-class FixtureReferenceResolverTest extends \PHPUnit_Framework_TestCase
+class FixtureReferenceResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -33,7 +34,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureWildcardReferenceResolver
  */
-class FixtureWildcardReferenceResolverTest extends \PHPUnit_Framework_TestCase
+class FixtureWildcardReferenceResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
@@ -28,7 +29,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\FunctionCallArgumentResolver
  */
-class FunctionCallArgumentResolverTest extends \PHPUnit_Framework_TestCase
+class FunctionCallArgumentResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\ListValue;
@@ -28,7 +29,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\ListValueResolver
  */
-class ListValueResolverTest extends \PHPUnit_Framework_TestCase
+class ListValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FixturePropertyValue;
@@ -27,7 +28,7 @@ use phpmock\MockBuilder;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\OptionalValueResolver
  */
-class OptionalValueResolverTest extends \PHPUnit_Framework_TestCase
+class OptionalValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\ParameterValue;
@@ -25,7 +26,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\ParameterValueResolver
  */
-class ParameterValueResolverTest extends \PHPUnit_Framework_TestCase
+class ParameterValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
@@ -31,7 +32,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\PhpFunctionCallValueResolver
  */
-class PhpFunctionCallValueResolverTest extends \PHPUnit_Framework_TestCase
+class PhpFunctionCallValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Definition\Value\FakeValue;
@@ -33,7 +34,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\SelfFixtureReferenceResolver
  */
-class SelfFixtureReferenceResolverTest extends \PHPUnit_Framework_TestCase
+class SelfFixtureReferenceResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\UniqueValue;
@@ -30,7 +31,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\UniqueValueResolver
  */
-class UniqueValueResolverTest extends \PHPUnit_Framework_TestCase
+class UniqueValueResolverTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -37,7 +38,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\UnresolvedFixtureReferenceIdResolver
  */
-class UnresolvedFixtureReferenceIdResolverTest extends \PHPUnit_Framework_TestCase
+class UnresolvedFixtureReferenceIdResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\VariableValue;
@@ -25,7 +26,7 @@ use Nelmio\Alice\ParameterBag;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\Chainable\VariableValueResolver
  */
-class VariableValueResolverTest extends \PHPUnit_Framework_TestCase
+class VariableValueResolverTest extends TestCase
 {
     public function testIsAChainableResolver()
     {

--- a/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Object\SimpleObject;
@@ -28,7 +29,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Value\ValueResolverRegistry
  */
-class ValueResolverRegistryTest extends \PHPUnit_Framework_TestCase
+class ValueResolverRegistryTest extends TestCase
 {
     public function testIsAValueResolver()
     {

--- a/tests/IsAServiceTraitTest.php
+++ b/tests/IsAServiceTraitTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\UnclonableException;
 
 /**
  * @covers \Nelmio\Alice\IsAServiceTrait
  */
-class IsAServiceTraitTest extends \PHPUnit_Framework_TestCase
+class IsAServiceTraitTest extends TestCase
 {
     public function testThrowsAnExceptionWhenTryingToCloneInstance()
     {

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Entity\Caller\Dummy;
 use Nelmio\Alice\Entity\DummyWithConstructorParam;
@@ -49,7 +50,7 @@ use Nelmio\Alice\Throwable\InstantiationThrowable;
 /**
  * @group integration
  */
-class LoaderIntegrationTest extends \PHPUnit_Framework_TestCase
+class LoaderIntegrationTest extends TestCase
 {
     const PARSER_FILES_DIR = __DIR__.'/../../fixtures/Parser/files';
     const FIXTURES_FILES_DIR = __DIR__.'/../../fixtures/Integration';

--- a/tests/Loader/NativeLoaderTest.php
+++ b/tests/Loader/NativeLoaderTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Loader\NativeLoader
  */
-class NativeLoaderTest extends \PHPUnit_Framework_TestCase
+class NativeLoaderTest extends TestCase
 {
     /**
      * @expectedException \BadMethodCallException

--- a/tests/Loader/SimpleDataLoaderTest.php
+++ b/tests/Loader/SimpleDataLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\FixtureBuilder\FakeFixtureBuilder;
 use Nelmio\Alice\FixtureBuilderInterface;
@@ -25,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Loader\SimpleDataLoader
  */
-class SimpleDataLoaderTest extends \PHPUnit_Framework_TestCase
+class SimpleDataLoaderTest extends TestCase
 {
     public function testIsADataLoader()
     {

--- a/tests/Loader/SimpleFileLoaderTest.php
+++ b/tests/Loader/SimpleFileLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\ObjectSetFactory;
 use Nelmio\Alice\Parser\FakeParser;
@@ -23,7 +24,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Loader\SimpleFileLoader
  */
-class SimpleFileLoaderTest extends \PHPUnit_Framework_TestCase
+class SimpleFileLoaderTest extends TestCase
 {
     public function testIsALoader()
     {

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Object\CompleteObject;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 
 /**
  * @covers \Nelmio\Alice\ObjectBag
  */
-class ObjectBagTest extends \PHPUnit_Framework_TestCase
+class ObjectBagTest extends TestCase
 {
     /**
      * @var \ReflectionProperty

--- a/tests/ObjectSetTest.php
+++ b/tests/ObjectSetTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\ObjectSet
  */
-class ObjectSetTest extends \PHPUnit_Framework_TestCase
+class ObjectSetTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/ParameterBagTest.php
+++ b/tests/ParameterBagTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\ParameterBag
  */
-class ParameterBagTest extends \PHPUnit_Framework_TestCase
+class ParameterBagTest extends TestCase
 {
     public function testReadAccessorsReturnPropertiesValues()
     {

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Parameter
  */
-class ParameterTest extends \PHPUnit_Framework_TestCase
+class ParameterTest extends TestCase
 {
     /**
      * @dataProvider provideValues

--- a/tests/Parser/Chainable/PhpParserTest.php
+++ b/tests/Parser/Chainable/PhpParserTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Parser\ChainableParserInterface;
 use Nelmio\Alice\Parser\FileListProviderTrait;
 
 /**
  * @covers \Nelmio\Alice\Parser\Chainable\PhpParser
  */
-class PhpParserTest extends \PHPUnit_Framework_TestCase
+class PhpParserTest extends TestCase
 {
     use FileListProviderTrait;
 

--- a/tests/Parser/Chainable/YamlParserTest.php
+++ b/tests/Parser/Chainable/YamlParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\Chainable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Parser\ChainableParserInterface;
 use Nelmio\Alice\Parser\FileListProviderTrait;
 use Nelmio\Alice\Throwable\Exception\Parser\UnparsableFileException;
@@ -23,7 +24,7 @@ use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
 /**
  * @covers \Nelmio\Alice\Parser\Chainable\YamlParser
  */
-class YamlParserTest extends \PHPUnit_Framework_TestCase
+class YamlParserTest extends TestCase
 {
     use FileListProviderTrait;
 

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\IncludeProcessor;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FileLocator\DefaultFileLocator;
 use Nelmio\Alice\FileLocator\FakeFileLocator;
 use Nelmio\Alice\FileLocatorInterface;
@@ -23,7 +24,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Parser\IncludeProcessor\DefaultIncludeProcessor
  */
-class DefaultIncludeProcessorTest extends \PHPUnit_Framework_TestCase
+class DefaultIncludeProcessorTest extends TestCase
 {
     private static $dir;
 

--- a/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
+++ b/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\IncludeProcessor;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Parser\IncludeProcessor\IncludeDataMerger
  */
-class IncludeDataMergerTest extends \PHPUnit_Framework_TestCase
+class IncludeDataMergerTest extends TestCase
 {
     /**
      * @var IncludeDataMerger

--- a/tests/Parser/ParserRegistryTest.php
+++ b/tests/Parser/ParserRegistryTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\ParserInterface;
 use Prophecy\Argument;
 
 /**
  * @covers \Nelmio\Alice\Parser\ParserRegistry
  */
-class ParserRegistryTest extends \PHPUnit_Framework_TestCase
+class ParserRegistryTest extends TestCase
 {
     public function testIsAParser()
     {

--- a/tests/Parser/RuntimeCacheParserTest.php
+++ b/tests/Parser/RuntimeCacheParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException;
 use Nelmio\Alice\FileLocator\FakeFileLocator;
 use Nelmio\Alice\FileLocatorInterface;
@@ -24,7 +25,7 @@ use Prophecy\Argument;
 /**
  * @covers \Nelmio\Alice\Parser\RuntimeCacheParser
  */
-class RuntimeCacheParserTest extends \PHPUnit_Framework_TestCase
+class RuntimeCacheParserTest extends TestCase
 {
     private static $dir;
 

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\PropertyAccess;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Entity\DummyWithPublicProperty;
 use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
@@ -20,7 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 /**
  * @covers \Nelmio\Alice\PropertyAccess\StdPropertyAccessor
  */
-class StdPropertyAccessorTest extends \PHPUnit_Framework_TestCase
+class StdPropertyAccessorTest extends TestCase
 {
     public function testIsAPropertyAccessor()
     {

--- a/tests/Throwable/BuildThrowableTest.php
+++ b/tests/Throwable/BuildThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootBuildException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\BuildThrowable
  */
-class BuildThrowableTest extends \PHPUnit_Framework_TestCase
+class BuildThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/DenormalizationThrowableTest.php
+++ b/tests/Throwable/DenormalizationThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootDenormalizationException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\DenormalizationThrowable
  */
-class DenormalizationThrowableTest extends \PHPUnit_Framework_TestCase
+class DenormalizationThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/Exception/BadMethodCallExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/BadMethodCallExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\BadMethodCallExceptionFactory
  */
-class BadMethodCallExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class BadMethodCallExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForUnknownMethod()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerExceptionFactory
  */
-class DenormalizerExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class DenormalizerExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForUndenormalizableConstructor()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\DenormalizationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerNotFoundException
  */
-class DenormalizerNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class DenormalizerNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserExceptionFactory
  */
-class FlagParserExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class FlagParserExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/FlagParser/FlagParserNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\DenormalizationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException
  */
-class FlagParserNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class FlagParserNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/InvalidScopeExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/InvalidScopeExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\DenormalizationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\InvalidScopeException
  */
-class InvalidScopeExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidScopeExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/UnexpectedValueExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/UnexpectedValueExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\DenormalizationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
  */
-class UnexpectedValueExceptionTest extends \PHPUnit_Framework_TestCase
+class UnexpectedValueExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ExpressionLanguageExceptionFactoryFactoryTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ExpressionLanguageExceptionFactoryFactoryTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ExpressionLanguageExceptionFactory
  */
-class ExpressionLanguageExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ExpressionLanguageExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForNoParserFoundForToken()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/LexExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/LexExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\LexException
  */
-class LexExceptionTest extends \PHPUnit_Framework_TestCase
+class LexExceptionTest extends TestCase
 {
     public function testIsAnException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/MalformedFunctionExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/MalformedFunctionExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\MalformedFunctionException
  */
-class MalformedFunctionExceptionTest extends \PHPUnit_Framework_TestCase
+class MalformedFunctionExceptionTest extends TestCase
 {
     public function testIsAnInvalidArgumentException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ParseExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ParseExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
  */
-class ParseExceptionTest extends \PHPUnit_Framework_TestCase
+class ParseExceptionTest extends TestCase
 {
     public function testIsAnException()
     {

--- a/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/ExpressionLanguage/ParserNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
  */
-class ParserNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ParserNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/FixtureNotFoundExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/FixtureNotFoundExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureNotFoundExceptionFactory
  */
-class FixtureNotFoundExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class FixtureNotFoundExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/FixtureNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/FixtureNotFoundExceptionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\FixtureNotFoundException
  */
-class FixtureNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class FixtureNotFoundExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Context/CachedValueNotFoundTest.php
+++ b/tests/Throwable/Exception/Generator/Context/CachedValueNotFoundTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Context;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Context\CachedValueNotFound
  */
-class CachedValueNotFoundTest extends \PHPUnit_Framework_TestCase
+class CachedValueNotFoundTest extends TestCase
 {
     public function testTestCreate()
     {

--- a/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactoryTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Property;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Hydrator\HydrationExceptionFactory
  */
-class HydrationExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class HydrationExceptionFactoryTest extends TestCase
 {
     public function testTestCreate()
     {

--- a/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Hydrator\HydrationException
  */
-class HydrationExceptionTest extends \PHPUnit_Framework_TestCase
+class HydrationExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Hydrator/InaccessiblePropertyExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/InaccessiblePropertyExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Hydrator\InaccessiblePropertyException
  */
-class InaccessiblePropertyExceptionTest extends \PHPUnit_Framework_TestCase
+class InaccessiblePropertyExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Hydrator/InvalidArgumentExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/InvalidArgumentExceptionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Throwable\HydrationThrowable;
@@ -20,7 +21,7 @@ use Nelmio\Alice\Throwable\HydrationThrowable;
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Hydrator\InvalidArgumentException
  */
-class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Hydrator/NoSuchPropertyExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/NoSuchPropertyExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Hydrator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Hydrator\NoSuchPropertyException
  */
-class NoSuchPropertyExceptionTest extends \PHPUnit_Framework_TestCase
+class NoSuchPropertyExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Instantiator/InstantiationExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Instantiator/InstantiationExceptionFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
@@ -21,7 +22,7 @@ use Nelmio\Alice\Throwable\InstantiationThrowable;
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationExceptionFactory
  */
-class InstantiationExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class InstantiationExceptionFactoryTest extends TestCase
 {
     public function testTestCreate()
     {

--- a/tests/Throwable/Exception/Generator/Instantiator/InstantiationExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Instantiator/InstantiationExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
  */
-class InstantiationExceptionTest extends \PHPUnit_Framework_TestCase
+class InstantiationExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Instantiator/InstantiatorNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Instantiator/InstantiatorNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Instantiator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiatorNotFoundException
  */
-class InstantiatorNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class InstantiatorNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator\ObjectGeneratorNotFoundExceptionFactory
  */
-class ObjectGeneratorNotFoundExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ObjectGeneratorNotFoundExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/ObjectGenerator/ObjectGeneratorNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator\ObjectGeneratorNotFoundException
  */
-class ObjectGeneratorNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ObjectGeneratorNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/CircularReferenceExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/CircularReferenceExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceExceptionFactory
  */
-class CircularReferenceExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class CircularReferenceExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/CircularReferenceExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/CircularReferenceExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException
  */
-class CircularReferenceExceptionTest extends \PHPUnit_Framework_TestCase
+class CircularReferenceExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/NoSuchPropertyExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/NoSuchPropertyExceptionFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Definition\Value\FakeValue;
@@ -21,7 +22,7 @@ use Nelmio\Alice\Definition\Value\FixturePropertyValue;
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\NoSuchPropertyExceptionFactory
  */
-class NoSuchPropertyExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class NoSuchPropertyExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForFixture()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/NoSuchPropertyExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/NoSuchPropertyExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\NoSuchPropertyException
  */
-class NoSuchPropertyExceptionTest extends \PHPUnit_Framework_TestCase
+class NoSuchPropertyExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/RecursionLimitReachedExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/RecursionLimitReachedExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\RecursionLimitReachedExceptionFactory
  */
-class RecursionLimitReachedExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class RecursionLimitReachedExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/RecursionLimitReachedExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/RecursionLimitReachedExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\RecursionLimitReachedException
  */
-class RecursionLimitReachedExceptionTest extends \PHPUnit_Framework_TestCase
+class RecursionLimitReachedExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/ResolverNotFoundExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/ResolverNotFoundExceptionFactoryTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\DummyValue;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptionFactory
  */
-class ResolverNotFoundExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ResolverNotFoundExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactoryForParameter()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/ResolverNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/ResolverNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
  */
-class ResolverNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ResolverNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedExceptionFactoryTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedExceptionFactory
  */
-class UniqueValueGenerationLimitReachedExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class UniqueValueGenerationLimitReachedExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UniqueValueGenerationLimitReachedExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException
  */
-class UniqueValueGenerationLimitReachedExceptionTest extends \PHPUnit_Framework_TestCase
+class UniqueValueGenerationLimitReachedExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueDuringGenerationExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueDuringGenerationExceptionFactoryTest.php
@@ -13,12 +13,13 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationExceptionFactory
  */
-class UnresolvableValueDuringGenerationExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class UnresolvableValueDuringGenerationExceptionFactoryTest extends TestCase
 {
     public function testTestCreateFromResolutionThrowable()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueDuringGenerationExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueDuringGenerationExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException
  */
-class UnresolvableValueDuringGenerationExceptionTest extends \PHPUnit_Framework_TestCase
+class UnresolvableValueDuringGenerationExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueExceptionFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Value\DummyValue;
 use Nelmio\Alice\Definition\Value\OptionalValue;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
@@ -20,7 +21,7 @@ use Nelmio\Alice\Throwable\ResolutionThrowable;
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueExceptionFactory
  */
-class UnresolvableValueExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class UnresolvableValueExceptionFactoryTest extends TestCase
 {
     public function testTestCreate()
     {

--- a/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueExceptionTest.php
+++ b/tests/Throwable/Exception/Generator/Resolver/UnresolvableValueExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Generator\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ResolutionThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
  */
-class UnresolvableValueExceptionTest extends \PHPUnit_Framework_TestCase
+class UnresolvableValueExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/InvalidArgumentExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/InvalidArgumentExceptionFactoryTest.php
@@ -13,13 +13,14 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\FlagBag;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory
  */
-class InvalidArgumentExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForInvalidReferenceType()
     {

--- a/tests/Throwable/Exception/LogicExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/LogicExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\LogicExceptionFactory
  */
-class LogicExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class LogicExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForUncallableMethod()
     {

--- a/tests/Throwable/Exception/NoValueForCurrentExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/NoValueForCurrentExceptionFactoryTest.php
@@ -13,12 +13,13 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\NoValueForCurrentExceptionFactory
  */
-class NoValueForCurrentExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class NoValueForCurrentExceptionFactoryTest extends TestCase
 {
     public function testTestCreateException()
     {

--- a/tests/Throwable/Exception/NoValueForCurrentExceptionTest.php
+++ b/tests/Throwable/Exception/NoValueForCurrentExceptionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\NoValueForCurrentException
  */
-class NoValueForCurrentExceptionTest extends \PHPUnit_Framework_TestCase
+class NoValueForCurrentExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/ObjectNotFoundExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/ObjectNotFoundExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\ObjectNotFoundExceptionFactory
  */
-class ObjectNotFoundExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ObjectNotFoundExceptionFactoryTest extends TestCase
 {
     public function testTestCreateNewExceptionWithFactory()
     {

--- a/tests/Throwable/Exception/ObjectNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/ObjectNotFoundExceptionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\ObjectNotFoundException
  */
-class ObjectNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ObjectNotFoundExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/ParameterNotFoundExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/ParameterNotFoundExceptionFactoryTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Parameter;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\ParameterNotFoundExceptionFactory
  */
-class ParameterNotFoundExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ParameterNotFoundExceptionFactoryTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/ParameterNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/ParameterNotFoundExceptionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\ParameterNotFoundException
  */
-class ParameterNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ParameterNotFoundExceptionTest extends TestCase
 {
     public function testIsARuntimeException()
     {

--- a/tests/Throwable/Exception/Parser/ParseExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Parser/ParseExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Parser;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Parser\ParseExceptionFactory
  */
-class ParseExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class ParseExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForParserNoFoundForFile()
     {

--- a/tests/Throwable/Exception/Parser/ParserNotFoundExceptionTest.php
+++ b/tests/Throwable/Exception/Parser/ParserNotFoundExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException
  */
-class ParserNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ParserNotFoundExceptionTest extends TestCase
 {
     public function testIsALogicException()
     {

--- a/tests/Throwable/Exception/Parser/UnparsableFileExceptionTest.php
+++ b/tests/Throwable/Exception/Parser/UnparsableFileExceptionTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable\Exception\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\ParseThrowable;
 
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\Parser\UnparsableFileException
  */
-class UnparsableFileExceptionTest extends \PHPUnit_Framework_TestCase
+class UnparsableFileExceptionTest extends TestCase
 {
     public function testIsAnException()
     {

--- a/tests/Throwable/Exception/PropertyAccess/NoSuchPropertyExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/PropertyAccess/NoSuchPropertyExceptionFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\PropertyAccess;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\PropertyAccess\NoSuchPropertyExceptionFactory
  */
-class NoSuchPropertyExceptionFactoryTest extends \PHPUnit_Framework_TestCase
+class NoSuchPropertyExceptionFactoryTest extends TestCase
 {
     public function testTestCreateForUnreadablePropertyFromStdClass()
     {

--- a/tests/Throwable/Exception/UnclonableExceptionTest.php
+++ b/tests/Throwable/Exception/UnclonableExceptionTest.php
@@ -13,10 +13,12 @@ declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Nelmio\Alice\Throwable\Exception\UnclonableException
  */
-class UnclonableExceptionTest extends \PHPUnit_Framework_TestCase
+class UnclonableExceptionTest extends TestCase
 {
     public function testIsADomainException()
     {

--- a/tests/Throwable/ExpressionLanguageParseThrowableTest.php
+++ b/tests/Throwable/ExpressionLanguageParseThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootExpressionLanguageParseException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\ExpressionLanguageParseThrowable
  */
-class ExpressionLanguageParseThrowableTest extends \PHPUnit_Framework_TestCase
+class ExpressionLanguageParseThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/GenerationThrowableTest.php
+++ b/tests/Throwable/GenerationThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootGenerationException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\GenerationThrowable
  */
-class GenerationThrowableTest extends \PHPUnit_Framework_TestCase
+class GenerationThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/InstantiationThrowableTest.php
+++ b/tests/Throwable/InstantiationThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootInstantiationException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\InstantiationThrowable
  */
-class InstantiationThrowableTest extends \PHPUnit_Framework_TestCase
+class InstantiationThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/ParseThrowableTest.php
+++ b/tests/Throwable/ParseThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootParseException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\ParseThrowable
  */
-class ParseThrowableTest extends \PHPUnit_Framework_TestCase
+class ParseThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {

--- a/tests/Throwable/ResolutionThrowableTest.php
+++ b/tests/Throwable/ResolutionThrowableTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Throwable;
 
+use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 
 /**
  * @covers \Nelmio\Alice\Throwable\ResolutionThrowable
  */
-class ResolutionThrowableTest extends \PHPUnit_Framework_TestCase
+class ResolutionThrowableTest extends TestCase
 {
     public function testIsABuildThrowable()
     {


### PR DESCRIPTION
After these changes the project is compatible with PHPUnit 6.0.
The symfony/phpunit-bridge however is still not compatible, so
the version requirement in the composer.json is not elevated to
^6.0 yet. As soon as symfony fixes their bridge this can be done.