### PR TITLE
Remove double loading of the var-dumper dump function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,6 @@
         }
     },
     "autoload-dev": {
-        "files": [
-            "vendor/symfony/var-dumper/Resources/functions/dump.php"
-        ],
         "psr-4": {
             "Nelmio\\Alice\\": [
                 "fixtures",


### PR DESCRIPTION
When installing the VarDumper component standalone (as opposed to using the full-stack repo), the file defining the dump function is already loaded automatically. This second require works only because the file itself has a guard to avoid redefining the function, but it is useless.