### PR TITLE
Added Symfony 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       env: SYMFONY_VERSION='~4.0.0'
     - php: '7.2'
       env: SYMFONY_VERSION='~4.1.0@dev'
+    - php: '7.2'
+      env: SYMFONY_VERSION='~5.0.0'
   allow_failures:
     - php: nightly
     - env: SYMFONY_VERSION='~4.1.0@dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     - php: '7.2'
       env: SYMFONY_VERSION='~4.1.0@dev'
     - php: '7.2'
+      env: SYMFONY_VERSION='~4.4.0'
+    - php: '7.2'
       env: SYMFONY_VERSION='~5.0.0'
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,11 @@ matrix:
     - php: '7.2'
       env: SYMFONY_VERSION='~3.4.0'
     - php: '7.2'
-      env: SYMFONY_VERSION='~4.0.0'
-    - php: '7.2'
-      env: SYMFONY_VERSION='~4.1.0@dev'
-    - php: '7.2'
       env: SYMFONY_VERSION='~4.4.0'
     - php: '7.2'
       env: SYMFONY_VERSION='~5.0.0'
   allow_failures:
     - php: nightly
-    - env: SYMFONY_VERSION='~4.1.0@dev'
 
 before_install:
   - set -eo pipefail

--- a/composer.json
+++ b/composer.json
@@ -23,17 +23,17 @@
         "php": "^7.1",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
-        "sebastian/comparator": "^3.0",	
-        "symfony/property-access": "^2.8 || ^3.4 || ^4.0",
-        "symfony/yaml": "^2.8 || ^3.4 || ^4.0"
+        "sebastian/comparator": "^3.0",
+        "symfony/property-access": "^2.8 || ^3.4 || ^4.0 || ^5.0",
+        "symfony/yaml": "^2.8 || ^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.1.0",
         "php-mock/php-mock": "^2.0",
         "phpspec/prophecy": "^1.6",
         "phpunit/phpunit": "^7.0",
-        "symfony/phpunit-bridge": "^3.4.5 || ^4.0.5",
-        "symfony/var-dumper": "^3.4 || ^4.0"
+        "symfony/phpunit-bridge": "^3.4.5 || ^4.0.5 || ^5.0",
+        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
     },
     "conflict": {
         "symfony/framework-bundle": "<3.4"

--- a/fixtures/Bridge/Symfony/Application/config.yml
+++ b/fixtures/Bridge/Symfony/Application/config.yml
@@ -9,6 +9,8 @@
 
 framework:
     secret:                  NelmioAliceBundleSecret
+    serializer:
+        enabled: true
     router:
         resource:            ~
         strict_requirements: '%kernel.debug%'

--- a/fixtures/Bridge/Symfony/Application/config_custom.yml
+++ b/fixtures/Bridge/Symfony/Application/config_custom.yml
@@ -9,6 +9,8 @@
 
 framework:
     secret:                  NelmioAliceBundleSecret
+    serializer:
+        enabled: true
     router:
         resource:            ~
         strict_requirements: '%kernel.debug%'


### PR DESCRIPTION
Symfony 4.4 and 5.0 were released today, so I decided to add support for both of them.

I had to enable the serializer since the new error handler component depends on it.

I've never worked with travis CI before, so please forgive me if I did something incorrect there.