### PR TITLE
Prepare for PHP7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - nightly
 
 matrix:
   fast_finish: true
@@ -33,8 +32,13 @@ matrix:
       env: SYMFONY_VERSION='~3.2.0'
     - php: '7.1'
       env: SYMFONY_VERSION='~3.3.0@dev'
+    - php: 'nightly'
+      env:
+        - COMPOSER_FLAGS='--ignore-platform-reqs'
+        - SYMFONY_DEPRECATIONS_HELPER='weak'
+        - SYMFONY_VERSION='~3.3.0@dev'
   allow_failures:
-    - php: nightly
+    - php: 'nightly'
     - env: SYMFONY_VERSION='~3.3.0@dev'
 
 install:

--- a/src/Nelmio/Alice/Fixtures/Fixture.php
+++ b/src/Nelmio/Alice/Fixtures/Fixture.php
@@ -368,19 +368,25 @@ class Fixture
             throw new \UnexpectedValueException("The __construct call in object '{$this}' must be defined as an array of arguments or false to bypass it");
         }
 
-        list($method, $args) = each($constructorValue);
-        if ($method !== 0) {
-            if (!is_callable([$this->class, $method])) {
-                throw new \UnexpectedValueException("Cannot call static method '{$method}' on class '{$this->class}' as a constructor for object '{$this}'");
-            }
-            if (!is_array($args)) {
-                throw new \UnexpectedValueException("The static '{$method}' call in object '{$this}' must be given an array");
+        foreach ($constructorValue as $method => $args) {
+            if ($method !== 0) {
+                if (!is_callable([$this->class, $method])) {
+                    throw new \UnexpectedValueException(
+                        "Cannot call static method '{$method}' on class '{$this->class}' as a constructor for object '{$this}'"
+                    );
+                }
+
+                if (!is_array($args)) {
+                    throw new \UnexpectedValueException(
+                        "The static '{$method}' call in object '{$this}' must be given an array"
+                    );
+                }
+
+                return ['method' => $method, 'args' => $args];
             }
 
-            return ['method' => $method, 'args' => $args];
+            return ['method' => '__construct', 'args' => $constructorValue];
         }
-
-        return ['method' => '__construct', 'args' => $constructorValue];
     }
 
     /**


### PR DESCRIPTION
* Run composer with --ignore-platform-reqs for nightly
* Run composer with weak deprecation warnings (PHPUnint still uses each())
* Rewrote usage of each() (which is deprecated in PHP7.2)
* `preg_match` returns `NULL` instead of `''` since PHP7.2