### PR TITLE
Add range name reference denormalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ for 2.x, head [here](https://github.com/nelmio/alice/tree/2.x)**.
         1. [PHP](doc/complete-reference.md#php)
     1. [Fixture Ranges](doc/complete-reference.md#fixture-ranges)
     1. [Fixture Lists](doc/complete-reference.md#fixture-lists)
+    1. [Fixture Reference](doc/complete-reference.md#fixture-reference)
     1. [Calling Methods](doc/complete-reference.md#calling-methods)
         1. [Method arguments with flags](doc/complete-reference.md#method-arguments-with-flags)
         1. [Method arguments with parameters](doc/complete-reference.md#method-arguments-with-parameters)

--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -130,21 +130,24 @@ You can also specify a reference to a previously created list of fixtures:
 Nelmio\Entity\User:
     user_{1..10}:
         username: '<name()>'
+
 Nelmio\Entity\UserDetail:
     userdetail_{@user_*}:  # is going to generate `userdetail_user_1`, `userdetail_user_2`, ..., `userdetail_user_10`
         user: <current()>
         email: '<email()>'
 ```
+
 You could either use a star to get all created fixtures matched by the reference or use just one by giving the full fixture name.
 
 ```yaml
 Nelmio\Entity\User:
     user_bob:
         username: 'bob'
+
 Nelmio\Entity\UserDetail:
     userdetail_{@user_bob}:
-        user: <current()>
-        email: 'bob@test.de'
+        user: <current()>   # holds `@user_bob`
+        email: 'bob@test.de'
 ```
 
 >The `<current()>` function holds the value of the referenced fixture.

--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -4,6 +4,7 @@
     1. [YAML](#yaml)
     1. [PHP](#php)
 1. [Fixture Ranges](#fixture-ranges)
+1. [Fixture Reference](#fixture-reference)
 1. [Fixture Lists](#fixture-lists)
 1. [Calling Methods](#calling-methods)
     1. [Method arguments with flags](#method-arguments-with-flags)
@@ -130,7 +131,7 @@ Nelmio\Entity\User:
     user_{1..10}:
         username: '<name()>'
 Nelmio\Entity\UserDetail:
-    userdetail_{@user_*}:
+    userdetail_{@user_*}:  # is going to generate `userdetail_user_1`, `userdetail_user_2`, ..., `userdetail_user_10`
         user: <current()>
         email: '<email()>'
 ```

--- a/doc/complete-reference.md
+++ b/doc/complete-reference.md
@@ -121,6 +121,32 @@ Nelmio\Entity\User:
 
 To go further we the example above, we can just randomize data.
 
+## Fixture Reference
+
+You can also specify a reference to a previously created list of fixtures:
+
+```yaml
+Nelmio\Entity\User:
+    user_{1..10}:
+        username: '<name()>'
+Nelmio\Entity\UserDetail:
+    userdetail_{@user_*}:
+        user: <current()>
+        email: '<email()>'
+```
+You could either use a star to get all created fixtures matched by the reference or use just one by giving the full fixture name.
+
+```yaml
+Nelmio\Entity\User:
+    user_bob:
+        username: 'bob'
+Nelmio\Entity\UserDetail:
+    userdetail_{@user_bob}:
+        user: <current()>
+        email: 'bob@test.de'
+```
+
+>The `<current()>` function holds the value of the referenced fixture.
 
 ## Calling Methods
 

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -15,10 +15,21 @@ namespace Nelmio\Alice;
 
 class User
 {
-    /**
-     * @var string|null
-     */
+    private $id;
+
     private $name;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id): User
+    {
+        $this->id = $id;
+
+        return $this;
+    }
 
     public function getName(): ?string
     {

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -1,33 +1,34 @@
 <?php
 
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Nelmio\Alice;
 
-/**
- * @package Nelmio\Alice
- */
 class User
 {
+    /**
+     * @var string|null
+     */
     private $name;
 
-    /**
-     * @return mixed
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    /**
-     * @param mixed $name
-     *
-     * @return User
-     */
-    public function setName($name)
+    public function setName(?string $name): User
     {
         $this->name = $name;
 
         return $this;
     }
-
-
 }

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nelmio\Alice;
+
+/**
+ * @package Nelmio\Alice
+ */
+class User
+{
+    private $name;
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     *
+     * @return User
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+
+}

--- a/fixtures/UserDetail.php
+++ b/fixtures/UserDetail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Nelmio\Alice;
+
+/**
+ * @package Nelmio\Alice
+ */
+class UserDetail
+{
+    private $email;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @return mixed
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param mixed $email
+     *
+     * @return UserDetail
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return User
+     */
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param User $user
+     *
+     * @return UserDetail
+     */
+    public function setUser(User $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+}

--- a/fixtures/UserDetail.php
+++ b/fixtures/UserDetail.php
@@ -1,12 +1,23 @@
 <?php
 
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Nelmio\Alice;
 
-/**
- * @package Nelmio\Alice
- */
 class UserDetail
 {
+    /**
+     * @var string|null
+     */
     private $email;
 
     /**
@@ -14,40 +25,24 @@ class UserDetail
      */
     private $user;
 
-    /**
-     * @return mixed
-     */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    /**
-     * @param mixed $email
-     *
-     * @return UserDetail
-     */
-    public function setEmail($email)
+    public function setEmail(?string $email): UserDetail
     {
         $this->email = $email;
 
         return $this;
     }
 
-    /**
-     * @return User
-     */
     public function getUser(): User
     {
         return $this->user;
     }
 
-    /**
-     * @param User $user
-     *
-     * @return UserDetail
-     */
-    public function setUser(User $user)
+    public function setUser(User $user): UserDetail
     {
         $this->user = $user;
 

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -53,6 +53,10 @@
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer">
         </service>
 
+        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range_reference"
+                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer">
+        </service>
+
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.temporary_range"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\CollectionDenormalizerWithTemporaryFixture">
             <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range" />

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -51,6 +51,7 @@
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer">
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.specs.simple" />
         </service>
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range_reference"

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -53,8 +53,8 @@
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer">
         </service>
 
-        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range_reference"
-                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer">
+        <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.reference_range_name"
+                 class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\ReferenceRangeNameDenormalizer">
             <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.specs.simple" />
 
             <tag name="nelmio_alice.fixture_builder.denormalizer.chainable_fixture_denormalizer" />

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -56,6 +56,8 @@
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range_reference"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer">
             <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.specs.simple" />
+
+            <tag name="nelmio_alice.fixture_builder.denormalizer.chainable_fixture_denormalizer" />
         </service>
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.temporary_range"

--- a/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
+++ b/src/Bridge/Symfony/Resources/config/fixture_builder/denormalizer/fixture.xml
@@ -51,11 +51,11 @@
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer">
-            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.specs.simple" />
         </service>
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.null_range_reference"
                  class="Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer">
+            <argument type="service" id="nelmio_alice.fixture_builder.denormalizer.specs.simple" />
         </service>
 
         <service id="nelmio_alice.fixture_builder.denormalizer.fixture.chainable.temporary_range"

--- a/src/Definition/Fixture/SimpleFixture.php
+++ b/src/Definition/Fixture/SimpleFixture.php
@@ -42,6 +42,12 @@ final class SimpleFixture implements FixtureInterface
      */
     private $valueForCurrent;
 
+    /**
+     * @param string                           $id
+     * @param string                           $className
+     * @param SpecificationBag                 $specs
+     * @param string|int|FixtureInterface|null $valueForCurrent
+     */
     public function __construct(string $id, string $className, SpecificationBag $specs, $valueForCurrent = null)
     {
         $this->id = $id;

--- a/src/Definition/Fixture/SimpleFixture.php
+++ b/src/Definition/Fixture/SimpleFixture.php
@@ -38,11 +38,11 @@ final class SimpleFixture implements FixtureInterface
     private $specs;
 
     /**
-     * @var string
+     * @var string|int|FixtureInterface
      */
     private $valueForCurrent;
 
-    public function __construct(string $id, string $className, SpecificationBag $specs, string $valueForCurrent = null)
+    public function __construct(string $id, string $className, SpecificationBag $specs, $valueForCurrent = null)
     {
         $this->id = $id;
         $this->className = $className;

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
@@ -29,13 +29,11 @@ use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
 
-final class NullRangeNameReferenceDenormalizer
-    implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
+final class NullRangeNameReferenceDenormalizer implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
 {
     use IsAServiceTrait;
 
-    /** @private */
-    const REGEX = '/.+\{(?<expression>@(?<name>([A-Za-z0-9-_]+))(?<flag>(\*+))?)\}/';
+    private const REGEX = '/.+\{(?<expression>@(?<name>([A-Za-z0-9-_]+))(?<flag>(\*+))?)\}/';
 
     /**
      * @var FlagParserInterface|null
@@ -135,15 +133,8 @@ final class NullRangeNameReferenceDenormalizer
         return $matchedFixtures;
     }
 
-    /**
-     * @param string $fixtureId
-     *
-     * @return string
-     * @throws \LogicException
-     */
-    private function determineFixtureIdPrefix(
-        string $fixtureId
-    ): string {
+    private function determineFixtureIdPrefix(string $fixtureId): string
+    {
         $matches = [];
         if (false === $this->canDenormalize($fixtureId, $matches)) {
             throw LogicExceptionFactory::createForCannotDenormalizerForChainableFixtureBuilderDenormalizer(__METHOD__);
@@ -156,16 +147,6 @@ final class NullRangeNameReferenceDenormalizer
         );
     }
 
-    /**
-     * @param string           $fixtureId
-     * @param string           $className
-     * @param array            $specs
-     * @param FlagBag          $flags
-     * @param FixtureInterface $valueForCurrent
-     *
-     * @return FixtureInterface
-     * @throws \Nelmio\Alice\Throwable\DenormalizationThrowable
-     */
     private function buildFixture(
         string $fixtureId,
         string $className,

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
@@ -98,11 +98,10 @@ final class NullRangeNameReferenceDenormalizer
                     $className,
                     $specs,
                     $flags,
-                    $valueForCurrent->getId()
+                    $valueForCurrent
                 )
             );
         }
-
 
         return $builtFixtures;
     }
@@ -158,11 +157,11 @@ final class NullRangeNameReferenceDenormalizer
     }
 
     /**
-     * @param string  $fixtureId
-     * @param string  $className
-     * @param array   $specs
-     * @param FlagBag $flags
-     * @param string  $valueForCurrent
+     * @param string           $fixtureId
+     * @param string           $className
+     * @param array            $specs
+     * @param FlagBag          $flags
+     * @param FixtureInterface $valueForCurrent
      *
      * @return FixtureInterface
      * @throws \Nelmio\Alice\Throwable\DenormalizationThrowable
@@ -172,7 +171,7 @@ final class NullRangeNameReferenceDenormalizer
         string $className,
         array $specs,
         FlagBag $flags,
-        string $valueForCurrent
+        FixtureInterface $valueForCurrent
     ): FixtureInterface {
         $fixture = new SimpleFixture(
             $fixtureId,

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameReferenceDenormalizer.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable;
+
+use Nelmio\Alice\Definition\Fixture\SimpleFixture;
+use Nelmio\Alice\Definition\Fixture\SimpleFixtureWithFlags;
+use Nelmio\Alice\Definition\Fixture\TemplatingFixture;
+use Nelmio\Alice\Definition\FlagBag;
+use Nelmio\Alice\Definition\MethodCallBag;
+use Nelmio\Alice\Definition\PropertyBag;
+use Nelmio\Alice\Definition\SpecificationBag;
+use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\ChainableFixtureDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationsDenormalizerInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserAwareInterface;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\IsAServiceTrait;
+use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
+
+final class NullRangeNameReferenceDenormalizer
+    implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
+{
+    use IsAServiceTrait;
+
+    /** @private */
+    const REGEX = '/.+\{(?<expression>@(?<name>([A-Za-z0-9-_]+))(?<flag>(\*+))?)\}/';
+
+    /**
+     * @var FlagParserInterface|null
+     */
+    private $flagParser;
+
+    /**
+     * @var SpecificationsDenormalizerInterface
+     */
+    private $specsDenormalizer;
+
+    public function __construct(SpecificationsDenormalizerInterface $specsDenormalizer, FlagParserInterface $parser = null)
+    {
+        $this->specsDenormalizer = $specsDenormalizer;
+        $this->flagParser = $parser;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withFlagParser(FlagParserInterface $parser): self
+    {
+        return new self($this->specsDenormalizer, $parser);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canDenormalize(string $name, array &$matches = []): bool
+    {
+        return 1 === preg_match(self::REGEX, $name, $matches);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function denormalize(
+        FixtureBag $builtFixtures,
+        string $className,
+        string $fixtureId,
+        array $specs,
+        FlagBag $flags
+    ): FixtureBag {
+        $matches = [];
+        if (false === $this->canDenormalize($fixtureId, $matches)) {
+            throw LogicExceptionFactory::createForCannotDenormalizerForChainableFixtureBuilderDenormalizer(__METHOD__);
+        }
+
+        $referencedName = $matches['name'];
+        $allFlag = ($matches['flag'] ?? null) === '*';
+
+        $fixtureIds = $this->buildReferencedValues($builtFixtures, $referencedName, $allFlag);
+
+        $fixtureIdPrefix = $this->determineFixtureIdPrefix($fixtureId);
+
+        foreach ($fixtureIds as $referencedFixtureId => $valueForCurrent) {
+            $builtFixtures = $builtFixtures->with(
+                $this->buildFixture(
+                    $fixtureIdPrefix . $referencedFixtureId,
+                    $className,
+                    $specs,
+                    $flags,
+                    $valueForCurrent->getId()
+                )
+            );
+        }
+
+
+        return $builtFixtures;
+    }
+
+    /**
+     * @param FixtureBag $builtFixtures
+     * @param string     $referencedName
+     * @param bool       $allFlag
+     *
+     * @return array
+     */
+    private function buildReferencedValues(
+        FixtureBag $builtFixtures,
+        string $referencedName,
+        bool $allFlag
+    ): array {
+        if (false === $allFlag) {
+            $fixture = $builtFixtures->get($referencedName);
+
+            return [$referencedName => $fixture];
+        }
+
+        $matchedFixtures = array_filter(
+            $builtFixtures->toArray(),
+            function (string $referenceName) use ($referencedName) {
+                return strpos($referenceName, $referencedName) === 0;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return $matchedFixtures;
+    }
+
+    /**
+     * @param string $fixtureId
+     *
+     * @return string
+     * @throws \LogicException
+     */
+    private function determineFixtureIdPrefix(
+        string $fixtureId
+    ): string {
+        $matches = [];
+        if (false === $this->canDenormalize($fixtureId, $matches)) {
+            throw LogicExceptionFactory::createForCannotDenormalizerForChainableFixtureBuilderDenormalizer(__METHOD__);
+        }
+
+        return str_replace(
+            sprintf('{%s}', $matches['expression']),
+            '',
+            $matches[0]
+        );
+    }
+
+    /**
+     * @param string  $fixtureId
+     * @param string  $className
+     * @param array   $specs
+     * @param FlagBag $flags
+     * @param string  $valueForCurrent
+     *
+     * @return FixtureInterface
+     * @throws \Nelmio\Alice\Throwable\DenormalizationThrowable
+     */
+    private function buildFixture(
+        string $fixtureId,
+        string $className,
+        array $specs,
+        FlagBag $flags,
+        string $valueForCurrent
+    ): FixtureInterface {
+        $fixture = new SimpleFixture(
+            $fixtureId,
+            $className,
+            new SpecificationBag(null, new PropertyBag(), new MethodCallBag()),
+            $valueForCurrent
+        );
+        $fixture = $fixture->withSpecs(
+            $this->specsDenormalizer->denormalize($fixture, $this->flagParser, $specs)
+        );
+
+        return new TemplatingFixture(
+            new SimpleFixtureWithFlags(
+                $fixture,
+                $flags->withKey($fixtureId)
+            )
+        );
+    }
+}

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
@@ -29,7 +29,7 @@ use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
 
-final class NullRangeNameReferenceDenormalizer implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
+final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
 {
     use IsAServiceTrait;
 

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
@@ -90,6 +90,10 @@ final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormaliz
         $fixtureIdPrefix = $this->determineFixtureIdPrefix($fixtureId);
 
         foreach ($fixtureIds as $referencedFixtureId => $valueForCurrent) {
+            if ($valueForCurrent->isATemplate()) {
+                continue;
+            }
+
             $builtFixtures = $builtFixtures->with(
                 $this->buildFixture(
                     $fixtureIdPrefix . $referencedFixtureId,
@@ -109,7 +113,7 @@ final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormaliz
      * @param string     $referencedName
      * @param bool       $allFlag
      *
-     * @return array
+     * @return TemplatingFixture[]
      */
     private function buildReferencedValues(
         FixtureBag $builtFixtures,

--- a/src/Generator/Resolver/Value/Chainable/ValueForCurrentValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/ValueForCurrentValueResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Value\Chainable;
 
+use Nelmio\Alice\Definition\Fixture\SimpleFixture;
 use Nelmio\Alice\Definition\Value\ValueForCurrentValue;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureInterface;
@@ -49,8 +50,21 @@ final class ValueForCurrentValueResolver implements ChainableValueResolverInterf
         array $scope,
         GenerationContext $context
     ): ResolvedValueWithFixtureSet {
+        $valueForCurrent = $fixture->getValueForCurrent();
+
+        if ($valueForCurrent instanceof FixtureInterface) {
+            $valueForCurrent = new SimpleFixture(
+                $valueForCurrent->getId(),
+                $valueForCurrent->getClassName(),
+                $valueForCurrent->getSpecs(),
+                $fixtureSet->getObjects()->get($valueForCurrent)->getInstance()
+            );
+        } else {
+            $valueForCurrent = $fixtureSet->getFixtures()->get($fixture->getId());
+        }
+
         return new ResolvedValueWithFixtureSet(
-            $fixtureSet->getFixtures()->get($fixture->getId()),
+            $valueForCurrent,
             $fixtureSet
         );
     }

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
 use Nelmio\Alice\DataLoaderInterface;
@@ -25,7 +23,9 @@ use Nelmio\Alice\FilesLoaderInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\CollectionDenormalizerWithTemporaryFixture;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullListNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleCollectionDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerRegistry;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SimpleFixtureBagDenormalizer;

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -23,7 +23,7 @@ use Nelmio\Alice\FilesLoaderInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\CollectionDenormalizerWithTemporaryFixture;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullListNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameDenormalizer;
-use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer;
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\ReferenceRangeNameDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleCollectionDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureDenormalizerInterface;
@@ -362,7 +362,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
                         new NullRangeNameDenormalizer()
                     )
                 ),
-                new NullRangeNameReferenceDenormalizer(
+                new ReferenceRangeNameDenormalizer(
                     new SimpleSpecificationsDenormalizer(
                         $this->getConstructorDenormalizer(),
                         $this->getPropertyDenormalizer(),

--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\NullRangeNameReferenceDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer as NelmioSimpleDenormalizer;
 use Faker\Factory as FakerGeneratorFactory;
 use Faker\Generator as FakerGenerator;
@@ -361,6 +362,13 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
                         new NullRangeNameDenormalizer()
                     )
                 ),
+                new NullRangeNameReferenceDenormalizer(
+                    new SimpleSpecificationsDenormalizer(
+                        $this->getConstructorDenormalizer(),
+                        $this->getPropertyDenormalizer(),
+                        $this->getCallsDenormalizer()
+                    )
+                )
             ]
         );
     }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -583,7 +583,7 @@ class LoaderIntegrationTest extends TestCase
         $this->assertCount(2, $objects);
     }
 
-    public function testLoadRangeReference()
+    public function testLoadReferenceRange()
     {
         $data = [
             User::class => [

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -27,6 +27,7 @@ use Nelmio\Alice\Throwable\GenerationThrowable;
 use Nelmio\Alice\Throwable\HydrationThrowable;
 use Nelmio\Alice\Throwable\InstantiationThrowable;
 use Nelmio\Alice\User;
+use Nelmio\Alice\UserDetail;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
@@ -593,7 +594,7 @@ class LoaderIntegrationTest extends TestCase
                     'name' => '<username()>',
                 ],
             ],
-            stdClass::class => [
+            UserDetail::class => [
                 'userdetail_{@user*}' => [
                     'email' => '<email()>',
                     'user'  => '<current()>',
@@ -614,9 +615,9 @@ class LoaderIntegrationTest extends TestCase
         $this->assertArrayHasKey('userdetail_user1', $objects);
         $this->assertArrayHasKey('userdetail_single_user1', $objects);
 
-        $this->assertInstanceOf(User::class, $objects['userdetail_user0']->user);
-        $this->assertInstanceOf(User::class, $objects['userdetail_user1']->user);
-        $this->assertInstanceOf(User::class, $objects['userdetail_single_user1']->user);
+        $this->assertInstanceOf(User::class, $objects['userdetail_user0']->getUser());
+        $this->assertInstanceOf(User::class, $objects['userdetail_user1']->getUser());
+        $this->assertInstanceOf(User::class, $objects['userdetail_single_user1']->getUser());
     }
 
     public function testTemplatesAreKeptBetweenFiles()

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1967,6 +1967,7 @@ class LoaderIntegrationTest extends TestCase
                     'another_dummy' => $yetAnotherDummy1 = (function (FixtureEntity\OnceTimerDummy $anotherDummy1) {
                         $anotherDummy1->call(true);
                         $anotherDummy1->setHydrate(true);
+
                         return $anotherDummy1;
                     })(new FixtureEntity\OnceTimerDummy()),
                     'dummy' => $dummy1 = new FixtureEntity\DummyWithConstructorParam($yetAnotherDummy1),

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -618,6 +618,10 @@ class LoaderIntegrationTest extends TestCase
         $this->assertInstanceOf(User::class, $objects['userdetail_user0']->getUser());
         $this->assertInstanceOf(User::class, $objects['userdetail_user1']->getUser());
         $this->assertInstanceOf(User::class, $objects['userdetail_single_user1']->getUser());
+
+        $this->assertSame($objects['user0'], $objects['userdetail_user0']->getUser());
+        $this->assertSame($objects['user1'], $objects['userdetail_user1']->getUser());
+        $this->assertSame($objects['user1'], $objects['userdetail_single_user1']->getUser());
     }
 
     public function testTemplatesAreKeptBetweenFiles()

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -587,7 +587,10 @@ class LoaderIntegrationTest extends TestCase
     {
         $data = [
             User::class => [
-                'user0' => [
+                'usertemplate (template)' => [
+                    'id' => '<uuid()>',
+                ],
+                'user0 (extends usertemplate)' => [
                     'name' => '<username()>',
                 ],
                 'user1' => [


### PR DESCRIPTION
Hey,

I tried to port my reference range name builder to version 3.0. It works but I'm quite unsure if this is the right way to handle it. (Solves https://github.com/nelmio/alice/issues/692)

One point which is currently not working is the <current()> value, because the simple fixture just requires a string as a name. That would work but then I would need to translate that to the referenced fixture by the id. The ValueForCurrentValueResolver would be the right place but I'm unsure how to differentiate between a normal current value and a current value from the referenced range.

I could add my own Fixture class but just for the one denormalizer?

As I don't know if that is the right way to implement it, I have not add any tests, would do this later when you say that it is the right way to handle the requirements.

And I am a bit unhappy about the name, so if you have any suggestions :)

Thanks for your help.