### PR TITLE
Fix links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Package version](http://img.shields.io/packagist/vpre/nelmio/alice.svg?style=flat-square)](https://packagist.org/packages/nelmio/alice)
 [![Build Status](https://img.shields.io/travis/nelmio/alice.svg?branch=2.x&style=flat-square)](https://travis-ci.org/nelmio/alice?branch=2.x)
-[![Slack](https://img.shields.io/badge/slack-%23alice--fixtures-red.svg?style=flat-square)](https://symfony-devs.slack.com/shared_invite/MTYxMjcxMjc0MTc5LTE0OTA3ODE4OTQtYzc4NWVmMzRmZQ)
+[![Slack](https://img.shields.io/badge/slack-%23alice--fixtures-red.svg?style=flat-square)](https://symfony.com/slack-invite)
 [![License](https://img.shields.io/badge/license-MIT-red.svg?style=flat-square)](LICENSE)
 
 Relying on [fzaninotto/Faker](https://github.com/fzaninotto/Faker), Alice
@@ -16,7 +16,7 @@ very easy to generate complex data with constraints in a readable and easy
 to edit way, so that everyone on your team can tweak the fixtures if needed.
 
 **You are reading the documentation for the 2.x branch. If you want to head back to the latest version, click
-[here](https://github.com/nelmio).**
+[here](https://github.com/nelmio/alice).**
  
 **2.x is in maintenance mode: PRs are accepted, but no active development is done on it by the maintainers any longer.**
 


### PR DESCRIPTION
This fixes the link to the latest version in the 2.x readme.

I also fixed the Slack link while I was at it, as done in master.