### PR TITLE
Fixed root_node deprecation with Symfony 4.2

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -27,8 +27,14 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('nelmio_alice');
+        $treeBuilder = new TreeBuilder('nelmio_alice');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('nelmio_alice');
+        }
+
         $rootNode
             ->children()
                 ->scalarNode('locale')


### PR DESCRIPTION
Hi, this PR fixes a small deprecation introduced in Symfony 4.2; the fix includes a BC layer for older versions.