### PR TITLE
adds check for service tag

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
@@ -70,6 +70,8 @@ final class NelmioAliceExtension extends Extension
             );
         }
 
+        // Check if the auto-configuration of the tag is not already done. This is a temporary measure to avoid to break
+        // existing versions of HautelookAliceBundle
         if ( 0 === count($container->findTaggedServiceIds('nelmio_alice.faker.provider')) ) {
             $container->registerForAutoconfiguration(BaseFakerProvider::class)->addTag('nelmio_alice.faker.provider');
         }

--- a/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
@@ -70,6 +70,8 @@ final class NelmioAliceExtension extends Extension
             );
         }
 
-        $container->registerForAutoconfiguration(BaseFakerProvider::class)->addTag('nelmio_alice.faker.provider');
+        if ( 0 === count($container->findTaggedServiceIds('nelmio_alice.faker.provider')) ) {
+            $container->registerForAutoconfiguration(BaseFakerProvider::class)->addTag('nelmio_alice.faker.provider');
+        }
     }
 }


### PR DESCRIPTION
currently alice and aliceBundle both try to autoRegister classes which are extending BaseFakerProvider.

preventing this happening until alice bundle bumps version information about require nelmio/alice