### PR TITLE
Avoid redundant inclusion

### DIFF
--- a/fixtures/Integration/recursive_0/another_dummy.yml
+++ b/fixtures/Integration/recursive_0/another_dummy.yml
@@ -1,0 +1,5 @@
+include:
+    - dummy.yml
+
+stdClass:
+    another_dummy: {}

--- a/fixtures/Integration/recursive_0/dummy.yml
+++ b/fixtures/Integration/recursive_0/dummy.yml
@@ -1,0 +1,5 @@
+include:
+    - another_dummy.yml
+
+stdClass:
+    dummy: {}

--- a/fixtures/Integration/recursive_1/another_dummy.yml
+++ b/fixtures/Integration/recursive_1/another_dummy.yml
@@ -1,0 +1,5 @@
+include:
+    - yet_another_dummy.yml
+
+stdClass:
+    another_dummy: {}

--- a/fixtures/Integration/recursive_1/dummy.yml
+++ b/fixtures/Integration/recursive_1/dummy.yml
@@ -1,0 +1,5 @@
+include:
+    - another_dummy.yml
+
+stdClass:
+    dummy: {}

--- a/fixtures/Integration/recursive_1/yet_another_dummy.yml
+++ b/fixtures/Integration/recursive_1/yet_another_dummy.yml
@@ -1,0 +1,5 @@
+include:
+    - dummy.yml
+
+stdClass:
+    yet_another_dummy: {}

--- a/src/Parser/RuntimeCacheParser.php
+++ b/src/Parser/RuntimeCacheParser.php
@@ -74,7 +74,7 @@ final class RuntimeCacheParser implements ParserInterface
         $data = $this->parser->parse($realPath);
 
         if (array_key_exists('include', $data)) {
-            $data = $this->includeProcessor->process($this, $file, $data);
+            $data = $this->includeProcessor->process($this, $realPath, $data);
         }
 
         $this->cache[$realPath] = $data;

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -86,6 +86,47 @@ class LoaderIntegrationTest extends TestCase
         );
     }
 
+    public function testLoadRecursiveFiles()
+    {
+        $objects = $this->loader->loadFiles([
+            self::FIXTURES_FILES_DIR.'/recursive_0/dummy.yml',
+        ])->getObjects();
+
+        $this->assertEquals(
+            [
+                'dummy' => new stdClass(),
+                'another_dummy' => new stdClass(),
+            ],
+            $objects
+        );
+
+        $objects = $this->loader->loadFiles([
+            self::FIXTURES_FILES_DIR.'/recursive_1/dummy.yml',
+        ])->getObjects();
+
+        $this->assertEquals(
+            [
+                'dummy' => new stdClass(),
+                'another_dummy' => new stdClass(),
+                'yet_another_dummy' => new stdClass(),
+            ],
+            $objects
+        );
+
+        $objects = $this->loader->loadFiles([
+            self::FIXTURES_FILES_DIR.'/recursive_1/another_dummy.yml',
+        ])->getObjects();
+
+        $this->assertEquals(
+            [
+                'dummy' => new stdClass(),
+                'another_dummy' => new stdClass(),
+                'yet_another_dummy' => new stdClass(),
+            ],
+            $objects
+        );
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The file "unknown.yml" could not be found.

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -58,11 +58,12 @@ class DefaultIncludeProcessorTest extends TestCase
         $parser = $parserProphecy->reveal();
 
         $fileLocatorProphecy = $this->prophesize(FileLocatorInterface::class);
-        $fileLocatorProphecy->locate(Argument::any())->shouldNotBeCalled();
+        $fileLocatorProphecy->locate('dummy.php')->willReturn('dummy.php');
         /* @var FileLocatorInterface $fileLocator */
         $fileLocator = $fileLocatorProphecy->reveal();
 
         $processor = new DefaultIncludeProcessor($fileLocator);
+
         $processor->process($parser, 'dummy.php', []);
     }
 
@@ -87,7 +88,7 @@ class DefaultIncludeProcessorTest extends TestCase
         $parser = $parserProphecy->reveal();
 
         $fileLocatorProphecy = $this->prophesize(FileLocatorInterface::class);
-        $fileLocatorProphecy->locate(Argument::any())->shouldNotBeCalled();
+        $fileLocatorProphecy->locate($mainFile)->willReturn('main.yml');
         /* @var FileLocatorInterface $fileLocator */
         $fileLocator = $fileLocatorProphecy->reveal();
 
@@ -179,8 +180,8 @@ class DefaultIncludeProcessorTest extends TestCase
         $mainFile = self::$dir.'/main.yml';   // needs to be a real file to be cached
         $parsedMainFileContent = [
             'include' => [
-                'file1.yml',
-                'another_level/file2.yml',
+                $file1Path = 'file1.yml',
+                $file2Path = 'another_level/file2.yml',
             ],
             'Nelmio\Alice\Model\User' => [
                 'user_main' => [],
@@ -193,7 +194,7 @@ class DefaultIncludeProcessorTest extends TestCase
         ];
         $parsedFile2Content = [
             'include' => [
-                self::$dir.'/file3.yml',
+                $file3Path = self::$dir.'/file3.yml',
             ],
             'Nelmio\Alice\Model\User' => [
                 'user_file2' => [],
@@ -221,7 +222,17 @@ class DefaultIncludeProcessorTest extends TestCase
         /* @var ParserInterface $parser */
         $parser = $parserProphecy->reveal();
 
-        $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
+        $fileLocatorProphecy = $this->prophesize(FileLocatorInterface::class);
+        $fileLocatorProphecy->locate('main.yml', Argument::cetera())->willReturn('main.yml');
+        $fileLocatorProphecy->locate($mainFile, Argument::cetera())->willReturn('main.yml');
+        $fileLocatorProphecy->locate($file1Path, Argument::cetera())->willReturn('file1.yml');
+        $fileLocatorProphecy->locate($file2Path, Argument::cetera())->willReturn('file2.yml');
+        $fileLocatorProphecy->locate($file3Path, Argument::cetera())->willReturn('file3.yml');
+        /* @var FileLocatorInterface $fileLocator */
+        $fileLocator = $fileLocatorProphecy->reveal();
+
+        $processor = new DefaultIncludeProcessor($fileLocator);
+
         $actual = $processor->process($parser, $mainFile, $parsedMainFileContent);
 
         $this->assertSame($expected, $actual);

--- a/tests/Parser/RuntimeCacheParserTest.php
+++ b/tests/Parser/RuntimeCacheParserTest.php
@@ -220,7 +220,7 @@ class RuntimeCacheParserTest extends TestCase
         $this->assertSame($expected, $actual);
 
         $decoratedParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(4);
-        $fileLocatorProphecy->locate(Argument::any())->shouldHaveBeenCalledTimes(4);
+        $fileLocatorProphecy->locate(Argument::any())->shouldHaveBeenCalledTimes(4 + 2); // nbr of files + includes
 
 
         // As the parser cache the results, parsing each file does not re-trigger a parse call
@@ -239,6 +239,6 @@ class RuntimeCacheParserTest extends TestCase
         $this->assertSame($parsedFile3Content, $actualFile3);
 
         $decoratedParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(4);
-        $fileLocatorProphecy->locate(Argument::any())->shouldHaveBeenCalledTimes(4 + 4);
+        $fileLocatorProphecy->locate(Argument::any())->shouldHaveBeenCalledTimes(4 + 4 + 2);
     }
 }


### PR DESCRIPTION
When files are refering to each others, they are always included. This
may result in:

- Duplicated fixtures
- Segfault (include recursion)

This PR ensures files are no longer included multiple times during a
same loading.

Closes #845