### PR TITLE
uniquevaluespool: compare by reference 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.1",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
+        "sebastian/comparator": "^3.0",	
         "symfony/property-access": "^2.8 || ^3.4 || ^4.0",
         "symfony/yaml": "^2.8 || ^3.4 || ^4.0"
     },

--- a/src/Generator/Resolver/UniqueValuesPool.php
+++ b/src/Generator/Resolver/UniqueValuesPool.php
@@ -51,7 +51,7 @@ final class UniqueValuesPool
         }
 
         if (is_object($val1)) {
-            return $val1 == $val2;
+            return $val1 === $val2;
         }
 
         if (is_scalar($val1) || null === $val1) {

--- a/src/Generator/Resolver/UniqueValuesPool.php
+++ b/src/Generator/Resolver/UniqueValuesPool.php
@@ -16,7 +16,6 @@ namespace Nelmio\Alice\Generator\Resolver;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 use SebastianBergmann\Comparator\Factory;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Comparator\ObjectComparator;
 
 /**
  * Class storing all the unique values.
@@ -54,7 +53,7 @@ final class UniqueValuesPool
         }
 
         if (is_object($val1) && is_object($val2)) {
-            $comparator = new ObjectComparator();
+            $comparator = (new Factory())->getComparatorFor($val1, $val2);
 
             try {
                 $comparator->assertEquals($val1, $val2);

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1001,7 +1001,7 @@ class LoaderIntegrationTest extends TestCase
                 $this->assertEquals($relatedDummy, $set->getObjects()['related_dummy'.$relatedDummy->name]);
             }
 
-            $self->assertEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
+            $self->assertNotEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
         };
         $assertEachValuesInRelatedDummiesAreUnique($result);
 

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1001,7 +1001,7 @@ class LoaderIntegrationTest extends TestCase
                 $this->assertEquals($relatedDummy, $set->getObjects()['related_dummy'.$relatedDummy->name]);
             }
 
-            $self->assertNotEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
+            $self->assertEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
         };
         $assertEachValuesInRelatedDummiesAreUnique($result);
 

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1287,7 +1287,7 @@ class LoaderIntegrationTest extends TestCase
     }
 
     /**
-     * @sestdox The cache of the loader
+     * @testdox The cache of the loader
      */
     public function testGenerationCache()
     {

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1126,6 +1126,34 @@ class LoaderIntegrationTest extends TestCase
         $this->assertCount(10, $value[FixtureEntity\DummyWithPublicProperty::class]);
     }
 
+    // https://github.com/nelmio/alice/issues/936
+    /**
+     */
+    public function testUniqueCircularReferencesThrowNoFatal()
+    {
+        //sample data, random members, which may or not be also owners of (other) groups
+        //this will cause a fatal error with the old UniqueValuesPool comparison logic (==)
+        $data = [
+            stdClass::class => [
+                'member{1..20}' => [],
+                'group{1..5}' => [
+                    'owner' => '@member*',
+                    'members (unique)' => '<numberBetween(1,3)>x @member*',
+                ],
+            ],
+        ];
+
+        try {
+            $result = $this->loader->loadData($data);
+            $this->assertCount(30, $result->getObjects());
+        } catch (\Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException $e) {
+            //This is necessary, since there may not be enough member objects to choose from.
+            //Alice is not very good at picking pseudo-random elements, it needs large sets and few samples to work reliably.
+            $this->addToAssertionCount(1);
+        }
+
+    }
+
     /**
      * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureNotFoundException
      * @expectedExceptionMessage Could not find the fixture "unknown".
@@ -1258,7 +1286,7 @@ class LoaderIntegrationTest extends TestCase
     }
 
     /**
-     * @testdox The cache of the loader
+     * @sestdox The cache of the loader
      */
     public function testGenerationCache()
     {

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1135,7 +1135,7 @@ class LoaderIntegrationTest extends TestCase
         //this will cause a fatal error with the old UniqueValuesPool comparison logic (==)
         $data = [
             stdClass::class => [
-                'member{1..20}' => [],
+                'member{1..20}' => [ 'id' => '<current()>' ],
                 'group{1..5}' => [
                     'owner' => '@member*',
                     'members (unique)' => '<numberBetween(1,3)>x @member*',
@@ -1145,11 +1145,12 @@ class LoaderIntegrationTest extends TestCase
 
         try {
             $result = $this->loader->loadData($data);
-            $this->assertCount(30, $result->getObjects());
+            $this->assertCount(25, $result->getObjects());
         } catch (\Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException $e) {
             //This is necessary, since there may not be enough member objects to choose from.
             //Alice is not very good at picking pseudo-random elements, it needs large sets and few samples to work reliably.
-            $this->addToAssertionCount(1);
+        } catch (Nelmio\Alice\Throwable\Exception\Generator\DebugUnexpectedValueException $e) {
+            //This exception may be wrapping the above one
         }
 
     }


### PR DESCRIPTION
As described in Issue https://github.com/nelmio/alice/issues/936, change the comparision operator to compare references only, not values to avoid infinite recursion on entities with cyclic/self-references.

