### PR TITLE
Fix comparison of objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.1",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
+        "sebastian/comparator": "^3.0",	
         "symfony/property-access": "^2.8 || ^3.4 || ^4.0",
         "symfony/yaml": "^2.8 || ^3.4 || ^4.0"
     },

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizer.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\InvalidScopeException;
+use function random_bytes;
 
 final class UniqueValueDenormalizer implements ValueDenormalizerInterface
 {
@@ -83,7 +84,7 @@ final class UniqueValueDenormalizer implements ValueDenormalizerInterface
         }
 
         if ($value instanceof DynamicArrayValue) {
-            $uniqueId = uniqid($uniqueId.'::', true);
+            $uniqueId = $uniqueId.'::__array_element_id#'.bin2hex(random_bytes(16));
 
             return new DynamicArrayValue(
                 $value->getQuantifier(),

--- a/src/Generator/Resolver/UniqueValuesPool.php
+++ b/src/Generator/Resolver/UniqueValuesPool.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Nelmio\Alice\Generator\Resolver;
 
 use Nelmio\Alice\Definition\Value\UniqueValue;
-use SebastianBergmann\Comparator\Factory;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
 
 /**
  * Class storing all the unique values.
@@ -52,22 +52,16 @@ final class UniqueValuesPool
             return false;
         }
 
-        if (is_object($val1) && is_object($val2)) {
-            $comparator = (new Factory())->getComparatorFor($val1, $val2);
+        if (is_object($val1)) {
+            $comparator = Factory::getInstance()->getComparatorFor($val1, $val2);
 
             try {
                 $comparator->assertEquals($val1, $val2);
+
                 return true;
             } catch (ComparisonFailure $failure) {
                 return false;
             }
-        }
-
-        if (
-            (is_object($val1) && !is_object($val2))
-            || (!is_object($val1) && is_object($val2))
-        ) {
-            return false;
         }
 
         if (is_scalar($val1) || null === $val1) {

--- a/src/Generator/Resolver/UniqueValuesPool.php
+++ b/src/Generator/Resolver/UniqueValuesPool.php
@@ -51,7 +51,7 @@ final class UniqueValuesPool
         }
 
         if (is_object($val1)) {
-            return $val1 == $val2;
+            return $val1 === $val2;
         }
 
         if (is_scalar($val1) || null === $val1) {

--- a/src/Generator/Resolver/UniqueValuesPool.php
+++ b/src/Generator/Resolver/UniqueValuesPool.php
@@ -16,7 +16,6 @@ namespace Nelmio\Alice\Generator\Resolver;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 use SebastianBergmann\Comparator\Factory;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Comparator\ObjectComparator;
 
 /**
  * Class storing all the unique values.
@@ -54,7 +53,7 @@ final class UniqueValuesPool
         }
 
         if (is_object($val1) && is_object($val2)) {
-            $comparator = new ObjectComparator();
+            $comparator = (new Factory())->getComparatorFor($val1, $val2);
 
             try {
                 $comparator->assertEquals($val1, $val2);

--- a/src/Parser/IncludeProcessor/DefaultIncludeProcessor.php
+++ b/src/Parser/IncludeProcessor/DefaultIncludeProcessor.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\IncludeProcessor;
 
-use function array_reverse;
 use Nelmio\Alice\FileLocatorInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Parser\IncludeProcessorInterface;
 use Nelmio\Alice\ParserInterface;
 use Nelmio\Alice\Throwable\Error\TypeErrorFactory;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
+use function array_reverse;
 
 final class DefaultIncludeProcessor implements IncludeProcessorInterface
 {
@@ -136,6 +136,7 @@ final class DefaultIncludeProcessor implements IncludeProcessorInterface
 
             $this->included[$includeFile] = true;
         }
+
         return $data;
     }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1403,7 +1403,7 @@ class LoaderIntegrationTest extends TestCase
     }
 
     /**
-     * @sestdox The cache of the loader
+     * @testdox The cache of the loader
      */
     public function testGenerationCache()
     {

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1237,7 +1237,7 @@ class LoaderIntegrationTest extends TestCase
         //this will cause a fatal error with the old UniqueValuesPool comparison logic (==)
         $data = [
             stdClass::class => [
-                'member{1..20}' => [],
+                'member{1..20}' => [ 'id' => '<current()>' ],
                 'group{1..5}' => [
                     'owner' => '@member*',
                     'members (unique)' => '<numberBetween(1,3)>x @member*',
@@ -1247,11 +1247,12 @@ class LoaderIntegrationTest extends TestCase
 
         try {
             $result = $this->loader->loadData($data);
-            $this->assertCount(30, $result->getObjects());
+            $this->assertCount(25, $result->getObjects());
         } catch (\Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException $e) {
             //This is necessary, since there may not be enough member objects to choose from.
             //Alice is not very good at picking pseudo-random elements, it needs large sets and few samples to work reliably.
-            $this->addToAssertionCount(1);
+        } catch (Nelmio\Alice\Throwable\Exception\Generator\DebugUnexpectedValueException $e) {
+            //This exception may be wrapping the above one
         }
 
     }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1091,7 +1091,7 @@ class LoaderIntegrationTest extends TestCase
                 $this->assertEquals($relatedDummy, $set->getObjects()['related_dummy'.$relatedDummy->name]);
             }
 
-            $self->assertEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
+            $self->assertNotEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
         };
         $assertEachValuesInRelatedDummiesAreUnique($result);
 

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1091,7 +1091,7 @@ class LoaderIntegrationTest extends TestCase
                 $this->assertEquals($relatedDummy, $set->getObjects()['related_dummy'.$relatedDummy->name]);
             }
 
-            $self->assertNotEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
+            $self->assertEquals($anotherDummy->relatedDummies[0], $anotherDummy->relatedDummies[1]);
         };
         $assertEachValuesInRelatedDummiesAreUnique($result);
 


### PR DESCRIPTION
Closes #938
Closes #936

Rebased & reviewed version of #938.

When comparing objects for unique values, a fatal error was thrown when doing `$object1 == $object2` whenever there was a circular reference.

Changes compared to #938:

- Retouched the unique ID generated for `UniqueValueDenormalizer` (unrelated change but saw that at the same time)
- Use a single instance of `SebastianBergmann\Comparator\Factory` instead of instantiating it each time
- Rewrote the test to ensure a fatal error is occurring before this patch

/cc @BigBadBassMan 