### PR TITLE
Fix ReferenceEscaperLexer.

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
@@ -44,7 +44,7 @@ final class ReferenceEscaperLexer implements LexerInterface
      */
     public function lex(string $value): array
     {
-        $escapedValue = preg_replace('/((\s|^)[a-zA-Z0-9_.+-]+?[A-Za-z0-9])@/', '$1\\@', $value);
+        $escapedValue = preg_replace('/((\s|^)[^@]?(\p{L}|\p{N}|[+-_.])+?(\p{L}|\p{N}))@/', '$1\\@', $value);
         return $this->lexer->lex($escapedValue);
     }
 }

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexer.php
@@ -44,8 +44,7 @@ final class ReferenceEscaperLexer implements LexerInterface
      */
     public function lex(string $value): array
     {
-        $escapedValue = preg_replace('/(\\p{L})@/', '$1\\@', $value);
-
+        $escapedValue = preg_replace('/((\s|^)[a-zA-Z0-9_.+-]+?[A-Za-z0-9])@/', '$1\\@', $value);
         return $this->lexer->lex($escapedValue);
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
@@ -66,5 +66,7 @@ class ReferenceEscaperLexerTest extends TestCase
         yield 'string with a reference with members' => ['bar @foo baz'];
 
         yield 'reference in a middle of a word' => ['email@example', 'email\\@example'];
+
+        yield 'email ending with a digit' => ['email1@example', 'email1\\@example'];
     }
 }


### PR DESCRIPTION
Escape emails ending with a digit. 
Related to #724.

Also @theofidry Keep in mind that the old Escaper would have escaped nested parameters such as `@user@user1`.