### PR TITLE
Avoid deprecated autowiring

### DIFF
--- a/src/Bridge/Symfony/Resources/config/faker.xml
+++ b/src/Bridge/Symfony/Resources/config/faker.xml
@@ -12,6 +12,9 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        
+        <service id="Faker\Generator" public="false"
+            alias="nelmio_alice.faker.generator" />
 
         <service id="nelmio_alice.faker.generator"
                  class="Faker\Generator">


### PR DESCRIPTION
Since Symfony 3.3, if we want use autowire services, we should alias tags with class name https://symfony.com/blog/new-in-symfony-3-3-deprecated-the-autowiring-types
If we create a faker provider and want to tags to "nelmio_alice.faker.provider"
```
AppBundle\Faker\Provider\MyPrettyProvider:
        tags:
            - { name: nelmio_alice.faker.provider }
```
If we don't want to precise argument like Faker\Generator and preserve compatibility for Symfony 4, I've created a service "Faker\Generator" alias to "nelmio_alice.faker.provider"