### PR TITLE
Do not use minor version for branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "bin-links": false
         },
         "branch-alias": {
-            "dev-master": "3.1.0-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
And make things simpler.

Here is my current issue, to test #926, I did change the `composer.json` file:

```
        "nelmio/alice": "^3.3,>3.3.0",
```

And I have this issue:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package nelmio/alice ^3.3,>3.3.0 exists as nelmio/alice[1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.7.1, 1.7.2, 1.x-dev, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.2.0, 2.2.1, 2.2.2, 2.x-dev, dev-master, 3.1.0.x-dev, v2.3.0, v2.3.1, v2.3.3, v2.3.4, v2.3.5, v3.0.0, v3.0.0-RC.0, v3.0.0-RC.1, v3.0.0-beta.0, v3.0.0-beta.1, v3.0.0-beta.2, v3.0.0-beta.3, v3.0.0-beta.4, v3.0.0-beta.5, v3.0.1, v3.1.0, v3.1.1, v3.1.2, v3.1.3, v3.2.0, v3.2.1, v3.2.2, v3.3.0] but these are rejected by your constraint.
```

It's because the branch alias is still on 3.1 while 3.2 and 3.3 are already out.

I saw regularly this kind of forget issues and I did forget it on my projects too.

The easier way is to make branch alias on major version only. Since you don't have minor branch, it should not be a problem.

Regard.

Side note: You may suggest me to use `dev-master` directly and yes, it will work. But with my notation, I ensure to go back to a stable version on next release, not with `dev-master`.