### PR TITLE
Refactoring FileReferenceResolver

### DIFF
--- a/fixtures/Entity/DummyWithThrowableSetter.php
+++ b/fixtures/Entity/DummyWithThrowableSetter.php
@@ -17,6 +17,8 @@ class DummyWithThrowableSetter
 {
     private $val = null;
 
+    private $hydrated = false;
+
     /**
      * @param $val
      */
@@ -27,5 +29,13 @@ class DummyWithThrowableSetter
         }
 
         $this->val = $val;
+    }
+
+    /**
+     * @param $hydrated
+     */
+    public function setHydrated($hydrated)
+    {
+        $this->hydrated = $hydrated;
     }
 }

--- a/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
@@ -147,11 +147,15 @@ final class FixtureReferenceResolver implements ChainableValueResolverInterface,
 
             $context->markIsResolvingFixture($referredFixtureId);
             $objects = $this->generator->generate($referredFixture, $fixtureSet, $context);
-            $fixtureSet =  $fixtureSet->withObjects($objects);
 
             if (false === $needsCompleteGeneration) {
+                $generatedObject = $objects->get($referredFixture);
+                $objects = $objects->with(new CompleteObject($generatedObject));
+
                 $context->unmarkAsNeedsCompleteGeneration();
             }
+
+            $fixtureSet =  $fixtureSet->withObjects($objects);
 
             return new ResolvedValueWithFixtureSet(
                 $fixtureSet->getObjects()->get($referredFixture)->getInstance(),

--- a/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
@@ -15,6 +15,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Fixture\SimpleFixture;
+use Nelmio\Alice\Definition\Object\CompleteObject;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\Definition\Value\DummyValue;
@@ -197,7 +198,7 @@ class FixtureReferenceResolverTest extends TestCase
         $generatorProphecy
             ->generate($referredFixture, $set, $generatorContext)
             ->willReturn(
-                $objects = new ObjectBag(['dummy' => $expectedInstance = new \stdClass()])
+                $objects = new ObjectBag(['dummy' => $generatedObject = new SimpleObject('dummy', $expectedInstance = new \stdClass())])
             )
         ;
         /** @var ObjectGeneratorInterface $generator */
@@ -208,7 +209,7 @@ class FixtureReferenceResolverTest extends TestCase
             ResolvedFixtureSetFactory::create(
                 null,
                 $fixtures,
-                $objects
+                $objects = $objects->with(new CompleteObject($generatedObject))
             )
         );
 

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1871,6 +1871,36 @@ class LoaderIntegrationTest extends TestCase
             ]
         ];
 
+        yield '[construct] with reference to object with throwable setter and caller' => [
+            [
+                FixtureEntity\DummyWithThrowableSetter::class => [
+                    'another_dummy' => [
+                        '__calls' => [
+                            ['setVal' => [1]],
+                        ]
+                    ]
+                ],
+                FixtureEntity\DummyWithConstructorParam::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            '@another_dummy'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'another_dummy' => $anotherDummy1 = (function (FixtureEntity\DummyWithThrowableSetter $anotherDummy1) {
+                        $anotherDummy1->setVal(1);
+
+                        return $anotherDummy1;
+                    })(new FixtureEntity\DummyWithThrowableSetter()),
+                    'dummy' => $dummy1 = new FixtureEntity\DummyWithConstructorParam($anotherDummy1),
+                ]
+            ]
+        ];
+
         yield 'empty instance' => [
             [
                 stdClass::class => [

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1875,6 +1875,7 @@ class LoaderIntegrationTest extends TestCase
             [
                 FixtureEntity\DummyWithThrowableSetter::class => [
                     'another_dummy' => [
+                        'hydrated' => true,
                         '__calls' => [
                             ['setVal' => [1]],
                         ]
@@ -1893,7 +1894,7 @@ class LoaderIntegrationTest extends TestCase
                 'objects' => [
                     'another_dummy' => $anotherDummy1 = (function (FixtureEntity\DummyWithThrowableSetter $anotherDummy1) {
                         $anotherDummy1->setVal(1);
-
+                        $anotherDummy1->setHydrated(true);
                         return $anotherDummy1;
                     })(new FixtureEntity\DummyWithThrowableSetter()),
                     'dummy' => $dummy1 = new FixtureEntity\DummyWithConstructorParam($anotherDummy1),

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1861,12 +1861,12 @@ class LoaderIntegrationTest extends TestCase
             [
                 'parameters' => [],
                 'objects' => [
-                    'another_dummy' => $anotherDummy1 = StdClassFactory::create([
-                        'val' => 1,
-                    ]),
-                    'dummy' => $dummy1 = StdClassFactory::create([
-                        'val' => $anotherDummy1,
-                    ]),
+                    'another_dummy' => $anotherDummy1 = (function (FixtureEntity\DummyWithThrowableSetter $anotherDummy1) {
+                        $anotherDummy1->setVal(1);
+
+                        return $anotherDummy1;
+                    })(new FixtureEntity\DummyWithThrowableSetter()),
+                    'dummy' => $dummy1 = new FixtureEntity\DummyWithConstructorParam($anotherDummy1),
                 ]
             ]
         ];


### PR DESCRIPTION
trying to fix #851 : adds setting CompleteObject for generated content in FileReferenceResolver; fixing tests.

the problem occured due to the following process:

DoublePassGenerator runs with firstPass over the fixtures, trying to generate objects with calling CompleteObjectGenerator calling SimpleObjectGenerator. 
So when this happens for 'code1', the instantiator->instantiate() will follow in calling the FixtureReferenceResolver cause auf the '_construct' - call in the fixture. This FixtureReference Resolves the reference to the fixture for sporty1 and will call the SimpleObjectGenerator->generate() for it.

The Problem here was, that this object was created, but the CompleteObjectGenerator does not track for it. This class only recognizes, that an IncompleteClass was created for 'code1' and correctly does not set this class as completed.
Now the DoublePassGenerator runs with secondPass and again, hydrates the fixture for sporty1 altough it was already hydrated to the FixtureReferenceResolver.

I saw in the FixtureReferenceResolverTest-Class, that it was assumed and expected, that the Generator will return a FixtureSet with an ObjectBag with an instance of CompleteObject. But this was only because the ObjectBag was initialised with it. In a non test environment the FixtureReferenceResolver would return a FixtureSet with an ObjectBag with SimpleObjects in it...
So i changed this behavior in the FixtureReferenceResolver to work as expected as in the Test-Class... The generated object will be set as CompleteObject and the Test-Class had to be changed a little.