### PR TITLE
Add the factory keyword

### DIFF
--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -208,8 +208,8 @@ Nelmio\Entity\User:
 
 ## Using a factory
 
-**[TODO] Status: unimplemented; usable in with `__construct` in `__factory` but this will be deprecated once
-`__factory` is out available and will be removed in 4.0**
+**Note**: the following also applies to `__construct`. However using `__construct` for factories has been deprecated as of
+3.0.0 and will be removed in 4.0.0. Use `__factory` instead.
 
 If you want to call a static factory method instead of a constructor, you can
 specify a hash as the constructor:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
 >
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <testsuites>
         <testsuite name="Dependent tests">
             <file>tests/Definition/PropertyTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
 >
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+    </php>
+
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
@@ -70,8 +74,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
-    </php>
 </phpunit>

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -87,16 +87,21 @@
 
         <!-- Specifications Constructors Denormalizer -->
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor"
-                 alias="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.constructor_with_caller_denormalizer" />
+                 alias="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.legacy_constructor_denormalizer" />
 
-        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.constructor_with_caller_denormalizer"
-                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorWithCallerDenormalizer">
-            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.simple_constructor_denormalizer" />
-            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.arguments.simple_arguments_denormalizer" />
+        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.legacy_constructor_denormalizer"
+                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer">
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.constructor_denormalizer" />
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.factory_denormalizer" />
         </service>
 
-        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.simple_constructor_denormalizer"
-                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\SimpleConstructorDenormalizer">
+        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.factory_denormalizer"
+                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\FactoryDenormalizer">
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.arguments" />
+        </service>
+
+        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.constructor.constructor_denormalizer"
+                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorDenormalizer">
             <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.specs.arguments" />
         </service>
 

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizer.php
@@ -15,7 +15,6 @@ namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenor
 
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 use Nelmio\Alice\Definition\MethodCallInterface;
-use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizer.php
@@ -23,7 +23,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 
-final class SimpleConstructorDenormalizer implements ConstructorDenormalizerInterface
+final class ConstructorDenormalizer implements ConstructorDenormalizerInterface
 {
     use IsAServiceTrait;
 
@@ -48,19 +48,9 @@ final class SimpleConstructorDenormalizer implements ConstructorDenormalizerInte
         array $unparsedConstructor
     ): MethodCallInterface
     {
-        /** @var int|string|null $firstKey */
-        $firstKey = key($unparsedConstructor);
-        if (null === $firstKey
-            || is_int($firstKey)
-            || count($unparsedConstructor) > 1
-            || (is_string($firstKey) && preg_match('/\(.*\)/', $firstKey))
-        ) {
-            return new SimpleMethodCall(
-                '__construct',
-                $this->argumentDenormalizer->denormalize($scope, $parser, $unparsedConstructor)
-            );
-        }
-
-        throw DenormalizerExceptionFactory::createForUndenormalizableConstructor();
+        return new SimpleMethodCall(
+            '__construct',
+            $this->argumentDenormalizer->denormalize($scope, $parser, $unparsedConstructor)
+        );
     }
 }

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\StaticReference;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
@@ -25,25 +26,17 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 
-final class ConstructorWithCallerDenormalizer implements ConstructorDenormalizerInterface
+final class FactoryDenormalizer implements ConstructorDenormalizerInterface
 {
     use IsAServiceTrait;
-
-    /**
-     * @var SimpleConstructorDenormalizer
-     */
-    private $simpleConstructorDenormalizer;
 
     /**
      * @var ArgumentsDenormalizerInterface
      */
     private $argumentsDenormalizer;
 
-    public function __construct(
-        SimpleConstructorDenormalizer $simpleConstructorDenormalizer,
-        ArgumentsDenormalizerInterface $argumentsDenormalizer
-    ) {
-        $this->simpleConstructorDenormalizer = $simpleConstructorDenormalizer;
+    public function __construct(ArgumentsDenormalizerInterface $argumentsDenormalizer)
+    {
         $this->argumentsDenormalizer = $argumentsDenormalizer;
     }
 
@@ -56,14 +49,21 @@ final class ConstructorWithCallerDenormalizer implements ConstructorDenormalizer
         array $unparsedConstructor
     ): MethodCallInterface
     {
-        try {
-            return $this->simpleConstructorDenormalizer->denormalize($scope, $parser, $unparsedConstructor);
-        } catch (UnexpectedValueException $exception) {
-            // Continue
-        }
-
         /** @var string $firstKey */
         $firstKey = key($unparsedConstructor);
+
+        if (false === $firstKey
+            || false === is_string($firstKey)
+        ) {
+            throw DenormalizerExceptionFactory::createForUndenormalizableConstructor();
+        }
+
+        $arguments = $unparsedConstructor[$firstKey];
+
+        if (false === is_array($arguments)) {
+            throw DenormalizerExceptionFactory::createForUndenormalizableConstructor();
+        }
+
         list($caller, $method) = $this->getCallerReference($scope, $firstKey);
         $arguments = $this->argumentsDenormalizer->denormalize($scope, $parser, $unparsedConstructor[$firstKey]);
 

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
@@ -19,7 +19,6 @@ use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\StaticReference;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerExceptionFactory;
-use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizer.php
@@ -54,14 +54,15 @@ final class FactoryDenormalizer implements ConstructorDenormalizerInterface
 
         if (false === $firstKey
             || false === is_string($firstKey)
+            || 1 !== count($unparsedConstructor)
         ) {
-            throw DenormalizerExceptionFactory::createForUndenormalizableConstructor();
+            throw DenormalizerExceptionFactory::createForUndenormalizableFactory();
         }
 
         $arguments = $unparsedConstructor[$firstKey];
 
         if (false === is_array($arguments)) {
-            throw DenormalizerExceptionFactory::createForUndenormalizableConstructor();
+            throw DenormalizerExceptionFactory::createForUndenormalizableFactory();
         }
 
         list($caller, $method) = $this->getCallerReference($scope, $firstKey);

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
+
+use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
+use Nelmio\Alice\Definition\MethodCallInterface;
+use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
+use Nelmio\Alice\Definition\ServiceReference\StaticReference;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
+use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\IsAServiceTrait;
+
+final class LegacyConstructorDenormalizer implements ConstructorDenormalizerInterface
+{
+    use IsAServiceTrait;
+
+    /**
+     * @var ConstructorDenormalizer
+     */
+    private $constructorDenormalizer;
+
+    /**
+     * @var ConstructorDenormalizer
+     */
+    private $factoryDenormalizer;
+
+    /**
+     * @var ArgumentsDenormalizerInterface
+     */
+    private $argumentsDenormalizer;
+
+    public function __construct(
+        ConstructorDenormalizerInterface $constructorDenormalizer,
+        ConstructorDenormalizerInterface $factoryDenormalizer,
+        ArgumentsDenormalizerInterface $argumentsDenormalizer
+    ) {
+        $this->constructorDenormalizer = $constructorDenormalizer;
+        $this->factoryDenormalizer = $factoryDenormalizer;
+        $this->argumentsDenormalizer = $argumentsDenormalizer;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function denormalize(
+        FixtureInterface $scope,
+        FlagParserInterface $parser,
+        array $unparsedConstructor
+    ): MethodCallInterface
+    {
+        try {
+            return $this->factoryDenormalizer->denormalize($scope, $parser, $unparsedConstructor);
+        } catch (UnexpectedValueException $exception) {
+            // Continue
+        }
+
+        return $this->constructorDenormalizer->denormalize($scope, $parser, $unparsedConstructor);
+    }
+}

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
@@ -39,19 +39,12 @@ final class LegacyConstructorDenormalizer implements ConstructorDenormalizerInte
      */
     private $factoryDenormalizer;
 
-    /**
-     * @var ArgumentsDenormalizerInterface
-     */
-    private $argumentsDenormalizer;
-
     public function __construct(
         ConstructorDenormalizerInterface $constructorDenormalizer,
-        ConstructorDenormalizerInterface $factoryDenormalizer,
-        ArgumentsDenormalizerInterface $argumentsDenormalizer
+        ConstructorDenormalizerInterface $factoryDenormalizer
     ) {
         $this->constructorDenormalizer = $constructorDenormalizer;
         $this->factoryDenormalizer = $factoryDenormalizer;
-        $this->argumentsDenormalizer = $argumentsDenormalizer;
     }
 
     /**

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizer.php
@@ -13,13 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
 
-use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCallInterface;
-use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
-use Nelmio\Alice\Definition\ServiceReference\StaticReference;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
-use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
@@ -120,7 +120,7 @@ final class SimpleSpecificationsDenormalizer implements SpecificationsDenormaliz
         $factory = $this->denormalizeConstructor($value, $scope, $parser);
 
         if ('__construct' === $factory->getMethod()) {
-            throw DenormalizerExceptionFactory::createForInvalidFactory();
+            throw DenormalizerExceptionFactory::createForUndenormalizableFactory();
         }
 
         return $factory;

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
@@ -66,7 +66,7 @@ final class SimpleSpecificationsDenormalizer implements SpecificationsDenormaliz
             if ('__construct' === $unparsedPropertyName) {
                 $constructor = $this->denormalizeConstructor($value, $scope, $parser);
 
-                if (false === ($constructor instanceof NoMethodCall) &&'__construct' !== $constructor->getMethod()) {
+                if (false === ($constructor instanceof NoMethodCall) && '__construct' !== $constructor->getMethod()) {
                     @trigger_error(
                         'Using factories with the fixture keyword "__construct" has been deprecated since '
                         .'3.0.0 and will no longer be supported in 4.0.0. Use "__factory" instead.',

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
@@ -66,6 +66,14 @@ final class SimpleSpecificationsDenormalizer implements SpecificationsDenormaliz
             if ('__construct' === $unparsedPropertyName) {
                 $constructor = $this->denormalizeConstructor($value, $scope, $parser);
 
+                if (false === ($constructor instanceof NoMethodCall) &&'__construct' !== $constructor->getMethod()) {
+                    @trigger_error(
+                        'Using factories with the fixture keyword "__construct" has been deprecated since '
+                        .'3.0.0 and will no longer be supported in 4.0.0. Use "__factory" instead.',
+                        E_USER_DEPRECATED
+                    );
+                }
+
                  continue;
             }
 

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\CollectionDenorma
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullListNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleCollectionDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\FactoryDenormalizer;
 use Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureMethodCallReferenceResolver;
 use Nelmio\Alice\Generator\Resolver\Value\Chainable\FunctionCallArgumentResolver;
 use Nelmio\Alice\Generator\Resolver\Value\Chainable\PhpFunctionCallValueResolver;
@@ -64,8 +65,8 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Calls\OptionalCallsDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\CallsDenormalizerInterface;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorWithCallerDenormalizer;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\SimpleConstructorDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Property\SimplePropertyDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\PropertyDenormalizerInterface;
@@ -342,8 +343,11 @@ class NativeLoader implements FileLoaderInterface, DataLoaderInterface
 
     protected function createConstructorDenormalizer(): ConstructorDenormalizerInterface
     {
-        return new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer(
+        return new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer(
+                $this->getArgumentsDenormalizer()
+            ),
+            new FactoryDenormalizer(
                 $this->getArgumentsDenormalizer()
             ),
             $this->getArgumentsDenormalizer()

--- a/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
+++ b/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
@@ -12,6 +12,7 @@
 declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
+use Nelmio\Alice\Definition\MethodCallInterface;
 
 /**
  * @private
@@ -60,5 +61,12 @@ final class DenormalizerExceptionFactory
     public static function createForInvalidScopeForUniqueValue(): InvalidScopeException
     {
         return new InvalidScopeException('Cannot bind a unique value scope to a temporary fixture.');
+    }
+
+    public static function createForInvalidFactory(): UnexpectedValueException
+    {
+        return new UnexpectedValueException(
+            'Cannot use `__construct` for a factory method. Use the `__construct` fixture property instead.'
+        );
     }
 }

--- a/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
+++ b/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
@@ -12,7 +12,6 @@
 declare(strict_types = 1);
 
 namespace Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer;
-use Nelmio\Alice\Definition\MethodCallInterface;
 
 /**
  * @private
@@ -26,7 +25,7 @@ final class DenormalizerExceptionFactory
 
     public static function createForUndenormalizableFactory(): UnexpectedValueException
     {
-        return new UnexpectedValueException('Cannot denormalize the given factory.');
+        return new UnexpectedValueException('Could not denormalize the given factory.');
     }
 
     public static function createForUnparsableValue(string $value, int $code = 0, \Throwable $previous): UnexpectedValueException

--- a/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
+++ b/src/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactory.php
@@ -24,6 +24,11 @@ final class DenormalizerExceptionFactory
         return new UnexpectedValueException('Could not denormalize the given constructor.');
     }
 
+    public static function createForUndenormalizableFactory(): UnexpectedValueException
+    {
+        return new UnexpectedValueException('Cannot denormalize the given factory.');
+    }
+
     public static function createForUnparsableValue(string $value, int $code = 0, \Throwable $previous): UnexpectedValueException
     {
         return new UnexpectedValueException(
@@ -61,12 +66,5 @@ final class DenormalizerExceptionFactory
     public static function createForInvalidScopeForUniqueValue(): InvalidScopeException
     {
         return new InvalidScopeException('Cannot bind a unique value scope to a temporary fixture.');
-    }
-
-    public static function createForInvalidFactory(): UnexpectedValueException
-    {
-        return new UnexpectedValueException(
-            'Cannot use `__construct` for a factory method. Use the `__construct` fixture property instead.'
-        );
     }
 }

--- a/src/Throwable/Exception/LogicExceptionFactory.php
+++ b/src/Throwable/Exception/LogicExceptionFactory.php
@@ -38,4 +38,11 @@ final class LogicExceptionFactory
             )
         );
     }
+
+    public static function createForCannotHaveBothConstructorAndFactory(): \LogicException
+    {
+        return new \LogicException(
+            'Cannot use the fixture property "__construct" and "__factory" together.'
+        );
+    }
 }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
@@ -13,16 +13,12 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
 
-use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
-use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
 use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
-use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
-use Nelmio\Alice\Definition\ServiceReference\StaticReference;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\FakeArgumentsDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
-use Nelmio\Alice\FixtureInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
+
+use PHPUnit\Framework\TestCase;
+use Nelmio\Alice\Definition\Fixture\FakeFixture;
+use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
+use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
+use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
+use Nelmio\Alice\Definition\ServiceReference\StaticReference;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\FakeArgumentsDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
+use Nelmio\Alice\FixtureInterface;
+use Prophecy\Argument;
+
+/**
+ * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorDenormalizer
+ */
+class ConstructorDenormalizerTest extends TestCase
+{
+    /**
+     * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException
+     */
+    public function testIsNotClonable()
+    {
+        clone new ConstructorDenormalizer(
+            new FakeArgumentsDenormalizer()
+        );
+    }
+
+    public function testDenormalizesInputAsAConstructorMethod()
+    {
+        $arguments = ['foo', 'bar'];
+        $fixture = new FakeFixture();
+        $flagParser = new FakeFlagParser();
+
+        $argumentsDenormalizerProphecy = $this->prophesize(ArgumentsDenormalizerInterface::class);
+        $argumentsDenormalizerProphecy
+            ->denormalize($fixture, $flagParser, $arguments)
+            ->willReturn($arguments)
+        ;
+        /** @var ArgumentsDenormalizerInterface $argumentsDenormalizer */
+        $argumentsDenormalizer = $argumentsDenormalizerProphecy->reveal();
+
+        $expected = new SimpleMethodCall(
+            '__construct',
+            ['foo', 'bar']
+        );
+
+        $denormalizer = new ConstructorDenormalizer($argumentsDenormalizer);
+
+        $actual = $denormalizer->denormalize($fixture, $flagParser, $arguments);
+
+        $this->assertEquals($expected, $actual);
+
+        $argumentsDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+}

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorWithCallerDenormalizerTest.php
@@ -25,8 +25,8 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureInterface;
 
 /**
- * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\SimpleConstructorDenormalizer
- * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorWithCallerDenormalizer
+ * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\ConstructorDenormalizer
+ * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer
  */
 class ConstructorWithCallerDenormalizerTest extends TestCase
 {
@@ -35,8 +35,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
      */
     public function testIsNotClonable()
     {
-        clone new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argsDenormalizer = new FakeArgumentsDenormalizer()),
+        clone new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argsDenormalizer = new FakeArgumentsDenormalizer()),
             $argsDenormalizer
         );
     }
@@ -60,8 +60,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             []
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
@@ -93,8 +93,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $constructor
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
@@ -132,8 +132,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
@@ -167,8 +167,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
@@ -202,8 +202,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
             $arguments
         );
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
@@ -227,8 +227,8 @@ class ConstructorWithCallerDenormalizerTest extends TestCase
         $flagParser = new FakeFlagParser();
         $argumentsDenormalizer = new FakeArgumentsDenormalizer();
 
-        $denormalizer = new ConstructorWithCallerDenormalizer(
-            new SimpleConstructorDenormalizer($argumentsDenormalizer),
+        $denormalizer = new LegacyConstructorDenormalizer(
+            new ConstructorDenormalizer($argumentsDenormalizer),
             $argumentsDenormalizer
         );
         $denormalizer->denormalize($fixture, $flagParser, $constructor);

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
@@ -13,17 +13,15 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
 
-use Nelmio\Alice\Definition\Fixture\DummyFixture;
-use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
-use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
 use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\StaticReference;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\FakeArgumentsDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\FactoryDenormalizer
@@ -42,7 +40,7 @@ class FactoryDenormalizerTest extends TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Cannot denormalize the given factory.
+     * @expectedExceptionMessage Could not denormalize the given factory.
      */
     public function testCannotDenormalizeEmptyFactory()
     {
@@ -59,7 +57,7 @@ class FactoryDenormalizerTest extends TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Cannot denormalize the given factory.
+     * @expectedExceptionMessage Could not denormalize the given factory.
      */
     public function testCannotDenormalizeFactoryWithMultipleNames()
     {
@@ -79,7 +77,7 @@ class FactoryDenormalizerTest extends TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Cannot denormalize the given factory.
+     * @expectedExceptionMessage Could not denormalize the given factory.
      */
     public function testCannotDenormalizeFactoryWithNoFactoryName()
     {

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
@@ -14,18 +14,11 @@ declare(strict_types=1);
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
 
 use Nelmio\Alice\Definition\FakeMethodCall;
+use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
-use Nelmio\Alice\Definition\Fixture\FakeFixture;
-use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
-use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
-use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
-use Nelmio\Alice\Definition\ServiceReference\StaticReference;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\FakeArgumentsDenormalizer;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
-use Nelmio\Alice\FixtureInterface;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor;
+
+use Nelmio\Alice\Definition\FakeMethodCall;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ConstructorDenormalizerInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
+use PHPUnit\Framework\TestCase;
+use Nelmio\Alice\Definition\Fixture\FakeFixture;
+use Nelmio\Alice\Definition\MethodCall\MethodCallWithReference;
+use Nelmio\Alice\Definition\MethodCall\SimpleMethodCall;
+use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
+use Nelmio\Alice\Definition\ServiceReference\StaticReference;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Arguments\FakeArgumentsDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ArgumentsDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
+use Nelmio\Alice\FixtureInterface;
+
+/**
+ * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer
+ */
+class LegacyConstructorDenormalizerTest extends TestCase
+{
+    /**
+     * @expectedException \Nelmio\Alice\Throwable\Exception\UnclonableException
+     */
+    public function testIsNotClonable()
+    {
+        clone new LegacyConstructorDenormalizer(
+            new FakeConstructorDenormalizer(),
+            new FakeConstructorDenormalizer()
+        );
+    }
+
+    public function testDenormalizesConstructorWithTheDecoratedFactoryDenormalizer()
+    {
+        $constructor = [];
+        $fixture = new FakeFixture();
+        $flagParser = new FakeFlagParser();
+
+        $constructorDenormalizer = new FakeConstructorDenormalizer();
+
+        $factoryDenormalizerProphecy = $this->prophesize(ConstructorDenormalizerInterface::class);
+        $factoryDenormalizerProphecy
+            ->denormalize($fixture, $flagParser, $constructor)
+            ->willReturn(
+                $expected = new FakeMethodCall()
+            )
+        ;
+        /** @var ConstructorDenormalizerInterface $factoryDenormalizer */
+        $factoryDenormalizer = $factoryDenormalizerProphecy->reveal();
+
+        $denormalizer = new LegacyConstructorDenormalizer($constructorDenormalizer, $factoryDenormalizer);
+
+        $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testDenormalizesConstructorWithTheDecoratedConstructorDenormalizerIfCannotDenormalizeWithTheFactoryDenormalizer()
+    {
+        $constructor = [];
+        $fixture = new FakeFixture();
+        $flagParser = new FakeFlagParser();
+
+        $constructorDenormalizerProphecy = $this->prophesize(ConstructorDenormalizerInterface::class);
+        $constructorDenormalizerProphecy
+            ->denormalize($fixture, $flagParser, $constructor)
+            ->willReturn($expected = new FakeMethodCall())
+        ;
+        /** @var ConstructorDenormalizerInterface $constructorDenormalizer */
+        $constructorDenormalizer = $constructorDenormalizerProphecy->reveal();
+
+        $factoryDenormalizerProphecy = $this->prophesize(ConstructorDenormalizerInterface::class);
+        $factoryDenormalizerProphecy
+            ->denormalize($fixture, $flagParser, $constructor)
+            ->willThrow(UnexpectedValueException::class)
+        ;
+        /** @var ConstructorDenormalizerInterface $factoryDenormalizer */
+        $factoryDenormalizer = $factoryDenormalizerProphecy->reveal();
+
+        $denormalizer = new LegacyConstructorDenormalizer($constructorDenormalizer, $factoryDenormalizer);
+
+        $actual = $denormalizer->denormalize($fixture, $flagParser, $constructor);
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -62,7 +62,7 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $fixture = new FakeFixture();
         $specs = [
             '__construct' => $construct = [
-                '<latitude()>'
+                'foo'
             ],
         ];
         $flagParser = new FakeFlagParser();
@@ -70,7 +70,12 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $constructorDenormalizerProphecy = $this->prophesize(ConstructorDenormalizerInterface::class);
         $constructorDenormalizerProphecy
             ->denormalize($fixture, $flagParser, $construct)
-            ->willReturn($constructor = new FakeMethodCall())
+            ->willReturn(
+                $constructor = new SimpleMethodCall(
+                    '__construct',
+                    ['foo']
+                )
+            )
         ;
         /** @var ConstructorDenormalizerInterface $constructorDenormalizer */
         $constructorDenormalizer = $constructorDenormalizerProphecy->reveal();
@@ -135,11 +140,11 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $fixture = new FakeFixture();
         $specs = [
             '__construct' => $construct = [
-                '<latitude()>'
+                'foo'
             ],
             '__factory' => $factory = [
                 'create' => [
-                    '<latitude()>',
+                    'foo',
                 ],
             ],
         ];
@@ -149,7 +154,10 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $constructorDenormalizerProphecy
             ->denormalize($fixture, $flagParser, $construct)
             ->willReturn(
-                $constructor = new FakeMethodCall()
+                $constructor = new SimpleMethodCall(
+                    '__construct',
+                    ['foo']
+                )
             )
         ;
         $constructorDenormalizerProphecy
@@ -323,7 +331,12 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $constructorDenormalizerProphecy = $this->prophesize(ConstructorDenormalizerInterface::class);
         $constructorDenormalizerProphecy
             ->denormalize($fixture, $flagParser, $construct)
-            ->willReturn($constructor = new FakeMethodCall())
+            ->willReturn(
+                $constructor = new SimpleMethodCall(
+                    '__construct',
+                    ['<latitude()>']
+                )
+            )
         ;
         /** @var ConstructorDenormalizerInterface $constructorDenormalizer */
         $constructorDenormalizer = $constructorDenormalizerProphecy->reveal();

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -174,7 +174,7 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
 
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Cannot use `__construct` for a factory method. Use the `__construct` fixture property instead.
+     * @expectedExceptionMessage Cannot denormalize the given factory.
      */
     public function testCannotDenormalizeAFactoryAndAConstructor()
     {

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -2978,6 +2978,27 @@ class LoaderIntegrationTest extends TestCase
             ],
         ];
 
+        yield 'argument indexes (ambiguous case, default to argument instead of factory)' => [
+            [
+                'parameters' => [],
+                DummyWithVariadicConstructorParam::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'foo' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => new DummyWithVariadicConstructorParam(
+                        'bar'
+                    ),
+                ],
+            ],
+        ];
+
         yield 'dynamic array with scalar value' => [
             [
                 \stdClass::class => [

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -174,9 +174,18 @@ class LoaderIntegrationTest extends TestCase
         ]);
     }
 
-    public function testUsingConstructorAsAFactoryIsDeprecated()
+    /**
+     * @dataProvider provideFixtureToInstantiateWithDeprecatedConstructor
+     *
+     * @group legacy
+     * @expectedDeprecation Using factories with the fixture keyword "__construct" has been deprecated since 3.0.0 and will no longer be supported in 4.0.0. Use "__factory" instead.
+     */
+    public function testUsingConstructorAsAFactoryIsDeprecated(array $data, $expected)
     {
+        $objects = $this->loader->loadData($data)->getObjects();
 
+        $this->assertCount(1, $objects);
+        $this->assertEquals($expected, $objects['dummy']);
     }
 
     /**
@@ -1566,6 +1575,95 @@ class LoaderIntegrationTest extends TestCase
                 ],
             ],
             null,
+        ];
+    }
+
+    public function provideFixtureToInstantiateWithDeprecatedConstructor()
+    {
+        yield 'with named constructor - use factory function' => [
+            [
+                DummyWithNamedConstructor::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructor::namedConstruct(),
+        ];
+
+        yield 'with named constructor and optional parameters with no parameters - use factory function' => [
+            [
+                DummyWithNamedConstructorAndOptionalParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndOptionalParameters::namedConstruct(),
+        ];
+
+        yield 'with named constructor and optional parameters with parameters - use factory function' => [
+            [
+                DummyWithNamedConstructorAndOptionalParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [
+                                100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndOptionalParameters::namedConstruct(100),
+        ];
+
+        yield 'with named constructor and optional parameters with parameters and unique value - use factory function' => [
+            [
+                DummyWithNamedConstructorAndOptionalParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [
+                                '0 (unique)' => 100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndOptionalParameters::namedConstruct(100),
+        ];
+
+        yield 'with named constructor and required parameters with parameters - use factory function' => [
+            [
+                DummyWithNamedConstructorAndRequiredParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [
+                                100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndRequiredParameters::namedConstruct(100),
+        ];
+
+        yield 'with named constructor and required parameters with named parameters - use factory function' => [
+            [
+                DummyWithNamedConstructorAndRequiredParameters::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            'namedConstruct' => [
+                                'param' => 100,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            DummyWithNamedConstructorAndRequiredParameters::namedConstruct(100),
         ];
     }
 

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -115,6 +115,10 @@ class LoaderIntegrationTest extends TestCase
     }
 
     /**
+     * Only a few tests samples are legacy.
+     *
+     * @group legacy
+     *
      * @dataProvider provideFixturesToInstantiate
      */
     public function testObjectInstantiation(array $data, $expected)
@@ -289,6 +293,11 @@ class LoaderIntegrationTest extends TestCase
         );
     }
 
+    /**
+     * Only a few tests samples are legacy.
+     *
+     * @group legacy
+     */
     public function testIfAFixtureAndAnInjectedObjectHaveTheSameIdThenTheInjectedObjectIsOverridden()
     {
         $set = $this->loader->loadData(

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
-use Humbug\Exception\LogicException;
 use Nelmio\Alice\Entity\DummyWithConstructorAndCallable;
-use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\DataLoaderInterface;
 use Nelmio\Alice\Entity\Caller\Dummy;
 use Nelmio\Alice\Entity\DummyWithConstructorParam;
@@ -49,6 +47,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group integration

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use Humbug\Exception\LogicException;
 use Nelmio\Alice\Entity\DummyWithConstructorAndCallable;
 use PHPUnit\Framework\TestCase;
 use Nelmio\Alice\DataLoaderInterface;
@@ -157,23 +158,25 @@ class LoaderIntegrationTest extends TestCase
         $this->assertEquals($expected, $objects['dummy']);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Cannot use the fixture property "__construct" and "__factory" together.
+     */
     public function testCannotUseBothConstructAndFactoryAtTheSameTime()
     {
-        try {
-            $this->loader->loadData([
-                \stdClass::class => [
-                    'dummy' => [
-                        '__construct' => [],
-                        '__factory' => [],
-                    ],
+        $this->loader->loadData([
+            \stdClass::class => [
+                'dummy' => [
+                    '__construct' => [],
+                    '__factory' => [],
                 ],
-            ]);
+            ],
+        ]);
+    }
 
-            $this->fail('Expected exception to be thrown.');
-        } catch (InstantiationThrowable $exception) {
-            //TODO: check message
-            throw $exception;
-        }
+    public function testUsingConstructorAsAFactoryIsDeprecated()
+    {
+
     }
 
     /**

--- a/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/FixtureBuilder/Denormalizer/DenormalizerExceptionFactoryTest.php
@@ -31,6 +31,17 @@ class DenormalizerExceptionFactoryTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
+    public function testTestCreateForUndenormalizableFactory()
+    {
+        $exception = DenormalizerExceptionFactory::createForUndenormalizableFactory();
+        $this->assertEquals(
+            'Could not denormalize the given factory.',
+            $exception->getMessage()
+        );
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
     public function testTestCreateForUnparsableValue()
     {
         $code = 500;

--- a/tests/Throwable/Exception/LogicExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/LogicExceptionFactoryTest.php
@@ -44,4 +44,16 @@ class LogicExceptionFactoryTest extends TestCase
         $this->assertEquals(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }
+
+    public function testTestCreateForCannotHaveBothConstructorAndFactory()
+    {
+        $exception = LogicExceptionFactory::createForCannotHaveBothConstructorAndFactory();
+
+        $this->assertEquals(
+            'Cannot use the fixture property "__construct" and "__factory" together.',
+            $exception->getMessage()
+        );
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
 }


### PR DESCRIPTION
Tackles the `__factory` part of https://github.com/nelmio/alice/issues/388.

Todo:

- [x] Deprecate the usage of `__construct` in favour of `__factory`
- [x] Fix the confusing case. With `__construct` with only 1 named param, it is not clear if the param is an argument key or a constructor name. In `__factory` the ambiguity is non existent
- [x] Tests (coverage + usage statements + Symfony bridge)
- [x] Doc