### PR TITLE
 Add Symfony Yaml PHP constants support integration (2.x)

### DIFF
--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\Alice\Fixtures\Parser\Methods;
 
-use Nelmio\Alice\Fixtures\Loader;
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
 /**

--- a/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
+++ b/src/Nelmio/Alice/Fixtures/Parser/Methods/Yaml.php
@@ -43,7 +43,9 @@ class Yaml extends Base
     public function parse($file)
     {
         $yaml = $this->compilePhp($file);
-        $data = YamlParser::parse($yaml);
+        $data = defined('Symfony\\Component\\Yaml\\Yaml::PARSE_CONSTANT')
+            ? YamlParser::parse($yaml, YamlParser::PARSE_CONSTANT)
+            : YamlParser::parse($yaml);
 
         if (!is_array($data)) {
             throw new \UnexpectedValueException('Yaml files must parse to an array of data');

--- a/tests/Nelmio/Alice/Fixtures/Parser/Files/Yaml/file_with_constants.yml
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Files/Yaml/file_with_constants.yml
@@ -1,0 +1,10 @@
+#
+# This file is part of the Alice package.
+#
+#  (c) Nelmio <hello@nelm.io>
+#
+#  For the full copyright and license information, please view the LICENSE
+#  file that was distributed with this source code.
+#
+
+max_int: !php/const:PHP_INT_MAX

--- a/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
+++ b/tests/Nelmio/Alice/Fixtures/Parser/Methods/YamlTest.php
@@ -78,6 +78,21 @@ class YamlTest extends TestCase
         );
     }
 
+    public function testParseReturnsInterpretedConstants()
+    {
+        if (!defined('Symfony\\Component\\Yaml\\Yaml::PARSE_CONSTANT')) {
+            $this->markTestSkipped('This test needs symfony/yaml v3.2 or higher.');
+        }
+        $data = $this->parser->parse(self::$dir.'/file_with_constants.yml');
+
+        $this->assertSame(
+            [
+                'max_int' => PHP_INT_MAX,
+            ],
+            $data
+        );
+    }
+
     /**
      * @group legacy
      */


### PR DESCRIPTION
Closes #827

@theofidry How do you want to backport this to master? Will you do a manual merge? Would you like me to cherry-pick this feature on an another PR?