### PR TITLE
Add project name in trigger error deprecation notices

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Builder/Builder.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Builder.php
@@ -92,7 +92,7 @@ class Builder
         @trigger_error(
             sprintf(
                 'Fixture with the name "%s" and the class "%s" could not be build. In such cases, null is returned.'
-                .' As of 2.2.0, this behaviour is deprecated and an exception will be thrown in 3.0 instead.',
+                .' As of 2.2.0, this behaviour is deprecated and an exception will be thrown in Alice 3.0 instead.',
                 $name,
                 $class
             ),

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/ListName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/ListName.php
@@ -48,7 +48,7 @@ class ListName implements MethodInterface
             @trigger_error(
                 sprintf(
                     'You have a malformed ranged list "%s". Ranged list must follow the mask "user_{alice, bob}". '
-                    .'Constructing malformed ranged list is deprecated since 2.2.0 and will throw an error in 3.0.',
+                    .'Constructing malformed ranged list is deprecated since 2.2.0 and will throw an error in Alice 3.0.',
                     $name
                 ),
                 E_USER_DEPRECATED

--- a/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
+++ b/src/Nelmio/Alice/Fixtures/Builder/Methods/RangeName.php
@@ -25,7 +25,7 @@ class RangeName implements MethodInterface
         if (1 === preg_match('/\{(?<from>[0-9]+)(?<deprecated>\.{3,})(?<to>[0-9]+)\}/', $name, $this->matches)) {
             @trigger_error(
                 'Ranged name should follow the pattern "name{X..Y}". Using "name{X...Y} or with more dots instead is '
-                .'deprecated since 2.2.0 and will be removed in 3.0. Please mind the change of behavior: "user{0..10}"'
+                .'deprecated since 2.2.0 and will be removed in Alice 3.0. Please mind the change of behavior: "user{0..10}"'
                 .'is creating 11 users whereas "user{0...10}" is creating 10',
                 E_USER_DEPRECATED
             );

--- a/src/Nelmio/Alice/Fixtures/Fixture.php
+++ b/src/Nelmio/Alice/Fixtures/Fixture.php
@@ -398,7 +398,7 @@ class Fixture
             @trigger_error(
                 sprintf(
                     'Fixture references 1 character long should be composed of a letter. Found "%s" instead. This is '
-                    .'is deprecated since 2.2.0 and will be removed in 3.0',
+                    .'is deprecated since 2.2.0 and will be removed in Alice 3.0',
                     $name
                 ),
                 E_USER_DEPRECATED
@@ -408,7 +408,7 @@ class Fixture
                 sprintf(
                     'Fixture references should only be composed of letters, digits, periods ("."), underscores ("_") '
                     .' and slashes ("/"). The usage of other characters is deprecated since 2.2.0 and will no longer be'
-                    .'supported in 3.0',
+                    .'supported in Alice 3.0',
                     $name
                 ),
                 E_USER_DEPRECATED

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Base.php
@@ -34,7 +34,7 @@ abstract class Base implements MethodInterface
     {
         if (null !== $context && false === $context instanceof Loader) {
             @trigger_error(
-                'Passing context in the parser is deprecated since 2.2.0 and will be removed in 3.0.',
+                'Passing context in the parser is deprecated since 2.2.0 and will be removed in Alice 3.0.',
                 E_USER_DEPRECATED
             );
         }

--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithConstructor.php
@@ -62,7 +62,7 @@ class ReflectionWithConstructor implements MethodInterface
             if (false === $constructorRefl->isPublic()) {
                 @trigger_error(
                     'Using a private or protected constructor is deprecated since 2.3.0 and will be removed in '
-                    .'3.0.0.',
+                    .'Alice 3.0.0.',
                     E_USER_DEPRECATED
                 );
             }

--- a/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
+++ b/src/Nelmio/Alice/Instances/Instantiator/Methods/ReflectionWithoutConstructor.php
@@ -48,7 +48,7 @@ class ReflectionWithoutConstructor implements MethodInterface
         ) {
             @trigger_error(
                 'Using a private or protected constructor is deprecated since 2.3.0 and will be removed in '
-                .'3.0.0.',
+                .'Alice 3.0.0.',
                 E_USER_DEPRECATED
             );
         }

--- a/src/Nelmio/Alice/Instances/Populator/Methods/ArrayDirect.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/ArrayDirect.php
@@ -40,7 +40,7 @@ class ArrayDirect implements MethodInterface
     public function set(Fixture $fixture, $object, $property, $value)
     {
         @trigger_error(
-            'Using a method call is deprecated since 2.3.0. This feature is will be removed in 3.0.0 in favour of'
+            'Using a method call is deprecated since 2.3.0. This feature is will be removed in Alice 3.0.0 in favour of'
             .' __calls.',
             E_USER_DEPRECATED
         );

--- a/src/Nelmio/Alice/Instances/Populator/Methods/Custom.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/Custom.php
@@ -29,7 +29,7 @@ class Custom implements MethodInterface
     public function set(Fixture $fixture, $object, $property, $value)
     {
         @trigger_error(
-            'Customer setters are deprecated since 2.3.0 and will be removed in 3.0.0.',
+            'Customer setters are deprecated since 2.3.0 and will be removed in Alice 3.0.0.',
             E_USER_DEPRECATED
         );
 

--- a/src/Nelmio/Alice/Instances/Populator/Methods/Direct.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/Direct.php
@@ -44,7 +44,7 @@ class Direct implements MethodInterface
 
         if (false !== strpos($setter, '_')) {
             @trigger_error(
-                'Using a non PSR-2 compliant setter is deprecated since 2.3.0 and will be removed in 3.0.0.',
+                'Using a non PSR-2 compliant setter is deprecated since 2.3.0 and will be removed in Alice 3.0.0.',
                 E_USER_DEPRECATED
             );
         }
@@ -55,7 +55,7 @@ class Direct implements MethodInterface
             if (false === $refl->isPublic()) {
                 @trigger_error(
                     'Using a private or protected method to set a property is deprecated since 2.3.0 and will be'
-                    .' removed in 3.0.0.',
+                    .' removed in Alice 3.0.0.',
                     E_USER_DEPRECATED
                 );
             }

--- a/src/Nelmio/Alice/Instances/Populator/Methods/Property.php
+++ b/src/Nelmio/Alice/Instances/Populator/Methods/Property.php
@@ -31,7 +31,7 @@ class Property implements MethodInterface
         $refl = new \ReflectionProperty($this->findClass($object, $property), $property);
         if (false === $refl->isPublic()) {
             @trigger_error(
-                'Setting a private or protected directly is deprecated since 2.3.0 and will be removed in 3.0.0.',
+                'Setting a private or protected directly is deprecated since 2.3.0 and will be removed in Alice 3.0.0.',
                 E_USER_DEPRECATED
             );
 

--- a/src/Nelmio/Alice/Instances/Populator/Populator.php
+++ b/src/Nelmio/Alice/Instances/Populator/Populator.php
@@ -128,7 +128,7 @@ class Populator
             } elseif (is_array($value)) {
                 $valHash = hash('md4', serialize($value));
                 @trigger_error(
-                    'Uniqueness of an array will translate in unicity of the items instead of the array hash in 3.0.0.',
+                    'Uniqueness of an array will translate in unicity of the items instead of the array hash in Alice 3.0.0.',
                     E_USER_DEPRECATED
                 );
             } else {

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Conditional.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Conditional.php
@@ -69,7 +69,7 @@ class Conditional implements MethodInterface
         if ((float) $threshold != (int) $threshold) {
             @trigger_error(
                 'Using floats for optional expressions such as "80%? true : false" is deprecated since 2.3.0 and will '
-                .'throw an exception in 3.0. Only integer values should be used.',
+                .'throw an exception in Alice 3.0. Only integer values should be used.',
                 E_USER_DEPRECATED
             );
         }
@@ -78,7 +78,7 @@ class Conditional implements MethodInterface
             @trigger_error(
                 'The threshold value in optional expressions such as "80%? true : false" should be an interger element'
                 .' of ]0;100[, i.e. the values 0 and 100 should not be used. This is deprecated since 2.3.0 and will'
-                .'throw an exception in 3.0. Only integer values should be used.',
+                .'throw an exception in Alice 3.0. Only integer values should be used.',
                 E_USER_DEPRECATED
             );
         }

--- a/src/Nelmio/Alice/Instances/Processor/Methods/Reference.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Reference.php
@@ -112,7 +112,7 @@ class Reference implements MethodInterface
             @trigger_error(
                 sprintf(
                     'A quoted reference "%s" has been given. This is deprecated since 2.3.0 and will throw an exception'
-                    .'in 3.0. Unquote the reference intead.',
+                    .'in Alice 3.0. Unquote the reference intead.',
                     $processable->getValue()
                 ),
                 E_USER_DEPRECATED

--- a/src/Nelmio/Alice/Util/TypeHintChecker.php
+++ b/src/Nelmio/Alice/Util/TypeHintChecker.php
@@ -78,7 +78,7 @@ class TypeHintChecker
     private function createDate($value, \ReflectionMethod $reflectionMethod, $method)
     {
         @trigger_error(
-            'Casting a string date into a DateTime object is deprecated since 2.3.0 and will be removed in 3.0. Create'
+            'Casting a string date into a DateTime object is deprecated since 2.3.0 and will be removed in Alice 3.0. Create'
             .'a DateTime object directly by using the identity function like "<(new \DateTime(\'2012-01-05\'))>" '
             .'instead.',
             E_USER_DEPRECATED


### PR DESCRIPTION
When we execute a PHPUnit test suite with multiple dependencies we need to dig a bit to understand the origin of the deprecation notice message.

In the same way as symfony, I suggest to add in deprecation notices messages the 'Alice' project name