### PR TITLE
Autoconfigure custom faker providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ cache:
     - "$HOME/.composer/cache/files"
 
 php:
-  - '7.0'
   - '7.1'
-  - '7.2'
   - nightly
 
 env:
@@ -17,12 +15,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '7.0'
+    - php: '7.1'
       env: COMPOSER_FLAGS='--prefer-lowest'
     - php: '7.2'
       env: COVERAGE='true'
-    - php: '7.2'
-      env: SYMFONY_VERSION='~3.3.0'
     - php: '7.2'
       env: SYMFONY_VERSION='~3.4.0'
     - php: '7.2'

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "symfony/phpunit-bridge": "^3.3 || ^4.0",
         "symfony/var-dumper": "^3.2 || ^4.0"
     },
+    "conflict": {
+        "symfony/framework-bundle": "<3.4"
+    },
 
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,19 @@
     ],
 
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
-        "symfony/property-access": "^2.7.11 || ^3.0 || ^4.0",
-        "symfony/yaml": "^2.7 || ^3.0 || ^4.0"
+        "symfony/property-access": "^2.8 || ^3.4 || ^4.0",
+        "symfony/yaml": "^2.8 || ^3.4 || ^4.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.1.0",
         "php-mock/php-mock": "^2.0",
         "phpspec/prophecy": "^1.6",
         "phpunit/phpunit": "^6.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
-        "symfony/var-dumper": "^3.2 || ^4.0"
+        "symfony/phpunit-bridge": "^3.4 || ^4.0",
+        "symfony/var-dumper": "^3.4 || ^4.0"
     },
     "conflict": {
         "symfony/framework-bundle": "<3.4"

--- a/doc/customizing-data-generation.md
+++ b/doc/customizing-data-generation.md
@@ -188,8 +188,11 @@ final class JobProvider extends BaseProvider
 ```
 
 Then you can add it to the Faker Generator used by Alice by either overriding
-the `NativeLoader::createFakerGenerator()` method or register it as a service
-with the tag `nelmio_alice.faker.provider`.
+the `NativeLoader::createFakerGenerator()` method.
+ 
+If you are using Symfony, custom Faker providers are registered by adding the
+tag `nelmio_alice.faker.provider` to the service. Note that this is automatically
+done if your service extends `Faker\Provider\Base`.  
 
 
 <br />

--- a/doc/customizing-data-generation.md
+++ b/doc/customizing-data-generation.md
@@ -191,7 +191,7 @@ Then you can add it to the Faker Generator used by Alice by either overriding
 the `NativeLoader::createFakerGenerator()` method.
  
 If you are using Symfony, custom Faker providers are registered by adding the
-tag `nelmio_alice.faker.provider` to the service. Note that this is automatically
+tag `nelmio_alice.faker.provider` to the services. Note that this is automatically
 done if your service extends `Faker\Provider\Base`.  
 
 

--- a/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Bridge\Symfony\DependencyInjection;
 
+use Faker\Provider\Base as BaseFakerProvider;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -60,11 +61,15 @@ final class NelmioAliceExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(self::SERVICES_DIR));
         $finder = new Finder();
+
         $finder->files()->in(self::SERVICES_DIR);
+
         foreach ($finder as $file) {
             $loader->load(
                 $file->getRelativePathname()
             );
         }
+
+        $container->registerForAutoconfiguration(BaseFakerProvider::class)->addTag('nelmio_alice.faker.provider');
     }
 }

--- a/src/Bridge/Symfony/Resources/config/faker.xml
+++ b/src/Bridge/Symfony/Resources/config/faker.xml
@@ -13,7 +13,7 @@
 
     <services>
         
-        <service id="Faker\Generator" public="false"
+        <service id="Faker\Generator" public="true"
             alias="nelmio_alice.faker.generator" />
 
         <service id="nelmio_alice.faker.generator"

--- a/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
+++ b/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
@@ -29,6 +29,7 @@ use Symfony\Component\PropertyAccess\Exception\ExceptionInterface as SymfonyProp
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException as SymfonyNoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use TypeError;
 
 final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
 {
@@ -65,6 +66,8 @@ final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
             throw HydrationExceptionFactory::createForInvalidProperty($object, $property, 0, $exception);
         } catch (SymfonyPropertyAccessException $exception) {
             throw HydrationExceptionFactory::create($object, $property, 0, $exception);
+        } catch (TypeError $error) {
+            throw HydrationExceptionFactory::createForInvalidProperty($object, $property, 0, $error);
         }
 
         return new SimpleObject($object->getId(), $instance);

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -136,6 +136,7 @@ class SymfonyPropertyAccessorHydratorTest extends TestCase
             $property = new Property('immutableDateTime', 'bar');
 
             $this->hydrator->hydrate($object, $property, new GenerationContext());
+
             $this->fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
             $this->assertEquals(

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "symfony/symfony": "^3.3 || ^4.0",
+        "symfony/symfony": "^3.4 || ^4.0",
         "theofidry/composer-inheritance-plugin": "^1.0"
     },
     "config": {


### PR DESCRIPTION
- Update Travis configuration
- Bump some dependencies
- Add a conflict rule to prevent installation on incompatible versions of Symfony
- Faker providers are automatically registered when they extend the Faker base class
- Make the `Faker\Generator` service public to allow automatic service binding