### PR TITLE
Throw exception on invalid property

### DIFF
--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer;
 
+use InvalidArgumentException;
 use Nelmio\Alice\Definition\MethodCall\NoMethodCall;
 use Nelmio\Alice\Definition\MethodCallBag;
 use Nelmio\Alice\Definition\MethodCallInterface;
@@ -62,8 +63,13 @@ final class SimpleSpecificationsDenormalizer implements SpecificationsDenormaliz
         $calls = new MethodCallBag();
 
         foreach ($unparsedSpecs as $unparsedPropertyName => $value) {
-            if (!is_string($unparsedPropertyName)) {
-                throw new \InvalidArgumentException("Invalid property name: $unparsedPropertyName.");
+            if (false === is_string($unparsedPropertyName)) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Invalid property name: %s.',
+                        $unparsedPropertyName
+                    )
+                );
             }
 
             if ('__construct' === $unparsedPropertyName) {

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php
@@ -62,6 +62,10 @@ final class SimpleSpecificationsDenormalizer implements SpecificationsDenormaliz
         $calls = new MethodCallBag();
 
         foreach ($unparsedSpecs as $unparsedPropertyName => $value) {
+            if (!is_string($unparsedPropertyName)) {
+                throw new \InvalidArgumentException("Invalid property name: $unparsedPropertyName.");
+            }
+
             if ('__construct' === $unparsedPropertyName) {
                 $constructor = $this->denormalizeConstructor($value, $scope, $parser);
 

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -172,6 +172,25 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid property name: 0.
+     */
+    public function testCannotProceedWithInvalidProperty()
+    {
+        $unparsedSpecs = [
+            'foo'
+        ];
+
+        $denormalizer = new SimpleSpecificationsDenormalizer(
+            new FakeConstructorDenormalizer(),
+            new FakePropertyDenormalizer(),
+            new FakeCallsDenormalizer()
+        );
+
+        $denormalizer->denormalize(new FakeFixture(), new FakeFlagParser(), $unparsedSpecs);
+    }
+
+    /**
      * @expectedException \LogicException
      * @expectedExceptionMessage Cannot use the fixture property "__construct" and "__factory" together.
      */


### PR DESCRIPTION
Hi,

Consider the following bad definition (excerpt):

```yaml
Step:
  st1:
    ingredients:
    - "@i1"
  st2:
    - "@i2"
```

Because I forgot the `ingredients` key on `st2` definition I'm presented with the following error:

```
TypeError: Argument 3 passed to Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\SimpleSpecificationsDenormalizer::denormalizeProperty() must be of the type string, integer given, called in /server/http/vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizer.php on line 99
```

Which appears like a bug in the software more than anything. I mean the application shouldn't crash on a type error.

With this PR, the following exception would be thrown:

```
InvalidArgumentException: Invalid property name: 0.
```

Granted it doesn't give much context about the origin of the error, but it could be improved.

What do you think?

<hr>

Maintainer edit: Closes #792 