### PR TITLE
Fix successive functions parsing

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/TolerantFunctionTokenParser.php
@@ -33,7 +33,7 @@ final class TolerantFunctionTokenParser extends AbstractChainableParserAwarePars
     use IsAServiceTrait;
 
     /** @private */
-    const REGEX = '/(\)>)(\ *)</';
+    const REGEX = '/(\)>)(.*?)</';
 
     /**
      * @var ChainableTokenParserInterface

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -372,6 +372,18 @@ class LexerIntegrationTest extends TestCase
                 new Token('<aliceTokenizedFunction(FUNCTION_START__f__IDENTITY_OR_FUNCTION_END)> <aliceTokenizedFunction(FUNCTION_START__g__IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
+        yield '[Function] correct successive functions with non space 0' => [
+            '<f()>_<g()>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__f__IDENTITY_OR_FUNCTION_END)>_<aliceTokenizedFunction(FUNCTION_START__g__IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
+        yield '[Function] correct successive functions with non space 1' => [
+            '<f()>h<g()>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__f__IDENTITY_OR_FUNCTION_END)>h<aliceTokenizedFunction(FUNCTION_START__g__IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
         yield '[Function] nested functions' => [
             '<f(<g()>)>',
             [

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -302,6 +302,22 @@ class ParserIntegrationTest extends TestCase
                 new FunctionCallValue('g'),
             ]),
         ];
+        yield '[Function] correct successive functions with non space 0' => [
+            '<f()>_<g()>',
+            new ListValue([
+                new FunctionCallValue('f'),
+                '_',
+                new FunctionCallValue('g'),
+            ]),
+        ];
+        yield '[Function] correct successive functions with non space 1' => [
+            '<f()>h<g()>',
+            new ListValue([
+                new FunctionCallValue('f'),
+                'h',
+                new FunctionCallValue('g'),
+            ]),
+        ];
         yield '[Function] nested functions' => [
             '<f(<g()>)>',
             new FunctionCallValue(


### PR DESCRIPTION
If two functions were separated by a non-whitespace characters, they were not being split correctly.

Closes #861

Thanks for the report @rvadym. Your regex was not enough but I could easily tweak it to make it work :)