### PR TITLE
#645 fixed array function arguments

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -65,14 +65,15 @@ final class FunctionTokenParser extends AbstractChainableParserAwareParser
         return new FunctionCallValue($function, $arguments);
     }
 
-    private function parseArguments(ParserInterface $parser, string $arguments): array
+    private function parseArguments(ParserInterface $parser, string $argumentsString): array
     {
-        if ('' === $arguments) {
+        if ('' === $argumentsString) {
             return [];
         }
 
-        $arguments = preg_split('/\s*,\s*/', $arguments);
-        foreach ($arguments as $index => $argument) {
+        $arguments = [];
+        preg_match_all('/\[[^[]+\]|[^,\s]+/', $argumentsString, $argumentsList);
+        foreach ($argumentsList[0] as $index => $argument) {
             $argument = trim($argument);
             if (is_string($argument) && preg_match('/^\'(.*)\'$|^"(.*)"$/', $argument, $match)) {
                 $argument = array_key_exists(2, $match) ? $match[2] : $match[1];

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -408,6 +408,12 @@ class LexerIntegrationTest extends TestCase
                 new Token('<aliceTokenizedFunction(FUNCTION_START__function__\'foo\', "bar"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
+        yield '[Function] nominal with array argument which contains string elements in quotes' => [
+            '<function([\'foo\', "bar"])>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__[\'foo\', "bar"]IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
         yield '[Function] unbalanced with arguments (1)' => [
             '<function($foo, $arg)',
             null,

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -349,6 +349,15 @@ class ParserIntegrationTest extends TestCase
                 ]
             ),
         ];
+        yield '[Function] nominal with array argument which contains string elements in quotes' => [
+            '<function([\'foo\', "bar"])>',
+            new FunctionCallValue(
+                'function',
+                [
+                    ['\'foo\'', '"bar"'],
+                ]
+            ),
+        ];
         yield '[Function] unbalanced with arguments (1)' => [
             '<function($foo, $arg)',
             null,


### PR DESCRIPTION
fixes parsing arrays as a function argument,
example:
the 
 <randomElement(['facebook','instagram','vkontakte'], 'test', ['lalala'])>
should be processed into three tokens/arguments:
['facebook','instagram','vkontakte']
'test'
['lalala'] 