### PR TITLE
Update the list of PHP versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
 
 env:
   global:
-    - PHPUNIT_FLAGS='--stop-on-failure --verbose'
+    - PHPUNIT_FLAGS='--verbose'
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
       env: SYMFONY_VERSION='~5.0.0'
 
 before_install:
-  - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini || true
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache:
 php:
   - '7.1'
   - '7.2'
-  - nightly
+  - '7.3'
+  - '7.4'
 
 env:
   global:
@@ -26,8 +27,6 @@ matrix:
       env: SYMFONY_VERSION='~4.4.0'
     - php: '7.2'
       env: SYMFONY_VERSION='~5.0.0'
-  allow_failures:
-    - php: nightly
 
 before_install:
   - set -eo pipefail

--- a/tests/Definition/Value/UniqueValueTest.php
+++ b/tests/Definition/Value/UniqueValueTest.php
@@ -89,7 +89,13 @@ class UniqueValueTest extends TestCase
         $this->assertEquals('(unique) \'foo\'', (string) $value);
 
         $value = new UniqueValue('', new \stdClass());
-        $this->assertEquals("(unique) stdClass::__set_state(array(\n))", (string) $value);
+
+        if (\PHP_VERSION_ID >= 70300) {
+            $expectedStdClass = "(unique) (object) array(\n)";
+        } else {
+            $expectedStdClass = "(unique) stdClass::__set_state(array(\n))";
+        }
+        $this->assertEquals($expectedStdClass, (string) $value);
 
         $value = new UniqueValue('', new DummyValue('foo'));
         $this->assertEquals('(unique) foo', (string) $value);

--- a/tests/Generator/Caller/SimpleCallerTest.php
+++ b/tests/Generator/Caller/SimpleCallerTest.php
@@ -130,7 +130,7 @@ class SimpleCallerTest extends TestCase
                 $object,
                 $set1,
                 $context,
-                $methodCall2
+                $methodCall2->withArguments([])
             )
             ->willReturn(
                 $set2 = ResolvedFixtureSetFactory::create(
@@ -146,7 +146,7 @@ class SimpleCallerTest extends TestCase
                 $object,
                 $set2,
                 $context,
-                $methodCall3
+                $methodCall3->withArguments([])
             )
             ->willReturn(
                 $set3 = ResolvedFixtureSetFactory::create(

--- a/tests/Parser/Chainable/YamlParserTest.php
+++ b/tests/Parser/Chainable/YamlParserTest.php
@@ -63,7 +63,7 @@ class YamlParserTest extends TestCase
     public function setUp()
     {
         $symfonyYamlParserProphecy = $this->prophesize(SymfonyYamlParser::class);
-        $symfonyYamlParserProphecy->parse(Argument::any())->shouldNotBeCalled();
+        $symfonyYamlParserProphecy->parse(Argument::cetera())->shouldNotBeCalled();
         /* @var SymfonyYamlParser $symfonyYamlParser */
         $symfonyYamlParser = $symfonyYamlParserProphecy->reveal();
 
@@ -248,7 +248,7 @@ EOF;
             $file = self::$dir.'/basic.yml';
 
             $symfonyYamlParserProphecy = $this->prophesize(SymfonyYamlParser::class);
-            $symfonyYamlParserProphecy->parse(Argument::any())->willThrow(\Exception::class);
+            $symfonyYamlParserProphecy->parse(Argument::cetera())->willThrow(\Exception::class);
             /* @var SymfonyYamlParser $symfonyYamlParser */
             $symfonyYamlParser = $symfonyYamlParserProphecy->reveal();
 


### PR DESCRIPTION
PHP 7.3 and 7.4 are added. nightly is removed as this is now 8.0-dev and so the job does not even start.