### PR TITLE
[Needs help] Replace in-house lexer by HoaCompiler

### DIFF
--- a/Alice.pp
+++ b/Alice.pp
@@ -1,0 +1,62 @@
+//
+// LEXEMES
+//
+%token true true
+%token false false
+%token null null
+%token escape_token \\
+%token string .+
+
+
+//
+// RULES
+//
+value:
+    string()
+
+string:
+    ::escape_token:: <string> | <escape_token> | <string>
+
+//
+//
+//
+//
+//
+//
+//%skip   space          \s
+//// Scalars.
+//%token  true           true
+//%token  false          false
+//%token  null           null
+//// Strings.
+//%token  quote_         <{        -> string
+//%token  string:string  [^"]+
+//%token  string:_quote  }>        -> default
+//// Objects.
+//%token  brace_         {
+//%token _brace          }
+//// Arrays.
+//%token  bracket_       \[
+//%token _bracket        \]
+//// Rest.
+//%token  colon          :
+//%token  comma          ,
+//%token  number         \d+
+//
+//value:
+//    <true> | <false> | <null> | string() | object() | array() | number()
+//
+//string:
+//    ::quote_:: <string> ::_quote::
+//
+//number:
+//    <number>
+//
+//#object:
+//    ::brace_:: pair() ( ::comma:: pair() )* ::_brace::
+//
+//#pair:
+//    string() ::colon:: value()
+//
+//#array:
+//    ::bracket_:: value() ( ::comma:: value() )* ::_bracket::

--- a/Alice.pp
+++ b/Alice.pp
@@ -1,62 +1,163 @@
-//
-// LEXEMES
-//
-%token true true
-%token false false
-%token null null
-%token escape_token \\
-%token string .+
+// All whitespaces matter, except the trailing ones.
+%skip  trailing_whitespaces    \s+$
+
+// An opening chevron must not be escaped by a backslash.
+// Matching an opening chevron changes the namespace from `default` to
+// `parameter`.
+%token opening_chevron    (?<!\\)<    -> parameter
+
+// All whitespaces.
+%skip parameter:whitespaces    \s+
+
+// A closing chevron.
+// Matching an closing chevron changes the namespace from `parameter`
+// to `default`.
+%token parameter:closing_chevron    >    -> __shift__
+
+// A variable opening.
+%token parameter:opening_variable    {    -> variable
+
+// All whitespaces.
+%skip variable:whitespaces    \s+
+
+// An expansion list separator.
+%token variable:comma    ,
+
+// A range separator
+%token variable:range    \.\.
+
+// A range bound.
+%token variable:number    [+-]?[0-9]+
+
+// A variable name can be anything except `}`.
+%token variable:name    [_\w][_\w\d]*
+
+// A variable closing.
+%token variable:closing_variable    }    -> __shift__
+
+// Opening parenthesis.
+%token parameter:opening_parenthesis    \(
+
+// Closing parenthesis.
+%token parameter:closing_parenthesis    \)
+
+// Constant string.
+%token parameter:string    ("|')(.*?)(?<!\\)\1
+
+// A comma used to separate items in a list.
+%token parameter:comma    ,
+
+// A variable or a function name.
+%token parameter:name    [_\w][_\w\d]*
 
 
-//
-// RULES
-//
-value:
-    string()
+// A reference is prefixed by an `@`.
+%token at    @    -> reference
 
-string:
-    ::escape_token:: <string> | <escape_token> | <string>
+// A star is a glob operator.
+%token reference:star    \*    -> __shift__
 
+// A left curly bracket introduces an expansion.
+%token reference:opening_expansion    {    -> expansion
+
+// All whitespaces.
+%skip expansion:whitespaces    \s+
+
+// A number can be signed or not.
+%token expansion:number    [-+]?[0-9]+
+
+// A range is represented by two dots.
+%token expansion:range    \.\.
+
+// A comma is the name separator.
+%token expansion:comma    ,
+
+// A reference expansion name is just like a reference constant name.
+%token expansion:name    [_\w][_\w\d]*
+
+// A right curly bracket closes an expansion.
+%token expansion:closing_expansion    }    -> __shift__ * 2
+
+// A reference name is dynamic if some parts of its name are known at runtime.
+%token reference:dynamic_name    [_\w][_\w\d]*(?=[\*\{])
+
+// A constant reference name is not a dynamic reference name.
+%token reference:constant_name    [_\w][_\w\d]*    ->    __shift__
+
+// Anything is a little bit tricky because it must stop on an
+// unescaped opening chevron. Thus:
+//      .+
+// is wrong because it is greedy. It must be lazy, so:
+//     .+?
 //
+// However, it does not take into account the opening chevron. Thus:
+//     .+?(?=<)
 //
+// This is valid but it does not take into account that the opening
+// chevron must be unescaped. And now it's funny. Thus:
+//     (\\<|.)+?(?=<)
 //
+// However, this works if and only if an unescaped opening chevron
+// exists on the right. So the right assertion must be `<` or `$`,
+// thus:
+//     (\\<|.)+?(?=(<|$))
 //
+// The final result contains non-capturing groups for memory concerns.
 //
-//
-//%skip   space          \s
-//// Scalars.
-//%token  true           true
-//%token  false          false
-//%token  null           null
-//// Strings.
-//%token  quote_         <{        -> string
-//%token  string:string  [^"]+
-//%token  string:_quote  }>        -> default
-//// Objects.
-//%token  brace_         {
-//%token _brace          }
-//// Arrays.
-//%token  bracket_       \[
-//%token _bracket        \]
-//// Rest.
-//%token  colon          :
-//%token  comma          ,
-//%token  number         \d+
-//
-//value:
-//    <true> | <false> | <null> | string() | object() | array() | number()
-//
-//string:
-//    ::quote_:: <string> ::_quote::
-//
-//number:
-//    <number>
-//
-//#object:
-//    ::brace_:: pair() ( ::comma:: pair() )* ::_brace::
-//
-//#pair:
-//    string() ::colon:: value()
-//
-//#array:
-//    ::bracket_:: value() ( ::comma:: value() )* ::_bracket::
+// Repeat this reasoning for each Alice opening symbol (like `@`).
+%token anything    (?:\\<|@@|.)+?(?=(?:<|@|$))
+
+#root:
+    ( anything()? ( parameter() | reference() ) )* anything()?
+
+#parameter:
+    ::opening_chevron:: ( variable() | identity() | function() ) ::closing_chevron::
+
+#variable:
+    ::opening_variable:: <name> ::closing_variable::
+
+variable_expansion_list:
+    ::opening_variable:: expansion_list() ::closing_variable::
+
+#expansion_list:
+    <name> ( ::comma:: <name> )*
+
+variable_range:
+    ::opening_variable:: range() ::closing_variable::
+
+#range:
+    <number> ::range:: <number>
+
+#identity:
+    ::opening_parenthesis:: <name> ::closing_parenthesis::
+
+#function:
+    <name> ::opening_parenthesis:: function_arguments()? ::closing_parenthesis::
+
+function_arguments:
+    function_argument() ( ::comma:: function_argument() )* #arguments
+
+function_argument:
+    <string>
+
+reference:
+    ::at::
+    (
+        <constant_name> #constant_reference
+      | <dynamic_name>
+        (
+            ::star:: #glob_reference
+          | ::opening_expansion::
+            ( reference_range() | reference_list() )
+            ::closing_expansion:: #expansion_reference
+        )
+    )
+
+reference_range:
+    <number> ::range:: <number> #range
+
+reference_list:
+    <name> ( ::comma:: <name> )* #list
+
+#anything:
+    <anything>

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.0",
         "fzaninotto/faker": "^1.6",
+        "hoa/compiler": "3.17.01.10",
         "myclabs/deep-copy": "^1.5.2",
         "symfony/property-access": "^2.7.11 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.0",
         "fzaninotto/faker": "^1.6",
-        "hoa/compiler": "3.17.01.10",
+        "hoa/compiler": "^3.17",
         "myclabs/deep-copy": "^1.5.2",
         "symfony/property-access": "^2.7.11 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0"

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/HoaLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/HoaLexer.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
+
+use Hoa\Compiler\Llk\Parser as HoaParser;
+use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
+
+final class HoaLexer implements LexerInterface
+{
+    /**
+     * @var HoaParser
+     */
+    private $parser;
+
+    public function __construct(HoaParser $parser)
+    {
+
+        $this->parser = $parser;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function lex(string $value)
+    {
+        return $this->parser->parse($value);
+    }
+}

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/HoaLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/HoaLexer.php
@@ -1,16 +1,24 @@
 <?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
 use Hoa\Compiler\Llk\Parser as HoaParser;
+use Hoa\Compiler\Llk\TreeNode;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 
 final class HoaLexer implements LexerInterface
 {
-    /**
-     * @var HoaParser
-     */
     private $parser;
 
     public function __construct(HoaParser $parser)
@@ -22,7 +30,7 @@ final class HoaLexer implements LexerInterface
     /**
      * @inheritdoc
      */
-    public function lex(string $value)
+    public function lex(string $value): TreeNode
     {
         return $this->parser->parse($value);
     }

--- a/src/FixtureBuilder/ExpressionLanguage/LexerInterface.php
+++ b/src/FixtureBuilder/ExpressionLanguage/LexerInterface.php
@@ -29,5 +29,5 @@ interface LexerInterface
      *
      * @return Token[]
      */
-    public function lex(string $value): array;
+    public function lex(string $value);
 }

--- a/src/Grammar.pp
+++ b/src/Grammar.pp
@@ -1,3 +1,12 @@
+//
+// This file is part of the Alice package.
+//
+// (c) Nelmio <hello@nelm.io>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+//
+
 // All whitespaces matter, except the trailing ones.
 %skip  trailing_whitespaces    \s+$
 

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -16,6 +16,8 @@ namespace Nelmio\Alice\Loader;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
+use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\HoaLexer;
+use Hoa\File\Read;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Faker\Provider\AliceProvider;
 use Nelmio\Alice\FileLoaderInterface;
@@ -208,6 +210,13 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
 
     /** @protected */
     const LOCALE = 'en_US';
+
+    /**
+     * @var string Path to Alice grammar defined in the PP language.
+     *
+     * @see https://hoa-project.net/En/Literature/Hack/Compiler.html#PP_language
+     */
+    protected $ppFilePath = __DIR__.'/../../Alice.pp';
 
     private $previous = '';
 
@@ -441,19 +450,9 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
 
     protected function createLexer(): LexerInterface
     {
-        return new EmptyValueLexer(
-            new ReferenceEscaperLexer(
-                new GlobalPatternsLexer(
-                    new FunctionLexer(
-                        new StringThenReferenceLexer(
-                            new SubPatternsLexer(
-                                new ReferenceLexer()
-                            )
-                        )
-                    )
-                )
-            )
-        );
+        $parser = \Hoa\Compiler\Llk\Llk::load(new Read($this->ppFilePath));
+
+        return new HoaLexer($parser);
     }
 
     protected function createExpressionLanguageTokenParser(): TokenParserInterface

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\HoaLexer;
+use Hoa\Compiler\Llk\Llk;
 use Hoa\File\Read;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Faker\Provider\AliceProvider;
@@ -27,6 +26,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\CollectionDenorma
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullListNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleCollectionDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerRegistry;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SimpleFixtureBagDenormalizer;
@@ -59,13 +59,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Parameter\SimpleParameterBagDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\SimpleDenormalizer;
 use Nelmio\Alice\FixtureBuilder\DenormalizerInterface;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\EmptyValueLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\FunctionLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\GlobalPatternsLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\ReferenceEscaperLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\ReferenceLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\StringThenReferenceLexer;
-use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\SubPatternsLexer;
+use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer\HoaLexer;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FunctionFixtureReferenceParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\SimpleParser;
@@ -212,11 +206,12 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
     const LOCALE = 'en_US';
 
     /**
-     * @var string Path to Alice grammar defined in the PP language.
+     * @Path to Alice grammar defined in the PP language.
      *
+     * @protected
      * @see https://hoa-project.net/En/Literature/Hack/Compiler.html#PP_language
      */
-    protected $ppFilePath = __DIR__.'/../../Alice.pp';
+    const GRAMMAR = __DIR__ . '/../../src/Grammar.pp';
 
     private $previous = '';
 
@@ -395,8 +390,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
             ),
             new FactoryDenormalizer(
                 $this->getCallsDenormalizer()
-            ),
-            $this->getArgumentsDenormalizer()
+            )
         );
     }
 
@@ -450,7 +444,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
 
     protected function createLexer(): LexerInterface
     {
-        $parser = \Hoa\Compiler\Llk\Llk::load(new Read($this->ppFilePath));
+        $parser = Llk::load(new Read(self::GRAMMAR));
 
         return new HoaLexer($parser);
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use Hoa\Compiler\Llk\TreeNode;
 use InvalidArgumentException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -73,7 +73,6 @@ class LexerIntegrationTest extends TestCase
         }
 
         $this->assertEquals($expected, $actual, var_export($actual, true));
-        $this->assertSameSize($expected, $actual);
     }
 
     /**
@@ -84,9 +83,9 @@ class LexerIntegrationTest extends TestCase
         // simple values
         yield 'empty string' => [
             '',
-            [
-                new Token('', new TokenType(TokenType::STRING_TYPE)),
-            ],
+            new TreeNode(
+                '#root'
+            ),
         ];
 
         yield 'regular string value' => [


### PR DESCRIPTION
Note: this message has been edited to avoid the read of the long discussion of here and the original issue (#601).

Alice ships with an Expression Language, which allows to interpret values such as `@user*` or `<current()>`. This is currently done by an in-house Expression Language which uses a Lexer to tokenize the string input and then a Parser which go through those tokens to transform it in an understandable expression. For example:

input: `'@user*'`

tokens returned by the Lexer:
```php
[
   new Token('@user*', new TokenType(TokenType::WILDCARD_REFERENCE_TYPE)),
]
```

value returned by the Parser:
```php
FixtureMatchReferenceValue::createWildcardReference('user')
```

As explained in greater details [here](https://github.com/nelmio/alice/blob/master/CONTRIBUTING.md#architecture), the fixtures are first build into an understandable structure of objects and then they are evaluated to generate the object we wants.

The plan now is to replace the in-house lexer with [HoaCompiler](https://github.com/hoaproject/Compiler). The current one relies on regexes and different pass to try to tokenize the input and then the parser trying to create objects from it. HoaCompiler however works with a better structure: a "grammar" which is a set of rules on how to parse strings is created and return a list of nodes from it. That approach is way more robust and would allow to avoid a lot of edge cases where regexes are just not the tool for the job.

Implementation wise it's not all too complex. Right now most of the Expression Language is tagged as internal so we can afford BC breaks on that part of the library which gives enough freedom to do that work without the need of another major release.

The current PR provides a start of implementation. The major work to do is to write the grammar which @Hywan already started to match our needs. Once done we can then update the Parser to process those `Node` objects instead of the tokens from the in-house lexer (that part should be relatively easy).

Most of the rules that the Expression Language implements are documented [here](https://github.com/nelmio/alice/blob/master/doc/advanced-guide.md#expression-language-dsl) besides the tests.
