### PR TITLE
Fix optional callables

### DIFF
--- a/src/Generator/Caller/SimpleCaller.php
+++ b/src/Generator/Caller/SimpleCaller.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Caller;
 
+use Nelmio\Alice\Definition\MethodCall\OptionalMethodCall;
 use Nelmio\Alice\Definition\MethodCallInterface;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
@@ -66,6 +67,12 @@ final class SimpleCaller implements CallerInterface, ValueResolverAwareInterface
         ];
 
         foreach ($calls as $methodCall) {
+            if ($methodCall instanceof OptionalMethodCall) {
+                if ($methodCall->getPercentage() <= mt_rand(0,99)) {
+                    continue;
+                }
+            }
+
             list($methodCall, $fixtureSet) = $this->processArguments($methodCall, $fixture, $fixtureSet, $scope, $context);
 
             $instance = $object->getInstance();

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -3058,6 +3058,44 @@ class LoaderIntegrationTest extends TestCase
             ],
         ];
 
+        yield 'percentage method calls, 100' => [
+            [
+                Dummy::class => [
+                    'dummy' => [
+                        '__calls' => [
+                            ['setTitle' => ['Fake Title']],
+                            ['addFoo (100%?)' => []],
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => Dummy::create('Fake Title', 1),
+                ],
+            ]
+        ];
+
+        yield 'percentage method calls, 0' => [
+            [
+                Dummy::class => [
+                    'dummy' => [
+                        '__calls' => [
+                            ['setTitle' => ['Fake Title']],
+                            ['addFoo (0%?)' => []],
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => Dummy::create('Fake Title', 0),
+                ],
+            ],
+        ];
+
         yield 'method calls' => [
             [
                 Dummy::class => [


### PR DESCRIPTION
The ```SimpleCaller``` had no implementation to handle ```OptionalMethodCall```. With this it is again possible to set a percentage on call configuration.

```php
'foo' => [
    '__calls' => [
        ['setBar (50%?)' => []],
        ['setBaz (50%?)' => []],
   ],
 ]
```