### PR TITLE
Refactoring tests

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -74,6 +74,7 @@ LICENSE
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'phpdoc_trim' => true,
+        'php_unit_dedicate_assert' => true,
         'php_unit_fqcn_annotation' => true,
         'php_unit_test_class_requires_covers' => true,
         'single_quote' => true,

--- a/tests/Definition/Fixture/TemplatingTest.php
+++ b/tests/Definition/Fixture/TemplatingTest.php
@@ -44,7 +44,7 @@ class TemplatingTest extends TestCase
         $this->assertEquals($isATemplate, $templating->isATemplate());
         $this->assertEquals($extendsFixtures, $templating->extendsFixtures());
         $this->assertEquals($extendedFixtures, $templating->getExtendedFixtures());
-        $this->assertEquals(count($extendedFixtures), count($templating->getExtendedFixtures()));
+        $this->assertCount(count($extendedFixtures), $templating->getExtendedFixtures());
     }
 
     /**
@@ -68,7 +68,7 @@ class TemplatingTest extends TestCase
         ];
         $actual = $templating->getExtendedFixtures();
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         foreach ($expected as $index => $expectedReference) {
             $this->assertEquals($expectedReference, $actual[$index]);
         }

--- a/tests/Definition/FlagBagTest.php
+++ b/tests/Definition/FlagBagTest.php
@@ -196,10 +196,10 @@ class FlagBagTest extends TestCase
     public function testIsCountable()
     {
         $flags = new FlagBag('user0');
-        $this->assertEquals(0, count($flags));
+        $this->assertCount(0, $flags);
 
         $flags = $flags->withFlag(new DummyFlag());
-        $this->assertEquals(1, count($flags));
+        $this->assertCount(1, $flags);
     }
 
     public function testDoesNotDuplicateFlags()

--- a/tests/Definition/PropertyBagTest.php
+++ b/tests/Definition/PropertyBagTest.php
@@ -123,16 +123,16 @@ class PropertyBagTest extends TestCase
     public function testIsCountable()
     {
         $bag = new PropertyBag();
-        $this->assertEquals(0, count($bag));
+        $this->assertCount(0, $bag);
 
         $bag = $bag->with(new Property('foo', 'bar'));
-        $this->assertEquals(1, count($bag));
+        $this->assertCount(1, $bag);
 
         $bag = $bag->with(new Property('foo', 'baz'));
-        $this->assertEquals(1, count($bag));
+        $this->assertCount(1, $bag);
 
         $bag = $bag->with(new Property('ping', 'pong'));
-        $this->assertEquals(2, count($bag));
+        $this->assertCount(2, $bag);
     }
 
     public function testIsEmpty()

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
@@ -45,7 +45,7 @@ class EmptyValueLexerTest extends TestCase
         $lexer = new EmptyValueLexer(new FakeLexer());
         $actual = $lexer->lex('');
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
     }
 
@@ -61,7 +61,7 @@ class EmptyValueLexerTest extends TestCase
         $lexer = new EmptyValueLexer($decoratedLexer);
         $actual = $lexer->lex($value);
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
 
         $decoratedLexerProphecy->lex(Argument::any())->shouldHaveBeenCalledTimes(1);

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
@@ -40,14 +40,14 @@ class GlobalPatternsLexerTest extends TestCase
         $expected = [
             new Token('10x @users', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE)),
         ];
-        
+
         $lexer = new GlobalPatternsLexer(new FakeLexer());
         $actual = $lexer->lex('10x @users');
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testHandOverTheLexificationToTheDecoratedLexerIfNoPatternsMatch()
     {
         $value = 'ali%ce';
@@ -60,7 +60,7 @@ class GlobalPatternsLexerTest extends TestCase
         $lexer = new GlobalPatternsLexer($decoratedLexer);
         $actual = $lexer->lex($value);
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
 
         $decoratedLexerProphecy->lex(Argument::any())->shouldHaveBeenCalledTimes(1);

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/StringThenReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/StringThenReferenceLexerTest.php
@@ -62,7 +62,7 @@ class StringThenReferenceLexerTest extends TestCase
         $lexer = new StringThenReferenceLexer($decoratedLexer);
         $actual = $lexer->lex($value);
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
 
         $decoratedLexerProphecy->lex(Argument::any())->shouldHaveBeenCalledTimes(1);

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
@@ -44,7 +44,7 @@ class SubPatternsLexerTest extends TestCase
         $lexer = new SubPatternsLexer(new FakeLexer());
         $actual = $lexer->lex('<{param}>');
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
     }
 
@@ -63,7 +63,7 @@ class SubPatternsLexerTest extends TestCase
         $lexer = new SubPatternsLexer($referenceLexer);
         $actual = $lexer->lex($value);
 
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
 
         $referenceLexerProphecy->lex(Argument::any())->shouldHaveBeenCalledTimes(1);

--- a/tests/FixtureBuilder/ExpressionLanguage/LexerParserSynchronizationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/LexerParserSynchronizationTest.php
@@ -40,6 +40,6 @@ class LexerParserSynchronizationTest extends TestCase
             $this->assertEquals($lexerProviderKey, $parserProviderKeys[$index]);
         }
 
-        $this->assertEquals(count($lexerProviderKeys), count($parserProviderKeys));
+        $this->assertCount(count($lexerProviderKeys), $parserProviderKeys);
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
@@ -50,7 +50,7 @@ class TokenTypeTest extends TestCase
         $reflProp->setAccessible(true);
         $values = $reflProp->getValue(TokenType::class);
 
-        $this->assertEquals(count($this->constants), count($values));
+        $this->assertCount(count($this->constants), $values);
         foreach ($this->constants as $constant) {
             $this->assertTrue($values[$constant]);
         }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -219,7 +219,7 @@ class LoaderIntegrationTest extends TestCase
             throw $exception;
         }
 
-        $this->assertEquals(count($expected), count($objects));
+        $this->assertCount(count($expected), $objects);
         $this->assertEquals($expected, $objects);
     }
 
@@ -246,12 +246,12 @@ class LoaderIntegrationTest extends TestCase
 
         $expectedParameters = $expected['parameters'];
         $actualParameters = $set->getParameters();
-        $this->assertEquals(count($expectedParameters), count($actualParameters));
+        $this->assertCount(count($expectedParameters), $actualParameters);
         $this->assertEquals($expectedParameters, $actualParameters);
 
         $expectedObjects = $expected['objects'];
         $actualObjects = $set->getObjects();
-        $this->assertEquals(count($expectedObjects), count($actualObjects));
+        $this->assertCount(count($expectedObjects), $actualObjects);
         $this->assertEquals($expectedObjects, $actualObjects);
     }
 
@@ -272,7 +272,7 @@ class LoaderIntegrationTest extends TestCase
         $set = $loader->loadData($data);
 
         $actual = $set->getObjects();
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         $this->assertEquals($expected, $actual);
     }
 
@@ -371,10 +371,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(4, count($objects));
+        $this->assertCount(4, $objects);
 
         $this->assertContains($objects['user0']->username, ['something', null]);
         $this->assertContains($objects['user1']->username, ['something', 'nothing']);
@@ -394,10 +394,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $user = $objects['user'];
         $this->assertInstanceOf(stdClass::class, $user);
@@ -416,14 +416,14 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $user = $objects['user'];
         $this->assertInstanceOf(stdClass::class, $user);
-        $this->assertTrue(10 === $user->age);
+        $this->assertSame(10, $user->age);
     }
 
     public function testLoadLocalizedFakerFunctionWithData()
@@ -438,10 +438,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $user = $objects['user'];
         $this->assertInstanceOf(stdClass::class, $user);
@@ -460,10 +460,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $user = $objects['user'];
         $this->assertInstanceOf(stdClass::class, $user);
@@ -487,10 +487,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $expectedDummy = new stdClass();
         $expectedDummy->relatedDummy = $expectedDummy;
@@ -510,10 +510,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(1, count($objects));
+        $this->assertCount(1, $objects);
 
         $expectedDummy = StdClassFactory::create([
             'email' => 'email@example.com',
@@ -534,10 +534,10 @@ class LoaderIntegrationTest extends TestCase
 
         $set = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($set->getParameters()));
+        $this->assertCount(0, $set->getParameters());
 
         $objects = $set->getObjects();
-        $this->assertEquals(2, count($objects));
+        $this->assertCount(2, $objects);
     }
 
     public function testTemplatesAreKeptBetweenFiles()
@@ -724,14 +724,14 @@ class LoaderIntegrationTest extends TestCase
 
         $result = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($result->getParameters()));
-        $this->assertEquals(10, count($result->getObjects()));
+        $this->assertCount(0, $result->getParameters());
+        $this->assertCount(10, $result->getObjects());
 
         $objects = $result->getObjects();
         $value = [];
         foreach ($objects as $object) {
-            $this->assertTrue(1 <= $object->number);
-            $this->assertTrue(10 >= $object->number);
+            $this->assertGreaterThanOrEqual(1, $object->number);
+            $this->assertLessThanOrEqual(10, $object->number);
             $value[$object->number] = true;
         }
 
@@ -755,11 +755,9 @@ class LoaderIntegrationTest extends TestCase
             $previous = $exception->getPrevious();
 
             $this->assertInstanceOf(UniqueValueGenerationLimitReachedException::class, $previous);
-            $this->assertTrue(
-                1 === preg_match(
-                    '/^Could not generate a unique value after 150 attempts for ".*"\.$/',
-                    $previous->getMessage()
-                )
+            $this->assertRegExp(
+                '/^Could not generate a unique value after 150 attempts for ".*"\.$/',
+                $previous->getMessage()
             );
         }
     }
@@ -778,14 +776,14 @@ class LoaderIntegrationTest extends TestCase
 
         $result = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($result->getParameters()));
-        $this->assertEquals(10, count($result->getObjects()));
+        $this->assertCount(0, $result->getParameters());
+        $this->assertCount(10, $result->getObjects());
 
         $objects = $result->getObjects();
         $value = [];
         foreach ($objects as $object) {
-            $this->assertTrue(1 <= $object->requiredParam);
-            $this->assertTrue(10 >= $object->requiredParam);
+            $this->assertGreaterThanOrEqual(1, $object->requiredParam);
+            $this->assertLessThanOrEqual(10, $object->requiredParam);
             $value[$object->requiredParam] = true;
         }
 
@@ -826,8 +824,8 @@ class LoaderIntegrationTest extends TestCase
 
         $self = $this;
         $assertEachValuesInRelatedDummiesAreUnique = function (ObjectSet $set) use ($self) {
-            $self->assertEquals(0, count($set->getParameters()));
-            $self->assertEquals(4, count($set->getObjects()));
+            $self->assertCount(0, $set->getParameters());
+            $self->assertCount(4, $set->getObjects());
 
             $dummy = $set->getObjects()['dummy1'];
             $self->assertCount(2, $dummy->relatedDummies);
@@ -950,8 +948,8 @@ class LoaderIntegrationTest extends TestCase
 
         $result = $this->loader->loadData($data);
 
-        $this->assertEquals(0, count($result->getParameters()));
-        $this->assertEquals(20, count($result->getObjects()));
+        $this->assertCount(0, $result->getParameters());
+        $this->assertCount(20, $result->getObjects());
 
         $objects = $result->getObjects();
         $value = [
@@ -959,8 +957,8 @@ class LoaderIntegrationTest extends TestCase
             FixtureEntity\DummyWithPublicProperty::class => [],
         ];
         foreach ($objects as $object) {
-            $this->assertTrue(1 <= $object->val);
-            $this->assertTrue(10 >= $object->val);
+            $this->assertGreaterThanOrEqual(1, $object->val);
+            $this->assertLessThanOrEqual(10, $object->val);
             $value[get_class($object)][$object->val] = true;
         }
 

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -294,7 +294,7 @@ class ObjectBagTest extends TestCase
             ],
             $bag->toArray()
         );
-        $this->assertEquals(count($bag), count($bag->toArray()));
+        $this->assertCount(count($bag), $bag->toArray());
     }
 
     public function testCountable()
@@ -327,7 +327,7 @@ class ObjectBagTest extends TestCase
         $actualObjects = $this->propRefl->getValue($actual);
 
         $this->assertEquals($expected, $actualObjects);
-        $this->assertEquals(count($expected), count($actualObjects));
+        $this->assertCount(count($expected), $actualObjects);
     }
 
     private function createFixture(string $reference, string $className): FixtureInterface

--- a/tests/ParameterBagTest.php
+++ b/tests/ParameterBagTest.php
@@ -116,17 +116,17 @@ class ParameterBagTest extends TestCase
 
         $this->assertSame($params, $traversed);
     }
-    
+
     public function testIsCountable()
     {
         $bag = new ParameterBag();
-        $this->assertEquals(0, count($bag));
-        
+        $this->assertCount(0, $bag);
+
         $bag = $bag
             ->with(new Parameter('foo', 'bar'))
             ->with(new Parameter('ping', 'pong'))
         ;
-        $this->assertEquals(2, count($bag));
+        $this->assertCount(2, $bag);
     }
 
     public function testCanRemoveElements()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertGreaterThanOrEqual` and `assertLessThanOrEqual` for mathematical comparion;
- `assertSame` instead of strict comparison `===`;
- `assertRegExp` instead of `preg_match`.

There is a `php_unit_dedicate_assert` rule for `PHP-CS-Fixer`. Should we enable it?