### PR TITLE
Changed use of self to static to allow for easier extension

### DIFF
--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -580,7 +580,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
 
     protected function createFakerGenerator(): FakerGenerator
     {
-        $generator = FakerGeneratorFactory::create(self::LOCALE);
+        $generator = FakerGeneratorFactory::create(static::LOCALE);
         $generator->addProvider(new AliceProvider());
         $generator->seed($this->getSeed());
 


### PR DESCRIPTION
Changed FakerGeneratorFactory::create calls use of LOCALE constant from self to static to allow for easier overriding