### PR TITLE
Fix: EvaluatedValueResolver fails to resolve current with range references

### DIFF
--- a/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
@@ -58,6 +58,10 @@ final class EvaluatedValueResolver implements ChainableValueResolverInterface
         $_scope = $scope;
         try {
             $_scope['current'] = $fixture->getValueForCurrent();
+
+            if ($_scope['current'] instanceof FixtureInterface) {
+                $_scope['current'] = $fixtureSet->getObjects()->get($_scope['current'])->getInstance();
+            }
         } catch (NoValueForCurrentException $exception) {
             // Continue
         }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -677,7 +677,7 @@ class LoaderIntegrationTest extends TestCase
                 ],
                 'userdetail_single_{@user1}' => [
                     'email' => '<email()>',
-                    'user'  => '<current()>',
+                    'user'  => '<($current)>',
                 ],
             ],
         ];


### PR DESCRIPTION
EvaluatedValueResolver fails to resolve current with range references.

The feature works as expected with `<current()>` but not with `<($current)>`