### PR TITLE
Remove obsolete article from the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ for 2.x, head [here](https://github.com/nelmio/alice/tree/2.x)**.
 1. [Upgrade](#upgrade)
     1. [Breaking changes between Alice 2.x and 3.0](UPGRADE.md#breaking-changes-between-alice-2x-and-30)
 
-Other references:
-  - [Tutorial: Using Alice in Symfony](https://knpuniversity.com/screencast/symfony-doctrine/fixtures-alice)
-
 
 ## Installation
 


### PR DESCRIPTION
This article is nice but it is about Alice 2.x and not 3.x.
It should be removed from the Readme.