### PR TITLE
Allow line breaks in function parameters

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
@@ -43,7 +43,7 @@ final class SubPatternsLexer implements LexerInterface
         '/^\\\$/' => null,
         '/^(<{[^\ <]+}>)/' => TokenType::PARAMETER_TYPE,
         '/^(<\(.+\)>)/' => TokenType::IDENTITY_TYPE,
-        '/^(<\S+\(.*\)>)/' => TokenType::FUNCTION_TYPE,
+        '/^(<\S+\((.|\n|\r)*\)>)/' => TokenType::FUNCTION_TYPE,
         '/^(<\S+>)/' => null,
         '/^(\[[^\[\]]*\])/' => TokenType::STRING_ARRAY_TYPE,
         '/^(@[^\ @\{\<]+\(.*\))/' => self::REFERENCE_LEXER, // Function with text

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -33,7 +33,7 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
     use IsAServiceTrait;
 
     /** @private */
-    const REGEX = '/^<(?<function>.+?)\((?<arguments>.*)\)>$/';
+    const REGEX = '/^<(?<function>(.|\n|\r)+?)\((?<arguments>.*)\)>$/';
 
     /**
      * @var ArgumentEscaper

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
@@ -48,6 +48,19 @@ class SubPatternsLexerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testLexAFunctionContainingLineBreaks()
+    {
+        $expected = [
+            new Token('<identity("foo'.PHP_EOL.'bar")>', new TokenType(TokenType::FUNCTION_TYPE)),
+        ];
+
+        $lexer = new SubPatternsLexer(new FakeLexer());
+        $actual = $lexer->lex('<identity("foo'.PHP_EOL.'bar")>');
+
+        $this->assertCount(count($expected), $actual);
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testUsesDecoratedLexerToLexReferenceValues()
     {
         $value = '@user';


### PR DESCRIPTION
Hello,

As recommended here: https://github.com/nelmio/alice/issues/569#issuecomment-299711055 I wanted to implement something like:

```yaml
Fixtures\Data:
    emails:
        body: "<identity('<p>foo\n\rbar</p>')"
```

But the function regex parser used the `.` token to extract parameters which excludes the line breaks.

I added `\n` and `\r` in addition to the `.` token to make it work with those kind of line breaks. I'm still new to alice so I might have missed some usage that could be broken with these additions. Let me know if this is the case.

I considered the `\X` token but It seems to widen the scope more than it's needed for my use case. Let me know if it it makes more sense to you.

Thanks

