### PR TITLE
Do not deep clone resolved values

### DIFF
--- a/src/Definition/Value/ResolvedFunctionCallValue.php
+++ b/src/Definition/Value/ResolvedFunctionCallValue.php
@@ -16,7 +16,7 @@ namespace Nelmio\Alice\Definition\Value;
 use Nelmio\Alice\Definition\ValueInterface;
 
 /**
- * Value object representing '<name()>' (no arguments cloning)
+ * Value object representing a function arguments which have already been re-solved.
  */
 final class ResolvedFunctionCallValue implements ValueInterface
 {

--- a/src/Definition/Value/ResolvedFunctionCallValue.php
+++ b/src/Definition/Value/ResolvedFunctionCallValue.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Definition\Value;
+
+use Nelmio\Alice\Definition\ValueInterface;
+
+/**
+ * Value object representing '<name()>' (no arguments cloning)
+ */
+final class ResolvedFunctionCallValue implements ValueInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @param string $name e.g. 'randomElement'
+     * @param array  $arguments
+     */
+    public function __construct(string $name, array $arguments = [])
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getValue()
+    {
+        return [
+            $this->name,
+            $this->getArguments(),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString(): string
+    {
+        return sprintf('<%s(%s)>', $this->name, [] === $this->arguments ? '' : var_export($this->arguments, true));
+    }
+}

--- a/src/Generator/Resolver/Value/Chainable/FakerFunctionCallValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FakerFunctionCallValueResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Faker\Generator as FakerGenerator;
-use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Faker\GeneratorFactory;
 use Nelmio\Alice\FixtureInterface;
@@ -44,13 +44,13 @@ final class FakerFunctionCallValueResolver implements ChainableValueResolverInte
      */
     public function canResolve(ValueInterface $value): bool
     {
-        return $value instanceof FunctionCallValue;
+        return $value instanceof ResolvedFunctionCallValue;
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param FunctionCallValue $value
+     * @param ResolvedFunctionCallValue $value
      */
     public function resolve(
         ValueInterface $value,

--- a/src/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\Generator\GenerationContext;
@@ -91,7 +92,7 @@ final class FunctionCallArgumentResolver implements ChainableValueResolverInterf
         }
 
         return $this->resolver->resolve(
-            new FunctionCallValue($value->getName(), $arguments),
+            new ResolvedFunctionCallValue($value->getName(), $arguments),
             $fixture,
             $fixtureSet,
             $scope,

--- a/src/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolver.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
-use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\Generator\GenerationContext;
@@ -52,13 +52,13 @@ final class PhpFunctionCallValueResolver implements ChainableValueResolverInterf
      */
     public function canResolve(ValueInterface $value): bool
     {
-        return $value instanceof FunctionCallValue;
+        return $value instanceof ResolvedFunctionCallValue;
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param FunctionCallValue $value
+     * @param ResolvedFunctionCallValue $value
      */
     public function resolve(
         ValueInterface $value,

--- a/tests/Definition/Value/ResolvedFunctionCallValueTest.php
+++ b/tests/Definition/Value/ResolvedFunctionCallValueTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Definition\Value;
+
+use Nelmio\Alice\Definition\ValueInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue
+ */
+class ResolvedFunctionCallValueTest extends TestCase
+{
+    public function testIsAValue()
+    {
+        $this->assertTrue(is_a(ResolvedFunctionCallValue::class, ValueInterface::class, true));
+    }
+
+    public function testReadAccessorsReturnPropertiesValues()
+    {
+        $name = 'setUsername';
+        $arguments = [new \stdClass()];
+
+        $value = new ResolvedFunctionCallValue($name, $arguments);
+
+        $this->assertEquals($name, $value->getName());
+        $this->assertEquals($arguments, $value->getArguments());
+        $this->assertEquals([$name, $arguments], $value->getValue());
+    }
+
+    public function testIsMutable()
+    {
+        $arguments = [
+            $arg0 = new \stdClass(),
+        ];
+        $value = new ResolvedFunctionCallValue('setUsername', $arguments);
+
+        // Mutate injected value
+        $arg0->foo = 'bar';
+
+        $this->assertEquals($arg0->foo, $value->getArguments()[0]->foo);
+        $this->assertSame($arg0, $value->getArguments()[0]);
+
+        $this->assertNotEquals(
+            [
+                new \stdClass(),
+            ],
+            $value->getArguments()
+        );
+        $this->assertNotEquals(
+            [
+                'setUsername',
+                [new \stdClass()],
+            ],
+            $value->getValue()
+        );
+    }
+
+    public function testCanBeCastedIntoAString()
+    {
+        $value = new ResolvedFunctionCallValue('foo');
+        $this->assertEquals('<foo()>', (string) $value);
+
+        $value = new ResolvedFunctionCallValue('foo', ['bar']);
+        $this->assertEquals("<foo(array (\n  0 => 'bar',\n))>", (string) $value);
+    }
+}

--- a/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
@@ -17,7 +17,7 @@ use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
-use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
@@ -46,13 +46,13 @@ class FakerFunctionCallValueResolverValueTest extends TestCase
     {
         $resolver = new FakerFunctionCallValueResolver(FakerGeneratorFactory::create());
 
-        $this->assertTrue($resolver->canResolve(new FunctionCallValue('')));
+        $this->assertTrue($resolver->canResolve(new ResolvedFunctionCallValue('')));
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
     public function testReturnsSetWithResolvedValue()
     {
-        $value = new FunctionCallValue('foo');
+        $value = new ResolvedFunctionCallValue('foo');
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
@@ -74,7 +74,7 @@ class FakerFunctionCallValueResolverValueTest extends TestCase
 
     public function testCallAProviderFunction()
     {
-        $value = new FunctionCallValue('lexify', ['Hello ???']);
+        $value = new ResolvedFunctionCallValue('lexify', ['Hello ???']);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
 
@@ -91,7 +91,7 @@ class FakerFunctionCallValueResolverValueTest extends TestCase
      */
     public function testThrowsAnExceptionIfTriesToCallAnUndefinedProviderFunction()
     {
-        $value = new FunctionCallValue('unknown');
+        $value = new ResolvedFunctionCallValue('unknown');
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create();
 

--- a/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
@@ -135,7 +136,7 @@ class FunctionCallArgumentResolverTest extends TestCase
         $decoratedResolverProphecy = $this->prophesize(ValueResolverInterface::class);
         $decoratedResolverProphecy
             ->resolve(
-                new FunctionCallValue(
+                new ResolvedFunctionCallValue(
                     'foo',
                     [
                         'scalar',

--- a/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
@@ -15,7 +15,7 @@ namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
 use Nelmio\Alice\Definition\Fixture\FakeFixture;
 use Nelmio\Alice\Definition\Value\FakeValue;
-use Nelmio\Alice\Definition\Value\FunctionCallValue;
+use Nelmio\Alice\Definition\Value\ResolvedFunctionCallValue;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
@@ -46,13 +46,13 @@ class PhpFunctionCallValueResolverTest extends TestCase
     {
         $resolver = new PhpFunctionCallValueResolver([], new FakeValueResolver());
 
-        $this->assertTrue($resolver->canResolve(new FunctionCallValue('')));
+        $this->assertTrue($resolver->canResolve(new ResolvedFunctionCallValue('')));
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
     public function testReturnsSetWithEvaluatedValueIfFunctionIsAPhpNativeFunction()
     {
-        $value = new FunctionCallValue('strtolower', ['BAR']);
+        $value = new ResolvedFunctionCallValue('strtolower', ['BAR']);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
@@ -69,7 +69,7 @@ class PhpFunctionCallValueResolverTest extends TestCase
 
     public function testReturnsResultOfTheDecoratedResolverIfFunctionIsNotAPhpNativeFunction()
     {
-        $value = new FunctionCallValue('foo');
+        $value = new ResolvedFunctionCallValue('foo');
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];
@@ -105,7 +105,7 @@ class PhpFunctionCallValueResolverTest extends TestCase
 
     public function testReturnsResultOfTheDecoratedResolverIfFunctionIsBlacklisted()
     {
-        $value = new FunctionCallValue('strtolower', ['BAR']);
+        $value = new ResolvedFunctionCallValue('strtolower', ['BAR']);
         $fixture = new FakeFixture();
         $set = ResolvedFixtureSetFactory::create(new ParameterBag(['foo' => 'bar']));
         $scope = ['val' => 'scopie'];

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1191,6 +1191,27 @@ class LoaderIntegrationTest extends TestCase
         ]);
     }
 
+    public function testFunctionCallArgumentResolverWithObjectsKeepsSameInstances()
+    {
+        $set = $this->loader->loadData([
+            stdClass::class => [
+                'dummy1' => [
+                    'foo' => 'bar',
+                    'sibling' => '<(@dummy2)>',
+                ],
+                'dummy2' => [
+                    'foo' => 'baz',
+                ]
+            ]
+        ]);
+
+        $this->assertCount(2, $set->getObjects());
+        list('dummy1' => $dummy1, 'dummy2' => $dummy2) = $set->getObjects();
+
+        $this->assertNotSame($dummy1, $dummy2);
+        $this->assertSame($dummy2, $dummy1->sibling);
+    }
+
     public function provideFixturesToInstantiate()
     {
         yield 'with default constructor – use default constructor' => [


### PR DESCRIPTION
FunctionCallArgumentResolver when resolving every argument in the FunctionCallValue, creates a new FunctionCallValue to be resolved by any of the functions callers.

FunctionCallValue creates a clone for every argument, so this could be a problem if we want to use objects as arguments (references, variables, ...). For example: to relate two objects that should be persisted. The cloned object is totally new for the persister and out of scope.

Fixes #859