### PR TITLE
Add alternative name for static factory methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ documentation for 2.x, head [here](https://github.com/nelmio/alice/tree/2.x)**.
         1. [Method arguments with flags](doc/complete-reference.md#method-arguments-with-flags)
         1. [Method arguments with parameters](doc/complete-reference.md#method-arguments-with-parameters)
     1. [Specifying Constructor Arguments](doc/complete-reference.md#specifying-constructor-arguments)
-    1. [Using a factory](doc/complete-reference.md#using-a-factory)
+    1. [Using a factory / a named constructor](doc/complete-reference.md#using-a-factory)
     1. [Optional Data](doc/complete-reference.md#optional-data)
     1. [Handling Unique Constraints](doc/complete-reference.md#handling-unique-constraints)
 1. [Handling Relations](doc/relations-handling.md)

--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -9,7 +9,7 @@
     1. [Method arguments with parameters](#method-arguments-with-parameters)
     1. [Optional method calls](#optional-method-calls)
 1. [Specifying Constructor Arguments](#specifying-constructor-arguments)
-1. [Using a factory](#using-a-factory)
+1. [Using a factory / a named constructor](#using-a-factory)
 1. [Optional Data](#optional-data)
 1. [Handling Unique Constraints](#handling-unique-constraints)
 
@@ -221,13 +221,13 @@ Nelmio\Entity\User:
 ```
 
 
-## Using a factory
+## Using a factory / a named constructor
 
 **Note**: the following also applies to `__construct`. However using `__construct` for factories has been deprecated as of
 3.0.0 and will be removed in 4.0.0. Use `__factory` instead.
 
-If you want to call a static factory method instead of a constructor, you can
-specify a hash as the constructor:
+If you want to call a static factory method (a.k.a named constructor) instead
+of a constructor, you can specify a hash as the constructor:
 
 ```yaml
 Nelmio\Entity\User:


### PR DESCRIPTION
I failed to find what I was looking for (named constructor), although it
seems to be used in the code. This should help finding the docs.