### PR TITLE
Composer: exclude some folders from downloading into vendor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Not archived
+doc export-ignore
+fixtures export-ignore
+profiling export-ignore
+tests export-ignore
+vendor-bin export-ignore


### PR DESCRIPTION
Hi. This should exlude these folders from composer install.

![image](https://user-images.githubusercontent.com/538058/62381153-20dc6480-b54b-11e9-8217-3f34cada5d5a.png)
