### PR TITLE
Add a ReflectionPropertyAccessor

### DIFF
--- a/doc/advanced-guide.md
+++ b/doc/advanced-guide.md
@@ -322,8 +322,21 @@ have 2 easy ways.
 
 1. Create a custom `PropertyAccessor`.
 
-By far the simplies solution, this is actually what is done for setting the
+By far the simplest solution, this is actually what is done for setting the
 values of an `stdClass` object (see [StdPropertyAccessor](../src/PropertyAccess/StdPropertyAccessor.php))
+or for setting private properties using reflection (see [`ReflectionPropertyAccessor`](../src/PropertyAccess/ReflectionPropertyAccessor.php))
+
+You can decorate the property accessor to use your own [by extending the `NativeLoader`](../fixtures/Loader/WithReflectionLoader.php)
+or by using the decoration feature of the Symfony DI component when using the provided integration:
+
+```yml
+    app.fixtures.reflection_property_accessor:
+        class: Nelmio\Alice\PropertyAccess\ReflectionPropertyAccessor
+        public: false
+        decorates: nelmio_alice.property_accessor
+        decoration_priority: -10
+        arguments: ['@app.fixtures.reflection_property_accessor']
+```
 
 
 2. Decorate the PropertyHydrator

--- a/doc/relations-handling.md
+++ b/doc/relations-handling.md
@@ -48,6 +48,7 @@ To be able to use this feature, your entities have to match some requirements :
 * You can reference properties reachable through a getter (i.e :
 `@name->property` will call `$name->getProperty()` if ```property``` is not
 public)
+* You can reference private properties [by decorating the property accessor with the `ReflectionPropertyAccessor`](advanced-guide.md#custom-accessor)
 * You can reference entities' ID but you will then have to split fixtures in
 multiple files (this is because objects are persisted at the end of each file
 processing) :

--- a/fixtures/Entity/DummyWithPrivateProperty.php
+++ b/fixtures/Entity/DummyWithPrivateProperty.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity;
+
+class DummyWithPrivateProperty
+{
+    private static $staticVal;
+    private $val;
+
+    public function __construct($val = null)
+    {
+        $this->val = $val;
+    }
+}

--- a/fixtures/Loader/WithReflectionLoader.php
+++ b/fixtures/Loader/WithReflectionLoader.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nelmio\Alice\Loader;
+
+use Nelmio\Alice\PropertyAccess\ReflectionPropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+class WithReflectionLoader extends NativeLoader
+{
+    protected function createPropertyAccessor(): PropertyAccessorInterface
+    {
+        return new ReflectionPropertyAccessor(parent::createPropertyAccessor());
+    }
+}

--- a/src/PropertyAccess/ReflectionPropertyAccessor.php
+++ b/src/PropertyAccess/ReflectionPropertyAccessor.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Nelmio\Alice\PropertyAccess;
+
+use Nelmio\Alice\IsAServiceTrait;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * Decorator that fallbacks to reflection in case a property cannot be reached another way.
+ */
+final class ReflectionPropertyAccessor implements PropertyAccessorInterface
+{
+    use IsAServiceTrait;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $decoratedPropertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $decoratedPropertyAccessor)
+    {
+        $this->decoratedPropertyAccessor = $decoratedPropertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setValue(&$objectOrArray, $propertyPath, $value)
+    {
+        try {
+            $this->decoratedPropertyAccessor->setValue($objectOrArray, $propertyPath, $value);
+        } catch (NoSuchPropertyException $e) {
+            if (!$this->propertyExists($objectOrArray, $propertyPath)) {
+                throw $e;
+            }
+
+            $setPropertyClosure = \Closure::bind(
+                function ($object) use ($propertyPath, $value) {
+                    $object->{$propertyPath} = $value;
+                },
+                $objectOrArray,
+                $objectOrArray
+            );
+
+            $setPropertyClosure($objectOrArray);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue($objectOrArray, $propertyPath)
+    {
+        try {
+            return $this->decoratedPropertyAccessor->getValue($objectOrArray, $propertyPath);
+        } catch (NoSuchPropertyException $e) {
+            if (!$this->propertyExists($objectOrArray, $propertyPath)) {
+                throw $e;
+            }
+
+            $getPropertyClosure = \Closure::bind(
+                function ($object) use ($propertyPath) {
+                    return $object->{$propertyPath};
+                },
+                $objectOrArray,
+                $objectOrArray
+            );
+
+            return $getPropertyClosure($objectOrArray);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable($objectOrArray, $propertyPath)
+    {
+        return $this->decoratedPropertyAccessor->isWritable($objectOrArray, $propertyPath) || $this->propertyExists($objectOrArray, $propertyPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable($objectOrArray, $propertyPath)
+    {
+        return $this->decoratedPropertyAccessor->isReadable($objectOrArray, $propertyPath) || $this->propertyExists($objectOrArray, $propertyPath);
+    }
+
+    /**
+     * @param object|array $objectOrArray
+     * @param string       $propertyPath
+     *
+     * @return bool Whether the property exists or not.
+     */
+    private function propertyExists($objectOrArray, $propertyPath)
+    {
+        if (!is_object($objectOrArray)) {
+            return false;
+        }
+
+        $reflectionClass = (new \ReflectionClass(get_class($objectOrArray)));
+
+        return $reflectionClass->hasProperty($propertyPath) && !$reflectionClass->getProperty($propertyPath)->isStatic();
+    }
+}

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Entity\Caller\Dummy;
 use Nelmio\Alice\Entity\DummyWithConstructorParam;
 use Nelmio\Alice\Entity\DummyWithPublicProperty;
+use Nelmio\Alice\Entity\DummyWithPrivateProperty;
 use Nelmio\Alice\Entity\DummyWithVariadicConstructorParam;
 use Nelmio\Alice\Entity\Hydrator\CamelCaseDummy;
 use Nelmio\Alice\Entity\Hydrator\MagicCallDummy;
@@ -182,6 +183,27 @@ class LoaderIntegrationTest extends TestCase
         $actualObjects = $set->getObjects();
         $this->assertEquals(count($expectedObjects), count($actualObjects));
         $this->assertEquals($expectedObjects, $actualObjects);
+    }
+
+    public function testWithReflection()
+    {
+        $loader = new WithReflectionLoader();
+
+        $data = [
+            DummyWithPrivateProperty::class => [
+                'dummy' => [
+                    'val' => 'bar',
+                ],
+            ],
+        ];
+
+        $expected = ['dummy' => new DummyWithPrivateProperty('bar')];
+
+        $set = $loader->loadData($data);
+
+        $actual = $set->getObjects();
+        $this->assertEquals(count($expected), count($actual));
+        $this->assertEquals($expected, $actual);
     }
 
     public function testLoadASetOfDataWithInjectedObjects()

--- a/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
+++ b/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\Alice\PropertyAccess;
+
+use Nelmio\Alice\Entity\DummyWithPrivateProperty;
+use Nelmio\Alice\Entity\DummyWithPublicProperty;
+use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * @covers \Nelmio\Alice\PropertyAccess\ReflectionPropertyAccessor
+ */
+class ReflectionPropertyAccessorTest extends TestCase
+{
+    public function testIsAPropertyAccessor()
+    {
+        $this->assertTrue(is_a(ReflectionPropertyAccessor::class, PropertyAccessorInterface::class, true));
+    }
+
+    /**
+     * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException
+     */
+    public function testIsNotClonable()
+    {
+        clone new ReflectionPropertyAccessor(new FakePropertyAccessor());
+    }
+
+    public function testSetValueOnNoSuchPropertyException()
+    {
+        $object = new DummyWithPrivateProperty();
+        $property = 'val';
+        $value = 'bar';
+
+        $expected = new DummyWithPrivateProperty('bar');
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->setValue($object, $property, $value)
+            ->willThrow(NoSuchPropertyException::class)
+        ;
+
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $accessor->setValue($object, $property, $value);
+
+        $this->assertEquals($expected, $object);
+    }
+
+    public function testSetValueWithTheDecoratedAccessorWhenPossible()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+        $value = 'bar';
+
+        $expected = new DummyWithPublicProperty();
+        $expected->val = 'bar';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->setValue($object, $property, $value)
+            ->will(
+                function ($args) {
+                    $args[0]->{$args[1]} = $args[2];
+                }
+            )
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $accessor->setValue($object, $property, $value);
+
+        $this->assertEquals($expected, $object);
+
+        $decoratedAccessorProphecy->setValue(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testGetPrivateValueOnNoSuchPropertyException()
+    {
+        $property = 'val';
+        $value = 'foo';
+        $object = new DummyWithPrivateProperty($value);
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->getValue($object, $property)
+            ->willThrow(NoSuchPropertyException::class)
+        ;
+
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->getValue($object, $property);
+
+        $this->assertEquals($value, $actual);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessage Cannot read property "foo".
+     */
+    public function testThrowsAnOriginalExceptionIfPropertyDoesNotExist()
+    {
+        $property = 'foo';
+        $object = new DummyWithPrivateProperty();
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->getValue($object, $property)
+            ->willThrow(new NoSuchPropertyException("Cannot read property \"$property\"."))
+        ;
+
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $accessor->getValue($object, $property);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessage Cannot read property "staticVal".
+     */
+    public function testThrowsAnOriginalExceptionIfPropertyIsStatic()
+    {
+        $property = 'staticVal';
+        $object = new DummyWithPrivateProperty();
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->getValue($object, $property)
+            ->willThrow(new NoSuchPropertyException("Cannot read property \"$property\"."))
+        ;
+
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $accessor->getValue($object, $property);
+    }
+
+    public function testGetValueWithTheDecoratedAccessorWhenPossible()
+    {
+        $property = 'val';
+        $value = $expected = 'bar';
+        $object = new DummyWithPublicProperty($value);
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->getValue($object, $property)
+            ->willReturn($value)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->getValue($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->getValue(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testExistingClassPropertiesAreAlwaysWritable()
+    {
+        $object = new DummyWithPrivateProperty();
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isWritable($object, Argument::any())
+            ->willReturn(false)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $this->assertTrue($accessor->isWritable($object, 'val'), 'writable if the property exists');
+        $this->assertFalse($accessor->isWritable($object, 'foo'), 'non writable if the property does not exist');
+        $this->assertFalse($accessor->isWritable($object, 'staticVal'), 'non writable if the property is static');
+    }
+
+    public function testUsesDecoratedAccessorToDetermineIfPropertyIsWritable()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isWritable($object, $property)
+            ->willReturn($expected = true)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->isWritable($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->isWritable(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testPrivateClassPropertiesAreReadableOnlyIfTheyExists()
+    {
+        $object = new DummyWithPrivateProperty();
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isReadable($object, Argument::any())
+            ->willReturn(false)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $this->assertTrue($accessor->isReadable($object, 'val'), 'readable if the property exists');
+        $this->assertFalse($accessor->isReadable($object, 'foo'), 'non readable if the property does not exist');
+        $this->assertFalse($accessor->isReadable($object, 'staticVal'), 'non readable if the property is static');
+    }
+
+    public function testUsesDecoratedAccessorToDetermineIfPropertyIsReadable()
+    {
+        $object = new DummyWithPublicProperty();
+        $property = 'val';
+
+        $decoratedAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+        $decoratedAccessorProphecy
+            ->isReadable($object, $property)
+            ->willReturn($expected = true)
+        ;
+        /** @var PropertyAccessorInterface $decoratedAccessor */
+        $decoratedAccessor = $decoratedAccessorProphecy->reveal();
+
+        $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+        $actual = $accessor->isReadable($object, $property);
+
+        $this->assertEquals($expected, $actual);
+
+        $decoratedAccessorProphecy->isReadable(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+}


### PR DESCRIPTION
I use this accessor mainly for hydratation because my domain objects do not have proper setters for every properties, or in order to set predictable values for those computed directly in the constructor.
However, I wonder if it should be wired by default or not.