### PR TITLE
adding test case to break current loader integration test

### DIFF
--- a/fixtures/Entity/DummyWithThrowableSetter.php
+++ b/fixtures/Entity/DummyWithThrowableSetter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity;
+
+class DummyWithThrowableSetter
+{
+    private $val = null;
+
+    /**
+     * @param $val
+     */
+    public function setVal($val)
+    {
+        if (!empty($this->val)) {
+            throw new \LogicException('val is already initialised, cant be set again');
+        }
+
+        $this->val = $val;
+    }
+}

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1842,6 +1842,35 @@ class LoaderIntegrationTest extends TestCase
 
     public function provideFixturesToGenerate()
     {
+
+        yield '[construct] with reference to object with throwable setter' => [
+            [
+                FixtureEntity\DummyWithThrowableSetter::class => [
+                    'another_dummy' => [
+                        'val' => 1
+                    ]
+                ],
+                FixtureEntity\DummyWithConstructorParam::class => [
+                    'dummy' => [
+                        '__construct' => [
+                            '@another_dummy'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'another_dummy' => $anotherDummy1 = StdClassFactory::create([
+                        'val' => 1,
+                    ]),
+                    'dummy' => $dummy1 = StdClassFactory::create([
+                        'val' => $anotherDummy1,
+                    ]),
+                ]
+            ]
+        ];
+
         yield 'empty instance' => [
             [
                 stdClass::class => [


### PR DESCRIPTION
with the new fixture the process is demonstrating that the fixture generating process will break if one fixture is referenced through a construct call.

supporting changes in https://github.com/nelmio/alice/pull/858