### PR TITLE
Prepare for PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     "require": {
         "php": "^5.6||^7.0",
         "fzaninotto/faker": "^1.5",
-        "symfony/yaml": "^2.0||^3.0",
-        "phpunit/phpunit": "^5.6"
+        "symfony/yaml": "^2.0||^3.0"
     },
     "require-dev": {
         "doctrine/common": "^2.3",
         "symfony/phpunit-bridge": "^3.0",
         "symfony/property-access": "^2.2||^3.0",
-        "phpspec/prophecy": "^1.5.0"
+        "phpspec/prophecy": "^1.5.0",
+        "phpunit/phpunit": "^5.6||^6.0"
     },
     "autoload": {
         "psr-4": { "Nelmio\\Alice\\": "src/Nelmio/Alice" }

--- a/tests/Nelmio/Alice/Fixtures/Builder/BuilderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/BuilderTest.php
@@ -14,12 +14,13 @@ namespace Nelmio\Alice\Fixtures\Builder;
 use Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface;
 use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\Fixtures\Loader;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
- * @covers Nelmio\Alice\Fixtures\Builder\Builder
+ * @covers \Nelmio\Alice\Fixtures\Builder\Builder
  */
-class BuilderTest extends \PHPUnit_Framework_TestCase
+class BuilderTest extends TestCase
 {
     use BuilderProviderTrait;
 
@@ -180,7 +181,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     public function testReturnsNullWhenCannotBuildAFixture()
     {
         $builder = new Builder([]);
-        $builder->build('Dummy', 'dummy', []);
+        $this->assertNull($builder->build('Dummy', 'dummy', []));
     }
 }
 

--- a/tests/Nelmio/Alice/Fixtures/Builder/FixtureParserTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/FixtureParserTest.php
@@ -12,8 +12,9 @@
 namespace Nelmio\Alice\Fixtures\Parser;
 
 use Nelmio\Alice\support\extensions\CustomParser;
+use PHPUnit\Framework\TestCase;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     /**
      * @var Parser

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/ListNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/ListNameTest.php
@@ -12,7 +12,7 @@
 namespace Nelmio\Alice\Fixtures\Builder\Methods;
 
 /**
- * @covers Nelmio\Alice\Fixtures\Builder\Methods\ListName
+ * @covers \Nelmio\Alice\Fixtures\Builder\Methods\ListName
  */
 class ListNameTest extends MethodTestCase
 {

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/MethodTestCase.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/MethodTestCase.php
@@ -12,8 +12,9 @@
 namespace Nelmio\Alice\Fixtures\Builder\Methods;
 
 use Nelmio\Alice\Fixtures\Builder\BuilderProviderTrait;
+use PHPUnit\Framework\TestCase;
 
-abstract class MethodTestCase extends \PHPUnit_Framework_TestCase
+abstract class MethodTestCase extends TestCase
 {
     use BuilderProviderTrait;
 

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/RangeNameTest.php
@@ -12,7 +12,7 @@
 namespace Nelmio\Alice\Fixtures\Builder\Methods;
 
 /**
- * @covers Nelmio\Alice\Fixtures\Builder\Methods\RangeName
+ * @covers \Nelmio\Alice\Fixtures\Builder\Methods\RangeName
  */
 class RangeNameTest extends MethodTestCase
 {

--- a/tests/Nelmio/Alice/Fixtures/Builder/Methods/SimpleNameTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Builder/Methods/SimpleNameTest.php
@@ -12,7 +12,7 @@
 namespace Nelmio\Alice\Fixtures\Builder\Methods;
 
 /**
- * @covers Nelmio\Alice\Fixtures\Builder\Methods\SimpleName
+ * @covers \Nelmio\Alice\Fixtures\Builder\Methods\SimpleName
  */
 class SimpleNameTest extends MethodTestCase
 {

--- a/tests/Nelmio/Alice/Fixtures/FixtureTest.php
+++ b/tests/Nelmio/Alice/Fixtures/FixtureTest.php
@@ -11,7 +11,9 @@
 
 namespace Nelmio\Alice\Fixtures;
 
-class FixtureTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FixtureTest extends TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
     const STATIC_USER = 'Nelmio\Alice\support\models\StaticUser';

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\Alice\Fixtures;
 
+use Nelmio\Alice\support\extensions;
 use Nelmio\Alice\support\extensions\FakerProviderWithRequiredParameter;
 use Nelmio\Alice\support\models\DummyWithVariadicConstructor;
 use Nelmio\Alice\support\models\Group;
@@ -19,9 +20,9 @@ use Nelmio\Alice\support\models\typehint\Dummy;
 use Nelmio\Alice\support\models\typehint\DummyWithInterface;
 use Nelmio\Alice\support\models\typehint\RelatedDummy;
 use Nelmio\Alice\support\models\User;
-use Nelmio\Alice\support\extensions;
+use PHPUnit\Framework\TestCase;
 
-class LoaderTest extends \PHPUnit_Framework_TestCase
+class LoaderTest extends TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
     const MAGIC_USER = 'Nelmio\Alice\support\models\MagicUser';
@@ -107,7 +108,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadUnparsableFile()
     {
         $file = __DIR__.'/../support/fixtures/not-parsable';
-        $this->setExpectedException(
+        $this->expectException(
             '\UnexpectedValueException',
             sprintf('%s cannot be parsed - no parser exists that can handle it.', $file)
         );
@@ -181,7 +182,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadInvalidFile()
     {
         $file = __DIR__.'/../support/fixtures/invalid.php';
-        $this->setExpectedException(
+        $this->expectException(
             '\UnexpectedValueException',
             sprintf('Included file "%s" must return an array of data', $file)
         );

--- a/tests/Nelmio/Alice/Fixtures/Parser/Methods/PhpTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Methods/PhpTest.php
@@ -13,9 +13,10 @@ namespace Nelmio\Alice\Fixtures\Parser\Methods;
 
 use Nelmio\Alice\Fixtures\Loader;
 use Nelmio\Alice\Fixtures\Parser\Methods\Php as PhpParser;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class PhpTest extends \PHPUnit_Framework_TestCase
+class PhpTest extends TestCase
 {
     private static $dir;
 

--- a/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
@@ -13,9 +13,10 @@ namespace Nelmio\Alice\Fixtures\Parser\Methods;
 
 use Nelmio\Alice\Fixtures\Loader;
 use Nelmio\Alice\Fixtures\Parser\Methods\Yaml as YamlParser;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class YamlTest extends \PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     private static $dir;
 

--- a/tests/Nelmio/Alice/Fixtures/PropertyDefinitionTest.php
+++ b/tests/Nelmio/Alice/Fixtures/PropertyDefinitionTest.php
@@ -11,7 +11,9 @@
 
 namespace Nelmio\Alice\Fixtures;
 
-class PropertyDefinitionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PropertyDefinitionTest extends TestCase
 {
     public function testWillParseFlagsOutOfName()
     {

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -15,8 +15,9 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\support\models\User;
+use PHPUnit\Framework\TestCase;
 
-class FixturesTest extends \PHPUnit_Framework_TestCase
+class FixturesTest extends TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
     const GROUP = 'Nelmio\Alice\support\models\Group';
@@ -249,7 +250,7 @@ class FixturesTest extends \PHPUnit_Framework_TestCase
         $om->expects($this->any())
             ->method('find')->will($this->returnValue(new User()));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\InvalidArgumentException',
             'The provider should be a string or an object, got array instead'
         );

--- a/tests/Nelmio/Alice/Instances/Instantiator/InstantiatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Instantiator/InstantiatorTest.php
@@ -13,8 +13,9 @@ namespace Nelmio\Alice\Instances\Instantiator;
 
 use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\support\extensions\CustomInstantiator;
+use PHPUnit\Framework\TestCase;
 
-class InstantiatorTest extends \PHPUnit_Framework_TestCase
+class InstantiatorTest extends TestCase
 {
     const USER = 'Nelmio\Alice\support\models\User';
 

--- a/tests/Nelmio/Alice/Instances/Instantiator/Methods/EmptyConstructorInstantiatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Instantiator/Methods/EmptyConstructorInstantiatorTest.php
@@ -12,11 +12,12 @@
 namespace Nelmio\Alice\Instances\Instantiator\Methods;
 
 use Nelmio\Alice\Fixtures\Fixture;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Nelmio\Alice\Instances\Instantiator\Methods\EmptyConstructor
+ * @covers \Nelmio\Alice\Instances\Instantiator\Methods\EmptyConstructor
  */
-class EmptyConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
+class EmptyConstructorInstantiatorTest extends TestCase
 {
     /**
      * @var EmptyConstructor

--- a/tests/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructorInstantiatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructorInstantiatorTest.php
@@ -11,10 +11,12 @@
 
 namespace Nelmio\Alice\Instances\Instantiator\Methods;
 
+use PHPUnit\Framework\TestCase;
+
 /**
- * @covers Nelmio\Alice\Instances\Instantiator\Methods\ReflectionWithConstructor
+ * @covers \Nelmio\Alice\Instances\Instantiator\Methods\ReflectionWithConstructor
  */
-class ReflectionWithConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
+class ReflectionWithConstructorInstantiatorTest extends TestCase
 {
     public function testIsAnInstantiatorMethod()
     {

--- a/tests/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructorInstantiatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructorInstantiatorTest.php
@@ -19,11 +19,12 @@ use Nelmio\Alice\Instances\Instantiator\DummyClasses\DummyWithOptionalParameterI
 use Nelmio\Alice\Instances\Instantiator\DummyClasses\DummyWithPrivateConstructor;
 use Nelmio\Alice\Instances\Instantiator\DummyClasses\DummyWithProtectedConstructor;
 use Nelmio\Alice\Instances\Instantiator\DummyClasses\DummyWithRequiredParameterInConstructor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Nelmio\Alice\Instances\Instantiator\Methods\ReflectionWithoutConstructor
  */
-class ReflectionWithoutConstructorInstantiatorTest extends \PHPUnit_Framework_TestCase
+class ReflectionWithoutConstructorInstantiatorTest extends TestCase
 {
     /**
      * @var ReflectionWithoutConstructor

--- a/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
+++ b/tests/Nelmio/Alice/Instances/Populator/Methods/DirectTest.php
@@ -23,12 +23,13 @@ use Nelmio\Alice\Instances\Populator\Fixtures\Direct\PublicDummy;
 use Nelmio\Alice\Instances\Populator\Fixtures\Direct\SimpleCamelCaseDummy;
 use Nelmio\Alice\Instances\Populator\Fixtures\Direct\SimpleSnakeCaseDummy;
 use Nelmio\Alice\Util\TypeHintChecker;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
- * @covers Nelmio\Alice\Instances\Populator\Methods\Direct
+ * @covers \Nelmio\Alice\Instances\Populator\Methods\Direct
  */
-class DirectTest extends \PHPUnit_Framework_TestCase
+class DirectTest extends TestCase
 {
     /**
      * @var Fixture

--- a/tests/Nelmio/Alice/Instances/Populator/PopulatorTest.php
+++ b/tests/Nelmio/Alice/Instances/Populator/PopulatorTest.php
@@ -11,16 +11,17 @@
 
 namespace Nelmio\Alice\Instances\Populator;
 
+use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\Fixtures\ParameterBag;
 use Nelmio\Alice\Instances\Collection;
-use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\Instances\Populator\Methods\ArrayAdd;
 use Nelmio\Alice\Instances\Populator\Methods\Property;
 use Nelmio\Alice\Instances\Processor\Processor;
 use Nelmio\Alice\support\extensions\CustomPopulator;
 use Nelmio\Alice\Util\TypeHintChecker;
+use PHPUnit\Framework\TestCase;
 
-class PopulatorTest extends \PHPUnit_Framework_TestCase
+class PopulatorTest extends TestCase
 {
     const CONTACT = 'Nelmio\Alice\support\models\Contact';
     const PLURAL = 'Nelmio\Alice\support\models\PluralProperties';

--- a/tests/Nelmio/Alice/Instances/Processor/Methods/FakerTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/Methods/FakerTest.php
@@ -12,24 +12,14 @@
 namespace Nelmio\Alice\Instances\Processor\Methods;
 
 use Nelmio\Alice\FooProvider;
+use PHPUnit\Framework\TestCase;
 
-class FakerTest extends \PHPUnit_Framework_TestCase
+class FakerTest extends TestCase
 {
-    const USER = 'Nelmio\Alice\support\models\User';
-    const MAGIC_USER = 'Nelmio\Alice\support\models\MagicUser';
-    const GROUP = 'Nelmio\Alice\support\models\Group';
-    const CONTACT = 'Nelmio\Alice\support\models\Contact';
-
-    protected $persister;
-
-    /**
-     * @var \Nelmio\Alice\Fixtures\Loader
-     */
-    protected $loader;
-
     public function testAddProvider()
     {
         $faker = new Faker([]);
         $faker->addProvider(new FooProvider());
+        $this->assertSame('foo_bar', $faker->fake('foo', null, '_bar'));
     }
 }

--- a/tests/Nelmio/Alice/Instances/Processor/Methods/ParameterizedTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/Methods/ParameterizedTest.php
@@ -13,11 +13,12 @@ namespace Nelmio\Alice\Instances\Processor\Methods;
 
 use Nelmio\Alice\Fixtures\ParameterBag;
 use Nelmio\Alice\Instances\Processor\Processable;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Nelmio\Alice\Instances\Processor\Methods\Parameterized
+ * @covers \Nelmio\Alice\Instances\Processor\Methods\Parameterized
  */
-class ParameterizedTest extends \PHPUnit_Framework_TestCase
+class ParameterizedTest extends TestCase
 {
     /**
      * @var Parameterized

--- a/tests/Nelmio/Alice/Instances/Processor/Methods/ReferenceTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/Methods/ReferenceTest.php
@@ -12,11 +12,12 @@
 namespace Nelmio\Alice\Instances\Processor\Methods;
 
 use Nelmio\Alice\Instances\Processor\Processable;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Nelmio\Alice\Instances\Processor\Methods\Reference
+ * @covers \Nelmio\Alice\Instances\Processor\Methods\Reference
  */
-class ReferenceTest extends \PHPUnit_Framework_TestCase
+class ReferenceTest extends TestCase
 {
     /**
      * @var Reference

--- a/tests/Nelmio/Alice/Instances/Processor/ProcessableTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/ProcessableTest.php
@@ -11,7 +11,9 @@
 
 namespace Nelmio\Alice\Instances\Processor;
 
-class ProcessableTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ProcessableTest extends TestCase
 {
     public function testValueMatchesWillReturnIfTheProcessablesValueMatchesAGivenRegex()
     {

--- a/tests/Nelmio/Alice/Instances/Processor/ProcessorTest.php
+++ b/tests/Nelmio/Alice/Instances/Processor/ProcessorTest.php
@@ -11,11 +11,12 @@
 
 namespace Nelmio\Alice\Instances\Processor;
 
-use Nelmio\Alice\Instances\Collection;
 use Nelmio\Alice\Fixtures\ParameterBag;
+use Nelmio\Alice\Instances\Collection;
 use Nelmio\Alice\support\extensions\CustomProcessor;
+use PHPUnit\Framework\TestCase;
 
-class ProcessorTest extends \PHPUnit_Framework_TestCase
+class ProcessorTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Nelmio/Alice/ReferenceRangeNameTest.php
+++ b/tests/Nelmio/Alice/ReferenceRangeNameTest.php
@@ -15,10 +15,11 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\support\models\Group;
-use Nelmio\Alice\support\models\User;
 use Nelmio\Alice\support\models\Task;
+use Nelmio\Alice\support\models\User;
+use PHPUnit\Framework\TestCase;
 
-class ReferenceRangeNameTest extends \PHPUnit_Framework_TestCase
+class ReferenceRangeNameTest extends TestCase
 {
     /**
      * @expectedException \UnexpectedValueException

--- a/tests/Nelmio/Alice/Util/TypeHintCheckerTest.php
+++ b/tests/Nelmio/Alice/Util/TypeHintCheckerTest.php
@@ -12,8 +12,9 @@
 namespace Nelmio\Alice\Util;
 
 use Nelmio\Alice\TestPersister;
+use PHPUnit\Framework\TestCase;
 
-class TypeHintCheckerTest extends \PHPUnit_Framework_TestCase
+class TypeHintCheckerTest extends TestCase
 {
     const DYNAMIC_CONSTRUCTOR_CLASS = 'Nelmio\Alice\support\models\DynamicConstructorClass';
 

--- a/tests/Nelmio/Alice/support/extensions/CustomBuilder.php
+++ b/tests/Nelmio/Alice/support/extensions/CustomBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Nelmio\Alice\support\extensions;
 
-use Nelmio\Alice\Fixtures\Fixture;
 use Nelmio\Alice\Fixtures\Builder\Methods\MethodInterface as BuilderInterface;
+use Nelmio\Alice\Fixtures\Fixture;
 
 class CustomBuilder implements BuilderInterface
 {


### PR DESCRIPTION
* Made PHPUnit a dev requirement (no dependencies on PHPUnit in the src folder)
* Allow for installing PHPUnit 6
* As Soon as the Symfony PHPunit bridge is released you'll get 6 on PHP 7.0
* Made @covers use FQCN's (as is the case in master)
* Removed old mock framework calls
* Added testcases for the only 2 tests marked as Risky by PHPUnit 6