### PR TITLE
Fix lexer on long arguments

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexer.php
@@ -44,6 +44,7 @@ final class SubPatternsLexer implements LexerInterface
         '/^(<{[^\ <]+}>)/' => TokenType::PARAMETER_TYPE,
         '/^(<\(.+\)>)/' => TokenType::IDENTITY_TYPE,
         '/^(<\S+\((.|\r?\n)*\)>)/' => TokenType::FUNCTION_TYPE,
+        '/^(<\S+\(.*\)>)/' => TokenType::FUNCTION_TYPE,
         '/^(<\S+>)/' => null,
         '/^(\[[^\[\]]*\])/' => TokenType::STRING_ARRAY_TYPE,
         '/^(@[^\ @\{\<]+\(.*\))/' => self::REFERENCE_LEXER, // Function with text

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -570,6 +570,14 @@ class LexerIntegrationTest extends TestCase
             ]
         ];
 
+        $arg = \str_repeat('a', 2000);
+        yield '[Function] with long argument' => [
+            '<function("'.$arg.'")>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__"'.$arg.'"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE))
+            ]
+        ];
+
         // Arrays
         yield '[Array] nominal string array' => [
             '10x @user',

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -561,6 +561,18 @@ class ParserIntegrationTest extends TestCase
             ),
         ];
 
+        $args = \str_repeat('a', 2000);
+        yield '[Function] with long argument' => [
+            '<function("'.$args.'")>',
+            new FunctionCallValue(
+                'function',
+                [
+                    // On windows if true
+                    $args,
+                ]
+            ),
+        ];
+
         // Arrays
         yield '[Array] nominal string array' => [
             '10x @user',


### PR DESCRIPTION
#967 introduced a regression when argument are too longs. 

When the string is very long, the regexp engine is fine with `.*` but isn't with `(.|.)*`