### PR TITLE
fix(): Fix the missing resolving or references in simple string arrays

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
-use Nelmio\Alice\Definition\Value\ArrayValue;
 use Nelmio\Alice\Definition\Value\EvaluatedValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
 use Nelmio\Alice\Definition\Value\ValueForCurrentValue;
@@ -101,7 +100,6 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         } elseif ('current' === $function) {
             $arguments = [new ValueForCurrentValue()];
         } else {
-            /** @var ArrayValue $arguments */
             $arguments = $this->parseArguments($this->parser, trim($matches['arguments']));
         }
 

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -103,10 +103,6 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         } else {
             /** @var ArrayValue $arguments */
             $arguments = $this->parseArguments($this->parser, trim($matches['arguments']));
-
-            if ($arguments instanceof ArrayValue) {
-                $arguments = $arguments->getValue();
-            }
         }
 
         return new FunctionCallValue($function, $arguments);

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use Nelmio\Alice\Definition\Value\ArrayValue;
 use Nelmio\Alice\Definition\Value\EvaluatedValue;
 use Nelmio\Alice\Definition\Value\FunctionCallValue;
 use Nelmio\Alice\Definition\Value\ValueForCurrentValue;
@@ -100,7 +101,12 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         } elseif ('current' === $function) {
             $arguments = [new ValueForCurrentValue()];
         } else {
+            /** @var ArrayValue $arguments */
             $arguments = $this->parseArguments($this->parser, trim($matches['arguments']));
+
+            if ($arguments instanceof ArrayValue) {
+                $arguments = $arguments->getValue();
+            }
         }
 
         return new FunctionCallValue($function, $arguments);

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParser.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use Nelmio\Alice\Definition\Value\ArrayValue;
+use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
@@ -36,7 +38,7 @@ final class StringArrayTokenParser extends AbstractChainableParserAwareParser
      *
      * {@inheritdoc}
      */
-    public function parse(Token $token): array
+    public function parse(Token $token): ValueInterface
     {
         parent::parse($token);
 
@@ -44,7 +46,7 @@ final class StringArrayTokenParser extends AbstractChainableParserAwareParser
         try {
             $elements = substr($value, 1, strlen($value) - 2);
 
-            return $this->parseElements($this->parser, $elements);
+            return new ArrayValue($this->parseElements($this->parser, $elements));
         } catch (\TypeError $error) {
             throw ExpressionLanguageExceptionFactory::createForUnparsableToken($token, 0, $error);
         }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -391,9 +391,9 @@ class ParserIntegrationTest extends TestCase
             '<function([\'foo\', "bar"])>',
             new FunctionCallValue(
                 'function',
-                new ArrayValue([
-                    ['foo', 'bar'],
-                ])
+                [
+                    new ArrayValue(['foo', 'bar']),
+                ]
             ),
         ];
         yield '[Function] unbalanced with arguments (1)' => [

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -391,9 +391,9 @@ class ParserIntegrationTest extends TestCase
             '<function([\'foo\', "bar"])>',
             new FunctionCallValue(
                 'function',
-                [
+                new ArrayValue([
                     ['foo', 'bar'],
-                ]
+                ])
             ),
         ];
         yield '[Function] unbalanced with arguments (1)' => [
@@ -607,7 +607,7 @@ class ParserIntegrationTest extends TestCase
             '10x [@user->name, @group->getName()]',
             new DynamicArrayValue(
                 10,
-                [
+                new ArrayValue([
                     new FixturePropertyValue(
                         new FixtureReferenceValue('user'),
                         'name'
@@ -616,7 +616,7 @@ class ParserIntegrationTest extends TestCase
                         new FixtureReferenceValue('group'),
                         new FunctionCallValue('getName')
                     ),
-                ]
+                ])
             ),
         ];
         yield '[Array] escaped array' => [
@@ -645,7 +645,7 @@ class ParserIntegrationTest extends TestCase
         ];
         yield '[Array] simple string array' => [
             '[@user->name, @group->getName()]',
-            [
+            new ArrayValue([
                 new FixturePropertyValue(
                     new FixtureReferenceValue('user'),
                     'name'
@@ -654,7 +654,7 @@ class ParserIntegrationTest extends TestCase
                     new FixtureReferenceValue('group'),
                     new FunctionCallValue('getName')
                 ),
-            ],
+            ]),
         ];
 
         // Optional

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable;
 
+use Nelmio\Alice\Definition\Value\ArrayValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
@@ -88,7 +89,7 @@ class StringArrayTokenParserTest extends TestCase
         /** @var ParserInterface $decoratedParser */
         $decoratedParser = $decoratedParserProphecy->reveal();
 
-        $expected = ['parsed_val1', 'parsed_val2'];
+        $expected = new ArrayValue(['parsed_val1', 'parsed_val2']);
 
         $parser = new StringArrayTokenParser($decoratedParser);
         $actual = $parser->parse($token);
@@ -107,7 +108,7 @@ class StringArrayTokenParserTest extends TestCase
         /** @var ParserInterface $decoratedParser */
         $decoratedParser = $decoratedParserProphecy->reveal();
 
-        $expected = [];
+        $expected = new ArrayValue([]);
 
         $parser = new StringArrayTokenParser($decoratedParser);
         $actual = $parser->parse($token);
@@ -125,7 +126,7 @@ class StringArrayTokenParserTest extends TestCase
         /** @var ParserInterface $decoratedParser */
         $decoratedParser = $decoratedParserProphecy->reveal();
 
-        $expected = ['parsed_val1', 'parsed_val2'];
+        $expected = new ArrayValue(['parsed_val1', 'parsed_val2']);
 
         $parser = new StringArrayTokenParser($decoratedParser);
         $actual = $parser->parse($token);

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -2632,6 +2632,30 @@ class LoaderIntegrationTest extends TestCase
             ],
         ];
 
+        yield 'string array value' => [
+            [
+                stdClass::class => [
+                    'dummy' => [
+                        'foo' => 'bar',
+                    ],
+                    'another_dummy' => [
+                        'dummies' => '[@dummy, @dummy, @dummy]',
+                    ],
+                ],
+            ],
+            [
+                'parameters' => [],
+                'objects' => [
+                    'dummy' => $dummy = StdClassFactory::create([
+                        'foo' => 'bar',
+                    ]),
+                    'another_dummy' => StdClassFactory::create([
+                        'dummies' => [$dummy, $dummy, $dummy]
+                    ]),
+                ],
+            ],
+        ];
+
         yield 'array value' => [
             [
                 stdClass::class => [


### PR DESCRIPTION
I had the problem that references in an array:

```
['@user1', '@user2']
```

were correctly recognized but never resolved to a `User` object but stayed as a reference object in the data structure. This PR fixes this.