### PR TITLE
Fix property reference usage with a function call

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizer.php
@@ -57,7 +57,7 @@ final class FunctionTokenizer
 
     public function isTokenized(string $value): bool
     {
-        return '<aliceTokenizedFunction(' === substr($value, 0, 24);
+        return strpos($value, '<aliceTokenizedFunction(') !== false;
     }
 
     public function detokenize(string $value): string

--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
@@ -50,6 +50,7 @@ final class SubPatternsLexer implements LexerInterface
         '/^(@[^\ @\{\<]+\(.*\))/' => self::REFERENCE_LEXER, // Function with text
         '/^(@[^\ @\<]+\{.*\}->\S+\(.*\))/' => self::REFERENCE_LEXER, // Range or list with function
         '/^(@[^\ @\<]+\{.*\}->[^\(\)\ \{]+)/' => self::REFERENCE_LEXER, // Range or list with property
+        '/^(@[^\ @\<]+\<[^>]+\([^)]*\)\>->[^\(\)\ \{]+)/' => self::REFERENCE_LEXER, // function with property, e.g. entity_<current()>->property
         '/^(@[^\ @\<]+\{.*\})/' => self::REFERENCE_LEXER,   // Range or list
         '/^(@[^\ @\{\<]+)/' => self::REFERENCE_LEXER,
         '/^(@)<\S+\(.*\)>/' => self::REFERENCE_LEXER,

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -1125,6 +1125,15 @@ class LexerIntegrationTest extends TestCase
             ],
         ];
 
+        yield '[Reference] property reference with a function call' => [
+            'foo @user0<current()>->prop bar',
+            [
+                new Token('foo ', new TokenType(TokenType::STRING_TYPE)),
+                new Token('@user0<aliceTokenizedFunction(FUNCTION_START__current__IDENTITY_OR_FUNCTION_END)>->prop', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE)),
+                new Token(' bar', new TokenType(TokenType::STRING_TYPE)),
+            ],
+        ];
+
         // Variables
         yield '[Variable] empty variable' => [
             '$',

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -126,5 +126,10 @@ class ReferenceLexerTest extends TestCase
             $value = '@ user',
             [new Token('@', new TokenType(TokenType::SIMPLE_REFERENCE_TYPE))],
         ];
+
+        yield 'property reference with interpolation' => [
+            $value = '@user_<current()>->email',
+            [new Token($value, new TokenType(TokenType::PROPERTY_REFERENCE_TYPE))],
+        ];
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -1243,6 +1243,23 @@ class ParserIntegrationTest extends TestCase
             ]),
         ];
 
+        yield '[Reference] property reference with a function call' => [
+            'foo @user0<current()>->prop bar',
+            new ListValue([
+                'foo ',
+                new FixturePropertyValue(
+                    new FixtureReferenceValue(
+                        new ListValue([
+                            'user0',
+                            new FunctionCallValue('current', [new ValueForCurrentValue()])
+                        ])
+                    ),
+                    'prop'
+                ),
+                ' bar',
+            ]),
+        ];
+
         // Variables
         yield '[Variable] empty variable' => [
             '$',


### PR DESCRIPTION
- Added a lexer regex to match a property reference using a func call
- relaxed the check of the function tokenizer as it will miss the already tokenized function of the reference and fail during the second pass (invoked by PropertyReferenceTokenParser)

Closes #925