### PR TITLE
Fix faker regexp when we want to generate SR_LATN names

### DIFF
--- a/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
+++ b/src/Nelmio/Alice/Instances/Processor/Methods/Faker.php
@@ -120,7 +120,7 @@ class Faker implements MethodInterface
      */
     public function process(ProcessableInterface $processable, array $variables)
     {
-        $fakerRegex = '<(?:(?<locale>[a-z]+(?:_[a-z]+)?):)?(?<name>[a-z0-9_]+?)?\((?<args>(?:[^)]*|\)(?!>))*)\)>';
+        $fakerRegex = '<(?:(?<locale>[a-z]+(?:_[a-z]+)?(?:_[a-z]+)?):)?(?<name>[a-z0-9_]+?)?\((?<args>(?:[^)]*|\)(?!>))*)\)>';
         if ($processable->valueMatches('#^'.$fakerRegex.'$#i')) {
             return $this->replacePlaceholder($processable->getMatches(), $variables);
         }

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -2131,6 +2131,23 @@ class LoaderTest extends TestCase
     }
 
     /**
+     * @issue https://github.com/nelmio/alice/issues/906
+     */
+    public function testFakerWithSrLatnRs()
+    {        
+        $res = $this->loadData([
+            self::USER => [
+                'user0' => [
+                    'family_name' => '<sr_Latn_RS:lastName()>',
+                ],
+            ],
+        ]);
+
+        $this->assertNotEquals('<sr_Latn_RS:lastName()>', $res['user0']->family_name);
+        $this->assertNotEmpty($res['user0']->family_name);
+    }
+
+    /**
      * Always return the same structure, see the first sample.
      */
     public function provideSpecialCharactersData()

--- a/tests/Nelmio/Alice/Fixtures/LoaderTest.php
+++ b/tests/Nelmio/Alice/Fixtures/LoaderTest.php
@@ -2133,7 +2133,7 @@ class LoaderTest extends TestCase
     /**
      * @issue https://github.com/nelmio/alice/issues/906
      */
-    public function testFakerWithSrLatnRs()
+    public function testFakerWithLatinLocale()
     {        
         $res = $this->loadData([
             self::USER => [


### PR DESCRIPTION
Fix the regex when we want to generate SR_LATN names.