### PR TITLE
Fix tags auto-configuration for faker providers (#960)

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
@@ -72,7 +72,7 @@ final class NelmioAliceExtension extends Extension
 
         // Check if the auto-configuration of the tag is not already done. This is a temporary measure to avoid to break
         // existing versions of HautelookAliceBundle
-        if (0 === count($container->findTaggedServiceIds('nelmio_alice.faker.provider'))) {
+        if ([] !== $container->findTaggedServiceIds('nelmio_alice.faker.provider')) {
             $container->registerForAutoconfiguration(BaseFakerProvider::class)->addTag('nelmio_alice.faker.provider');
         }
     }


### PR DESCRIPTION
This fixes: #960