### PR TITLE
Fix usage with current

### DIFF
--- a/fixtures/Bridge/Symfony/Application/AppKernel.php
+++ b/fixtures/Bridge/Symfony/Application/AppKernel.php
@@ -19,7 +19,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -63,7 +62,7 @@ class AppKernel extends Kernel
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new class implements CompilerPassInterface {
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
             public function process(ContainerBuilder $container)
             {
                 foreach ($container->getDefinitions() as $id => $definition) {

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/expression_language/token_parser.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/expression_language/token_parser.xml
@@ -70,6 +70,11 @@
             <tag name="nelmio_alice.fixture_builder.expression_language.chainable_token_parser" />
         </service>
 
+        <service id="nelmio_alice.fixture_builder.expression_language.parser.token_parser.chainable.variable_reference_token_parser"
+                 class="Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\VariableReferenceTokenParser">
+            <tag name="nelmio_alice.fixture_builder.expression_language.chainable_token_parser" />
+        </service>
+
         <service id="nelmio_alice.fixture_builder.expression_language.parser.token_parser.chainable.simple_reference_token_parser"
                  class="Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\SimpleReferenceTokenParser">
             <tag name="nelmio_alice.fixture_builder.expression_language.chainable_token_parser" />

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexer.php
@@ -35,6 +35,7 @@ final class ReferenceLexer implements LexerInterface
         '/^@[^\ @]+\{.*,.*}/' => TokenType::LIST_REFERENCE_TYPE,
         '/^@.*\*/' => TokenType::WILDCARD_REFERENCE_TYPE,
         '/^@.*->.*/' => null,
+        '/^@\S+\$\S+/' => TokenType::VARIABLE_REFERENCE_TYPE,
         '/^@\S+/' => TokenType::SIMPLE_REFERENCE_TYPE,
         '/^@/' => TokenType::SIMPLE_REFERENCE_TYPE,
     ];

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParser.php
@@ -53,7 +53,7 @@ final class FunctionFixtureReferenceParser implements ParserInterface
         $mergedValues = array_reduce(
             $parsedValue->getValue(),
             [$this, 'mergeFunctionFixtureReferences'],
-            $initial = []
+            []
         );
 
         return (1 === count($mergedValues))

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/VariableTokenParser.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ValueForCurrentValue;
 use Nelmio\Alice\Definition\Value\VariableValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
@@ -20,6 +22,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ExpressionLanguageExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use TypeError;
 
 /**
  * @internal
@@ -45,9 +48,18 @@ final class VariableTokenParser implements ChainableTokenParserInterface
      */
     public function parse(Token $token)
     {
+        $variable = substr($token->getValue(), 1);
+
+        if ('current' === $variable) {
+            return new FunctionCallValue(
+                'current',
+                [new ValueForCurrentValue()]
+            );
+        }
+
         try {
-            return new VariableValue(substr($token->getValue(), 1));
-        } catch (\TypeError $error) {
+            return new VariableValue($variable);
+        } catch (TypeError $error) {
             throw ExpressionLanguageExceptionFactory::createForUnparsableToken($token, 0, $error);
         }
     }

--- a/src/FixtureBuilder/ExpressionLanguage/TokenType.php
+++ b/src/FixtureBuilder/ExpressionLanguage/TokenType.php
@@ -36,6 +36,7 @@ final class TokenType
     const RANGE_REFERENCE_TYPE = 'RANGE_REFERENCE_TYPE';
     const PROPERTY_REFERENCE_TYPE = 'PROPERTY_REFERENCE_TYPE';
     const METHOD_REFERENCE_TYPE = 'METHOD_REFERENCE_TYPE';
+    const VARIABLE_REFERENCE_TYPE = 'VARIABLE_REFERENCE_TYPE';
 
     const VARIABLE_TYPE = 'VARIABLE_TYPE';
 
@@ -54,6 +55,7 @@ final class TokenType
         self::RANGE_REFERENCE_TYPE => true,
         self::PROPERTY_REFERENCE_TYPE => true,
         self::METHOD_REFERENCE_TYPE => true,
+        self::VARIABLE_REFERENCE_TYPE => true,
         self::VARIABLE_TYPE => true,
     ];
 

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -83,6 +83,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\StringArrayTokenParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\StringTokenParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\TolerantFunctionTokenParser;
+use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\VariableReferenceTokenParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\VariableTokenParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\WildcardReferenceTokenParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\TokenParserRegistry;
@@ -468,6 +469,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
             new OptionalTokenParser(),
             new ParameterTokenParser(),
             new PropertyReferenceTokenParser(),
+            new VariableReferenceTokenParser(),
             new SimpleReferenceTokenParser(),
             new StringArrayTokenParser(),
             new StringTokenParser($argumentEscaper),

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 
+use InvalidArgumentException;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -56,7 +57,7 @@ class LexerIntegrationTest extends TestCase
                     )
                 );
             }
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             if (null === $expected) {
                 return;
             }
@@ -841,6 +842,12 @@ class LexerIntegrationTest extends TestCase
                 new Token('@user{1..2}->username', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE)),
             ],
         ];
+        yield '[Reference] variable with prop' => [
+            '@user$current->username',
+            [
+                new Token('@user$current->username', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE)),
+            ],
+        ];
         yield '[Reference] left with prop' => [
             'foo @user0->username',
             [
@@ -1020,6 +1027,12 @@ class LexerIntegrationTest extends TestCase
                 new Token('foo ', new TokenType(TokenType::STRING_TYPE)),
                 new Token('@user0{alice, bob}', new TokenType(TokenType::LIST_REFERENCE_TYPE)),
                 new Token(' bar', new TokenType(TokenType::STRING_TYPE)),
+            ],
+        ];
+        yield '[Reference] reference variable' => [
+            '@user0$foo',
+            [
+                new Token('@user0$foo', new TokenType(TokenType::VARIABLE_REFERENCE_TYPE)),
             ],
         ];
         yield '[Reference] reference function' => [

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -890,6 +890,18 @@ class ParserIntegrationTest extends TestCase
                 'username'
             ),
         ];
+        yield '[Reference] variable with prop' => [
+            '@user$foo->username',
+            new FixturePropertyValue(
+                new FixtureReferenceValue(
+                    new ListValue([
+                        'user',
+                        new VariableValue('foo'),
+                    ])
+                ),
+                'username'
+            ),
+        ];
         yield '[Reference] left with prop' => [
             'foo @user0->username',
             new ListValue([
@@ -1098,6 +1110,15 @@ class ParserIntegrationTest extends TestCase
                 ]),
                 ' bar',
             ]),
+        ];
+        yield '[Reference] reference variable' => [
+            '@user0$foo',
+            new FixtureReferenceValue(
+                new ListValue([
+                    'user0',
+                    new VariableValue('foo')
+                ])
+            ),
         ];
         yield '[Reference] reference function' => [
             '@user0<foo()>',

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -2025,6 +2025,36 @@ class LoaderIntegrationTest extends TestCase
             ],
         ];
 
+        yield 'dynamic reference with variable' => [
+            [
+                stdClass::class => [
+                    'dummy{1..2}' => [
+                        'name' => '<current()>',
+                    ],
+                    'another_dummy{1..2}' => [
+                        'dummy' => '@dummy$current',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy1' => $dummy1 = StdClassFactory::create([
+                        'name' => '1',
+                    ]),
+                    'dummy2' => $dummy2 = StdClassFactory::create([
+                        'name' => '2',
+                    ]),
+                    'another_dummy1' => StdClassFactory::create([
+                        'dummy' => $dummy1,
+                    ]),
+                    'another_dummy2' => StdClassFactory::create([
+                        'dummy' => $dummy2,
+                    ]),
+                ],
+            ],
+        ];
+
         yield 'property reference value' => [
             [
                 stdClass::class => [
@@ -2068,6 +2098,36 @@ class LoaderIntegrationTest extends TestCase
                     ]),
                     'another_dummy' => StdClassFactory::create([
                         'name' => 'foo',
+                    ]),
+                ],
+            ],
+        ];
+
+        yield 'dynamic property reference value' => [
+            [
+                stdClass::class => [
+                    'dummy{1..2}' => [
+                        'name' => '<current()>',
+                    ],
+                    'another_dummy{1..2}' => [
+                        'dummy' => '@dummy$current->name',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy1' => $dummy1 = StdClassFactory::create([
+                        'name' => '1',
+                    ]),
+                    'dummy2' => $dummy2 = StdClassFactory::create([
+                        'name' => '2',
+                    ]),
+                    'another_dummy1' => StdClassFactory::create([
+                        'dummy' => '1',
+                    ]),
+                    'another_dummy2' => StdClassFactory::create([
+                        'dummy' => '2',
                     ]),
                 ],
             ],
@@ -2782,6 +2842,12 @@ class LoaderIntegrationTest extends TestCase
                     'dummy_{alice, bob}' => [
                         'val' => '<current()>',
                     ],
+                    'dummy_var{1..2}' => [
+                        'val' => '$current',
+                    ],
+                    'dummy_var_{alice, bob}' => [
+                        'val' => '$current',
+                    ],
                 ],
             ],
             [
@@ -2797,6 +2863,18 @@ class LoaderIntegrationTest extends TestCase
                         'val' => 'alice',
                     ]),
                     'dummy_bob' => StdClassFactory::create([
+                        'val' => 'bob',
+                    ]),
+                    'dummy_var1' => StdClassFactory::create([
+                        'val' => 1,
+                    ]),
+                    'dummy_var2' => StdClassFactory::create([
+                        'val' => 2,
+                    ]),
+                    'dummy_var_alice' => StdClassFactory::create([
+                        'val' => 'alice',
+                    ]),
+                    'dummy_var_bob' => StdClassFactory::create([
                         'val' => 'bob',
                     ]),
                 ],


### PR DESCRIPTION
Allow to use `$current` variable outside of the identity context and
more peticuliarly allow to use expressions such as `@user$current`.

Closes #761