### PR TITLE
Update upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ for 2.x, head [here](https://github.com/nelmio/alice/tree/2.x)**.
         1. [YAML](doc/complete-reference.md#yaml)
         1. [PHP](doc/complete-reference.md#php)
     1. [Fixture Ranges](doc/complete-reference.md#fixture-ranges)
+    1. [Fixture Lists](doc/complete-reference.md#fixture-lists)
     1. [Calling Methods](doc/complete-reference.md#calling-methods)
         1. [Method arguments with flags](doc/complete-reference.md#method-arguments-with-flags)
         1. [Method arguments with parameters](doc/complete-reference.md#method-arguments-with-parameters)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,3 +62,6 @@ done depending on the case, but no Alice maintainer will actively work on it
     which does not support this.
     
     [See the original discussion](https://github.com/nelmio/alice/issues/654)
+
+- The fixture range syntax has been hardened: `user{1..10}`
+- The fixture list syntax has been hardened: `user_{alice, bob}`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,30 +38,35 @@ done depending on the case, but no Alice maintainer will actively work on it
 
 ## User-land changes
 
-- `addXxx()` methods are no longer supported, you need to define a setter for the collection.
+- `addX()` methods are no longer supported unless you have the corresponding
+  `removeX()` method. You will need to define a setter for the collection if
+  you do not want to have the `removeX()` method.
 
-    ```php
-    class Recipe
-    {
-        // no longer supported
-        public function addServing(Serving $serving)
-        {
-            // …
-        }
-        
-        // the setter must be defined
-        public function setServings(iterable $servings)
-        {
-            // …
-        }
-    }
-    ```
-    
-    This change is mostly the result of moving from a custom property accessor to the
-    [Symfony Property Access Component](https://symfony.com/doc/current/components/property_access.html)
-    which does not support this.
-    
-    [See the original discussion](https://github.com/nelmio/alice/issues/654)
+  ```php
+  class Recipe
+  
+      // no longer supported
+      public function addServing(Serving $serving)
+      {
+          // …
+      }
+      
+      // the setter must be defined
+      public function setServings(iterable $servings)
+      {
+          // …
+      }
+  }
+  ```
+  
+  Also note that previously if an `addX($object)` method existed but the
+  argument in alice was an array, then `addX($object)` was called for
+  each elements of the array. This is no longer the case in 3.x. 
+  
+  Those changes are mostly the result of moving from a custom property accessor to the
+  [Symfony Property Access Component](https://symfony.com/doc/current/components/property_access.html).
+  
+  [See the original discussion](https://github.com/nelmio/alice/issues/654)
 
 - The fixture range syntax has been hardened: `user{1..10}`
 - The fixture list syntax has been hardened: `user_{alice, bob}`

--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -4,6 +4,7 @@
     1. [YAML](#yaml)
     1. [PHP](#php)
 1. [Fixture Ranges](#fixture-ranges)
+1. [Fixture Lists](#fixture-lists)
 1. [Calling Methods](#calling-methods)
     1. [Method arguments with flags](#method-arguments-with-flags)
     1. [Method arguments with parameters](#method-arguments-with-parameters)


### PR DESCRIPTION
Closes #872 and #870.

- Add missing title in ToC
- Add missing BC breaks between 2.x and 3.x regarding fixture ranges and lists
- Update the BC break mention regarding the `addX()` methods