### PR TITLE
Mark objects as completed whenever possible in SimpleObjectGenerator

### DIFF
--- a/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FixtureReferenceResolver.php
@@ -150,14 +150,6 @@ final class FixtureReferenceResolver implements ChainableValueResolverInterface,
 
             // Restore the context
             $needsCompleteGeneration ? $context->markAsNeedsCompleteGeneration() : $context->unmarkAsNeedsCompleteGeneration();
-//            if (false === $needsCompleteGeneration) {
-//                $generatedObject = $objects->get($referredFixture);
-//                $objects = $objects->with(new CompleteObject($generatedObject));
-
-//                $context->unmarkAsNeedsCompleteGeneration();
-//            }
-
-//            $fixtureSet =  $fixtureSet->withObjects($objects);
 
             return new ResolvedValueWithFixtureSet(
                 $fixtureSet->getObjects()->get($referredFixture)->getInstance(),


### PR DESCRIPTION
Follow up of #865.

I don't think this is necessary, but better safe than sorry. Indeed in theory with the current implementation we could still get incomplete objects from SimpleObjectGenerator although they should be marked as complete.

As mentionned in the changes, this could be done a better way by injecting the CompleteObjectGenerator into the value resolver instead of the SimpleObjectGenerator. This is however not easily doable without BC break changes so we keep it that way for now.

Also note that now the CompleteObjectGenerator is now useless (in 3.x). However I think removing it at this point would do more harm than nothing by eventually breaking something for someone. Instead we can just keep it as the performance overhead for it should be minimal.

Also cleaned up the comments left in #865

/cc @Nijusan 