### PR TITLE
[DX] Properly handle missing specs

### DIFF
--- a/src/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizer.php
@@ -70,7 +70,7 @@ final class SimpleFixtureBagDenormalizer implements FixtureBagDenormalizerInterf
                     $fixtures,
                     $fqcn,
                     $reference,
-                    $specs,
+                    $specs ?? [],
                     $flags
                 );
             }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -613,6 +613,29 @@ class LoaderIntegrationTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testEmptyInheritance()
+    {
+        $data = [
+            \stdClass::class => [
+                'dummy_template (template)' => [
+                    'foo' => 'bar',
+                ],
+                'dummy (extends dummy_template)' => null,
+            ],
+        ];
+        $expected = new ObjectSet(
+            new ParameterBag(),
+            new ObjectBag([
+                'dummy' => StdClassFactory::create([
+                    'foo' => 'bar',
+                ]),
+            ])
+        );
+        $actual = $this->loader->loadData($data);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testMultipleInheritanceInTemplates()
     {
         $data = [


### PR DESCRIPTION
Coalesce missing specs to an empty array to improve error message.

I've been bitten a few times by typing this:
```
My\Fine\Entity:
  base_entity (template):
    username: '<username()>

  entity{1..10} (extends base_entity): ~
```
Which gives a wonderfully unhelpful error as it should be `[]` instead right now.

> PHP Fatal error:  Uncaught TypeError: Argument 4 passed to Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerRegistry::denormalize() must be of the type array, null given, called in /vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizer.php on line 70 and defined in /vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistry.php:59

This patch coalesces the `null` into an empty array instead to give the expected behavior.