### PR TITLE
Fix error on static factory with associative array

### DIFF
--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -92,6 +92,7 @@
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.constructor_with_caller_denormalizer"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorWithCallerDenormalizer">
             <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.simple_constructor_denormalizer" />
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.arguments.simple_arguments_denormalizer" />
         </service>
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.simple_constructor_denormalizer"

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizer.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\StaticReference;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
@@ -33,9 +34,17 @@ final class ConstructorWithCallerDenormalizer implements ConstructorDenormalizer
      */
     private $simpleConstructorDenormalizer;
 
-    public function __construct(SimpleConstructorDenormalizer $simpleConstructorDenormalizer)
-    {
+    /**
+     * @var ArgumentsDenormalizerInterface
+     */
+    private $argumentsDenormalizer;
+
+    public function __construct(
+        SimpleConstructorDenormalizer $simpleConstructorDenormalizer,
+        ArgumentsDenormalizerInterface $argumentsDenormalizer
+    ) {
         $this->simpleConstructorDenormalizer = $simpleConstructorDenormalizer;
+        $this->argumentsDenormalizer = $argumentsDenormalizer;
     }
 
     /**
@@ -56,9 +65,9 @@ final class ConstructorWithCallerDenormalizer implements ConstructorDenormalizer
         /** @var string $firstKey */
         $firstKey = key($unparsedConstructor);
         list($caller, $method) = $this->getCallerReference($scope, $firstKey);
-        $arguments = $this->simpleConstructorDenormalizer->denormalize($scope, $parser, $unparsedConstructor[$firstKey]);
+        $arguments = $this->argumentsDenormalizer->denormalize($scope, $parser, $unparsedConstructor[$firstKey]);
 
-        return new MethodCallWithReference($caller, $method, $arguments->getArguments());
+        return new MethodCallWithReference($caller, $method, $arguments);
     }
 
     /**

--- a/src/Generator/Instantiator/Chainable/StaticFactoryInstantiator.php
+++ b/src/Generator/Instantiator/Chainable/StaticFactoryInstantiator.php
@@ -47,7 +47,7 @@ final class StaticFactoryInstantiator extends AbstractChainableInstantiator
             $arguments = [];
         }
 
-        $instance = $factory::$method(...$arguments);
+        $instance = $factory::$method(...array_values($arguments));
         if (false === $instance instanceof $class) {
             throw InstantiationExceptionFactory::createForInvalidInstanceType($fixture, $instance);
         }

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -341,7 +341,8 @@ class NativeLoader implements FileLoaderInterface, DataLoaderInterface
         return new ConstructorWithCallerDenormalizer(
             new SimpleConstructorDenormalizer(
                 $this->getArgumentsDenormalizer()
-            )
+            ),
+            $this->getArgumentsDenormalizer()
         );
     }
 

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
@@ -35,7 +35,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
      */
     public function testIsNotClonable()
     {
-        clone new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer(new FakeArgumentsDenormalizer()));
+        clone new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argsDenormalizer = new FakeArgumentsDenormalizer()),
+            $argsDenormalizer
+        );
     }
 
     public function testDenormalizesEmptyConstructorAsSimpleConstructor()
@@ -57,7 +60,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             []
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
 
         $this->assertEquals($expected, $actual);
@@ -87,7 +93,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $constructor
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
 
         $this->assertEquals($expected, $actual);
@@ -123,7 +132,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
 
         $this->assertEquals($expected, $actual);
@@ -155,7 +167,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
 
         $this->assertEquals($expected, $actual);
@@ -187,7 +202,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
 
         $this->assertEquals($expected, $actual);
@@ -209,7 +227,10 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
         $flagParser = new FakeFlagParser();
         $argumentsDenormalizer = new FakeArgumentsDenormalizer();
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(new SimpleConstructorDenormalizer($argumentsDenormalizer));
+        $denormalizer = new ConstructorWithCallerDenormalizer(
+            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+            $argumentsDenormalizer
+        );
         $denormalizer->denormalize($fixture, $flagParser, $constructor);
     }
 }

--- a/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
@@ -137,6 +137,27 @@ class StaticFactoryInstantiatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testInstantiatesObjectWithFactoryAndNamedArguments()
+    {
+        $fixture = new SimpleFixture(
+            'dummy',
+            DummyWithNamedConstructorAndOptionalParameters::class,
+            SpecificationBagFactory::create(
+                new MethodCallWithReference(
+                    new StaticReference(DummyWithNamedConstructorAndOptionalParameters::class),
+                    'namedConstruct',
+                    ['param' => 10]
+                )
+            )
+        );
+        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
+
+        $expected = DummyWithNamedConstructorAndOptionalParameters::namedConstruct(10);
+        $actual = $set->getObjects()->get($fixture)->getInstance();
+
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
      * @expectedExceptionMessage Could not instantiate fixture "dummy".

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1169,6 +1169,21 @@ class LoaderIntegrationTest extends TestCase
             DummyWithNamedConstructorAndRequiredParameters::namedConstruct(100),
         ];
 
+        yield 'with named constructor and required parameters with named parameters - use factory function' => [
+            [
+                DummyWithNamedConstructorAndRequiredParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [
+                                'param' => 100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndRequiredParameters::namedConstruct(100),
+        ];
+
         yield 'with unknown named constructor' => [
             [
                 DummyWithDefaultConstructor::class => [


### PR DESCRIPTION
I don't know if this is something you want to officially support, but at least it used to work in previous versions ^^

```php
User::class => [
    'user_1' => [
        '__construct' => [
            'create' => [
                'username' => 'john.doe',
                'firstname' => 'John',
                'lastname' => 'Doe',
                // ...
            ],
        ],
    ],
],
```

but since beta4, it'll produce the following error:

> [Error]
  Cannot unpack array with string keys