### PR TITLE
Legacy Testing

### DIFF
--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LegacyConstructorDenormalizerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizer
+ * @group legacy
  */
 class LegacyConstructorDenormalizerTest extends TestCase
 {


### PR DESCRIPTION
When i tried to run the test in local i got 3 warning like this one

```
Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Constructor\LegacyConstructorDenormalizerTest::testIsNotClonable
Using the "Legacy" prefix to mark all tests of a class as legacy is deprecated since version 3.3 and will be removed in 4.0. Use the "@group legacy" notation instead to add the test to the legacy group.
```

So i add the `@group legacy` annotation, i don't know if this is the correct thing to do
