### PR TITLE
Make loaders aliases public

### DIFF
--- a/src/Bridge/Symfony/Resources/config/loader.xml
+++ b/src/Bridge/Symfony/Resources/config/loader.xml
@@ -13,7 +13,7 @@
 
     <services>
 
-        <service id="nelmio_alice.data_loader"
+        <service id="nelmio_alice.data_loader" public="true"
                  alias="nelmio_alice.data_loader.simple" />
 
         <service id="nelmio_alice.data_loader.simple"
@@ -22,7 +22,7 @@
             <argument type="service" id="nelmio_alice.generator" />
         </service>
 
-        <service id="nelmio_alice.file_loader"
+        <service id="nelmio_alice.file_loader" public="true"
                  alias="nelmio_alice.file_loader.simple" />
 
         <service id="nelmio_alice.file_loader.simple"


### PR DESCRIPTION
> User Deprecated: The "nelmio_alice.file_loader" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.

because of https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default

I guess we can mark those aliases explicitly public, in order to directly get these services from the container in a functional test case or a doctrine fixture for instance. AFAIK there is still no way to workaround these use-cases.