### PR TITLE
Make testsuite compatible with PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /vendor-bin/*/composer.lock
 /humbuglog.json
 /humbuglog.txt
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "bamarni/composer-bin-plugin": "^1.1.0",
         "php-mock/php-mock": "^2.0",
         "phpspec/prophecy": "^1.6",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.5",
         "symfony/phpunit-bridge": "^3.4.5 || ^4.0.5 || ^5.0",
         "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
     },

--- a/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\Bridge\Symfony\DependencyInjection;
 use Nelmio\Alice\Symfony\KernelFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * @covers \Nelmio\Alice\Bridge\Symfony\DependencyInjection\Configuration
@@ -68,14 +69,13 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "nelmio_alice.locale": Expected a string value but got "boolean" instead.
-     */
     public function testLocaleMustBeAStringValues()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "nelmio_alice.locale": Expected a string value but got "boolean" instead.');
 
         $processor->processConfiguration(
             $configuration,
@@ -111,14 +111,13 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^Invalid type for path "nelmio_alice.functions_blacklist"\. Expected array, but got string/
-     */
     public function testFunctionsBlacklistMustAnArray()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.functions_blacklist"\. Expected array, but got string/');
 
         $processor->processConfiguration(
             $configuration,
@@ -130,14 +129,13 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "nelmio_alice.functions_blacklist": Expected an array of strings but got "boolean" element in the array instead.
-     */
     public function testFunctionsBlacklistMustBeStrings()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "nelmio_alice.functions_blacklist": Expected an array of strings but got "boolean" element in the array instead.');
 
         $processor->processConfiguration(
             $configuration,
@@ -149,14 +147,13 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "nelmio_alice.max_unique_values_retry": Expected a strictly positive integer but got "0" instead.
-     */
     public function testMaxUniqueValuesRetryMustBeAStrictlyPositiveValues()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "nelmio_alice.max_unique_values_retry": Expected a strictly positive integer but got "0" instead.');
 
         $processor->processConfiguration(
             $configuration,
@@ -168,14 +165,13 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^Invalid type for path "nelmio_alice.loading_limit"\. Expected int, but got boolean\./
-     */
     public function testLoadingLimitMustBeAnInteger()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.loading_limit"\. Expected int, but got boolean\./');
 
         $processor->processConfiguration(
             $configuration,
@@ -187,14 +183,13 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "nelmio_alice.loading_limit": Expected a strictly positive integer but got "0" instead.
-     */
     public function testLoadingLimitMustBeAStrictlyPositiveValues()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "nelmio_alice.loading_limit": Expected a strictly positive integer but got "0" instead.');
 
         $processor->processConfiguration(
             $configuration,
@@ -206,14 +201,13 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^Invalid type for path "nelmio_alice.max_unique_values_retry"\. Expected int, but got boolean\./
-     */
     public function testMaxUniqueValuesRetryMustBeAnInteger()
     {
         $configuration = new Configuration();
         $processor = new Processor();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.max_unique_values_retry"\. Expected int, but got boolean\./');
 
         $processor->processConfiguration(
             $configuration,

--- a/tests/Bridge/Symfony/DependencyInjection/DynamicServicesConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/DynamicServicesConfigurationTest.php
@@ -36,7 +36,7 @@ class DynamicServicesConfigurationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->kernel = KernelFactory::createKernel(__DIR__.'/../../../../fixtures/Bridge/Symfony/Application/config_custom.yml');
         $this->kernel->boot();
@@ -45,7 +45,7 @@ class DynamicServicesConfigurationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         if (null !== $this->kernel) {
             $this->kernel->shutdown();

--- a/tests/Bridge/Symfony/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/Bridge/Symfony/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -27,7 +27,7 @@ class LexerIntegrationTest extends CoreLexerIntegrationTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->lexer = new IsolatedSymfonyBuiltInLexer();
     }

--- a/tests/Bridge/Symfony/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/Bridge/Symfony/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -25,7 +25,7 @@ class ParserIntegrationTest extends CoreParserIntegrationTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new IsolatedSymfonyBuiltInParser();
     }

--- a/tests/Bridge/Symfony/Generator/Resolver/ParameterResolverIntegrationTest.php
+++ b/tests/Bridge/Symfony/Generator/Resolver/ParameterResolverIntegrationTest.php
@@ -24,7 +24,7 @@ class ParameterResolverIntegrationTest extends \Nelmio\Alice\Generator\Resolver\
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->resolver = new IsolatedSymfonyParameterBagResolver();
     }

--- a/tests/Bridge/Symfony/Loader/LoaderIntegrationTest.php
+++ b/tests/Bridge/Symfony/Loader/LoaderIntegrationTest.php
@@ -32,7 +32,7 @@ class LoaderIntegrationTest extends CoreLoaderIntegrationTest
     /**
      * @inheritdoc
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -42,7 +42,7 @@ class LoaderIntegrationTest extends CoreLoaderIntegrationTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         static::$kernel->boot();
 
@@ -52,7 +52,7 @@ class LoaderIntegrationTest extends CoreLoaderIntegrationTest
     /**
      * @inheritdoc
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         static::$kernel->shutdown();
     }
@@ -60,7 +60,7 @@ class LoaderIntegrationTest extends CoreLoaderIntegrationTest
     /**
      * @inheritdoc
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         static::$kernel = null;
 

--- a/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
@@ -29,7 +29,7 @@ class SimpleFixtureWithFlagsTest extends TestCase
     {
         $this->assertTrue(is_a(SimpleFixtureWithFlags::class, FixtureWithFlagsInterface::class, true));
     }
-    
+
     public function testReadAccessorsReturnPropertiesValues()
     {
         $reference = 'user0';
@@ -93,14 +93,13 @@ class SimpleFixtureWithFlagsTest extends TestCase
         $this->assertEquals($flags, $newFixture->getFlags());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected the fixture ID and the flags key to be the same. Got "foo" and "bar" instead.
-     */
     public function testThrowsAnExceptionIfFixtureIdAndFlagKeyMistmatch()
     {
         $fixture = new DummyFixture('foo');
         $flags = new FlagBag('bar');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected the fixture ID and the flags key to be the same. Got "foo" and "bar" instead.');
 
         new SimpleFixtureWithFlags($fixture, $flags);
     }

--- a/tests/Definition/MethodCall/NoMethodCallTest.php
+++ b/tests/Definition/MethodCall/NoMethodCallTest.php
@@ -33,43 +33,43 @@ class NoMethodCallTest extends TestCase
         $this->assertEquals('none', $call->__toString());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::withArguments()" should not be called.
-     */
     public function testCannotCreateNewInstanceWithNewArguments()
     {
         $call = new NoMethodCall();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::withArguments()" should not be called.');
+
         $call->withArguments();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getCaller()" should not be called.
-     */
     public function testCannotGetCaller()
     {
         $call = new NoMethodCall();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getCaller()" should not be called.');
+
         $call->getCaller();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getMethod()" should not be called.
-     */
     public function testCannotGetMethod()
     {
         $call = new NoMethodCall();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getMethod()" should not be called.');
+
         $call->getMethod();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getArguments()" should not be called.
-     */
     public function testCannotGetArguments()
     {
         $call = new NoMethodCall();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('By its nature, "Nelmio\Alice\Definition\MethodCall\NoMethodCall::getArguments()" should not be called.');
+
         $call->getArguments();
     }
 }

--- a/tests/Definition/MethodCallBagTest.php
+++ b/tests/Definition/MethodCallBagTest.php
@@ -30,7 +30,7 @@ class MethodCallBagTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $refl = new \ReflectionClass(MethodCallBag::class);
         $propRefl = $refl->getProperty('methodCalls');

--- a/tests/Definition/Object/CompleteObjectTest.php
+++ b/tests/Definition/Object/CompleteObjectTest.php
@@ -127,13 +127,12 @@ class CompleteObjectTest extends TestCase
         $this->assertEquals(new \stdClass(), $clone->getInstance());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Cannot create a new object from a complete object.
-     */
     public function testCannotCreateANewInstance()
     {
         $object = new CompleteObject(new FakeObject());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot create a new object from a complete object.');
 
         $object->withInstance(null);
     }

--- a/tests/Definition/Object/SimpleObjectTest.php
+++ b/tests/Definition/Object/SimpleObjectTest.php
@@ -30,7 +30,7 @@ class SimpleObjectTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propRefl = (new \ReflectionClass(SimpleObject::class))->getProperty('instance');
         $this->propRefl->setAccessible(true);

--- a/tests/Definition/Object/SimpleObjectTest.php
+++ b/tests/Definition/Object/SimpleObjectTest.php
@@ -88,12 +88,12 @@ class SimpleObjectTest extends TestCase
 
     /**
      * @dataProvider provideInvalidInstances
-     *
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^Expected instance argument to be an object. Got ".+?" instead\.$/
      */
     public function testThrowsAnErrorIfInstanceIsNotAnObject($instance)
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^Expected instance argument to be an object. Got ".+?" instead\.$/');
+
         new SimpleObject('user0', $instance);
     }
 

--- a/tests/Definition/PropertyBagTest.php
+++ b/tests/Definition/PropertyBagTest.php
@@ -28,7 +28,7 @@ class PropertyBagTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $refl = new \ReflectionClass(PropertyBag::class);
         $propRefl = $refl->getProperty('properties');

--- a/tests/Definition/Value/UniqueValueTest.php
+++ b/tests/Definition/Value/UniqueValueTest.php
@@ -39,13 +39,13 @@ class UniqueValueTest extends TestCase
         $this->assertEquals($value, $definition->getValue());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot create a unique value of a unique value for value "".
-     */
     public function testCannotCreateUniqueOfUniqueValue()
     {
         $definition = new UniqueValue('', new \stdClass());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot create a unique value of a unique value for value "".');
+
         new UniqueValue('', $definition);
     }
 

--- a/tests/FileLocator/DefaultFileLocatorTest.php
+++ b/tests/FileLocator/DefaultFileLocatorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\Alice\FileLocator;
 
 use Nelmio\Alice\FileLocatorInterface;
+use Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -67,30 +68,27 @@ class DefaultFileLocatorTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException
-     * @expectedExceptionMessage An empty file name is not valid to be located.
-     */
     public function testThrowsExceptionIfEmptyFileNamePassed()
     {
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('An empty file name is not valid to be located.');
+
         $this->locator->locate('');
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException
-     * @expectedExceptionMessageRegExp /^The file "(.+?)foobar.xml" does not exist\.$/
-     */
     public function testThrowsExceptionIfTheFileDoesNotExists()
     {
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessageRegExp('/^The file "(.+?)foobar.xml" does not exist\.$/');
+
         $this->locator->locate('foobar.xml', __DIR__);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException
-     * @expectedExceptionMessageRegExp /^The file "(.+?)foobar.xml" does not exist\.$/
-     */
     public function testLocatingFileThrowsExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessageRegExp('/^The file "(.+?)foobar.xml" does not exist\.$/');
+
         $this->locator->locate(__DIR__.'/Fixtures/foobar.xml');
     }
 

--- a/tests/FileLocator/DefaultFileLocatorTest.php
+++ b/tests/FileLocator/DefaultFileLocatorTest.php
@@ -29,7 +29,7 @@ class DefaultFileLocatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->locator = new DefaultFileLocator();
     }

--- a/tests/FixtureBagTest.php
+++ b/tests/FixtureBagTest.php
@@ -34,7 +34,7 @@ class FixtureBagTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $propRelf = (new \ReflectionClass(FixtureBag::class))->getProperty('fixtures');
         $propRelf->setAccessible(true);

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullListNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullListNameDenormalizerTest.php
@@ -29,7 +29,7 @@ class NullListNameDenormalizerTest extends ChainableDenormalizerTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->denormalizer = new NullListNameDenormalizer();
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/NullRangeNameDenormalizerTest.php
@@ -30,7 +30,7 @@ class NullRangeNameDenormalizerTest extends ChainableDenormalizerTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->denormalizer = new NullRangeNameDenormalizer();
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
@@ -39,7 +39,7 @@ class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->denormalizer = new ReferenceRangeNameDenormalizer(
             new DummySpecificationBagDenormalizer(),

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
@@ -28,6 +28,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\DummyFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use Prophecy\Argument;
 use ReflectionClass;
 
@@ -57,16 +58,16 @@ class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
         $this->assertFalse((new ReflectionClass(ReferenceRangeNameDenormalizer::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\ReferenceRangeNameDenormalizer::denormalize" to be called only if it has a flag parser.
-     */
     public function testCannotDenormalizeFixtureIfHasNoFlagParser()
     {
         /** @var SpecificationsDenormalizerInterface $specsDenormalizer */
         $specsDenormalizer = $this->prophesize(SpecificationsDenormalizerInterface::class)->reveal();
 
         $denormalizer = new ReferenceRangeNameDenormalizer($specsDenormalizer);
+
+        $this->expectException(FlagParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\ReferenceRangeNameDenormalizer::denormalize" to be called only if it has a flag parser.');
+
         $denormalizer->denormalize(new FixtureBag(), 'Nelmio\Alice\Entity\User', 'user_{@account}', [], new FlagBag(''));
     }
 

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
@@ -39,7 +39,7 @@ class SimpleDenormalizerTest extends ChainableDenormalizerTest
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->denormalizer = new SimpleDenormalizer(
             new DummySpecificationBagDenormalizer(),

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
@@ -28,6 +28,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\DummyFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use Prophecy\Argument;
 use ReflectionClass;
 
@@ -57,16 +58,16 @@ class SimpleDenormalizerTest extends ChainableDenormalizerTest
         $this->assertFalse((new ReflectionClass(SimpleDenormalizer::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer::denormalize" to be called only if it has a flag parser.
-     */
     public function testCannotDenormalizeFixtureIfHasNoFlagParser()
     {
         /** @var SpecificationsDenormalizerInterface $specsDenormalizer */
         $specsDenormalizer = $this->prophesize(SpecificationsDenormalizerInterface::class)->reveal();
 
         $denormalizer = new SimpleDenormalizer($specsDenormalizer);
+
+        $this->expectException(FlagParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\Chainable\SimpleDenormalizer::denormalize" to be called only if it has a flag parser.');
+
         $denormalizer->denormalize(new FixtureBag(), 'Nelmio\Alice\Entity\User', 'user0', [], new FlagBag(''));
     }
 

--- a/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
@@ -39,7 +39,7 @@ class FixtureDenormalizerRegistryTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $propRelf = (new \ReflectionClass(FixtureDenormalizerRegistry::class))->getProperty('denormalizers');
         $propRelf->setAccessible(true);
@@ -78,7 +78,7 @@ class FixtureDenormalizerRegistryTest extends TestCase
             );
         }
     }
-    
+
     public function testInjectsParserInParserAwareDenormalizersAndItselfInDenormalizerAwareDenormalizers()
     {
         $flagParser = new FakeFlagParser();
@@ -110,7 +110,7 @@ class FixtureDenormalizerRegistryTest extends TestCase
         $this->assertNotNull($actualDenormalizers[1]->parser);
         $this->assertSame($denormalizer, $denormalizerAwareDenormalizer->denormalizer);
     }
-    
+
     public function testUsesTheFirstSuitableDenormalizer()
     {
         $fixtureProphecy = $this->prophesize(FixtureInterface::class);
@@ -134,7 +134,7 @@ class FixtureDenormalizerRegistryTest extends TestCase
         $chainableDenormalizer1Prophecy->canDenormalize($reference)->willReturn(false);
         /** @var ChainableFixtureDenormalizerInterface $chainableDenormalizer1 */
         $chainableDenormalizer1 = $chainableDenormalizer1Prophecy->reveal();
-        
+
         $chainableDenormalizer2Prophecy = $this->prophesize(ChainableFixtureDenormalizerInterface::class);
         $chainableDenormalizer2Prophecy->canDenormalize($reference)->willReturn(true);
         $chainableDenormalizer2Prophecy->denormalize($builtFixtures, $className, $reference, $specs, $flags)->willReturn($expected);

--- a/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserAwareInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use TypeError;
@@ -162,10 +163,6 @@ class FixtureDenormalizerRegistryTest extends TestCase
         $chainableDenormalizer2Prophecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerNotFoundException
-     * @expectedExceptionMessage No suitable fixture denormalizer found to handle the fixture with the reference "user0".
-     */
     public function testThrowsExceptionIfNotSuitableDenormalizer()
     {
         $builtFixtures = new FixtureBag();
@@ -180,6 +177,10 @@ class FixtureDenormalizerRegistryTest extends TestCase
         $flagParser = $flagParserProphecy->reveal();
 
         $denormalizer = new FixtureDenormalizerRegistry($flagParser, []);
+
+        $this->expectException(DenormalizerNotFoundException::class);
+        $this->expectExceptionMessage('No suitable fixture denormalizer found to handle the fixture with the reference "user0".');
+
         $denormalizer->denormalize($builtFixtures, $className, $reference, $specs, $flags);
     }
 }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
@@ -36,12 +36,11 @@ class CallsWithFlagsDenormalizerTest extends TestCase
         $this->assertFalse((new ReflectionClass(CallsWithFlagsDenormalizer::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /must be an instance of Nelmio\\Alice\\FixtureBuilder\\Denormalizer\\Fixture\\SpecificationBagDenormalizer\\Calls\\MethodFlagHandler\, instance of stdClass given/
-     */
     public function testCannotAcceptInvalidMethodHandlers()
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/must be an instance of Nelmio\\\\Alice\\\\FixtureBuilder\\\\Denormalizer\\\\Fixture\\\\SpecificationBagDenormalizer\\\\Calls\\\\MethodFlagHandler, instance of stdClass given/');
+
         new CallsWithFlagsDenormalizer(
             new FakeCallsDenormalizer(),
             [
@@ -132,11 +131,11 @@ class CallsWithFlagsDenormalizerTest extends TestCase
         ;
         /** @var CallsDenormalizerInterface $callsDenormalizer */
         $callsDenormalizer = $callsDenormalizerProphecy->reveal();
-        
+
         $returnMethodUnchanged = function (array $args) {
             return $args[0];
         };
-        
+
         $dummyFlagMethodHandlerProphecy = $this->prophesize(MethodFlagHandler::class);
         $dummyFlagMethodHandlerProphecy
             ->handleMethodFlags(

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/FunctionDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/FunctionDenormalizerTest.php
@@ -131,10 +131,6 @@ class FunctionDenormalizerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid constructor method "Invalid::method::reference".
-     */
     public function testThrowsExceptionIfInvalidConstructor()
     {
         $method = 'Invalid::method::reference';
@@ -144,6 +140,9 @@ class FunctionDenormalizerTest extends TestCase
         $argumentsDenormalizer = new FakeArgumentsDenormalizer();
 
         $denormalizer = new FunctionDenormalizer($argumentsDenormalizer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid constructor method "Invalid::method::reference".');
 
         $denormalizer->denormalize($fixture, $flagParser, $method, $unparsedArguments);
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\CallsDenormalizerInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -32,10 +33,6 @@ class FactoryDenormalizerTest extends TestCase
         $this->assertFalse((new ReflectionClass(FactoryDenormalizer::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Could not denormalize the given factory.
-     */
     public function testCannotDenormalizeEmptyFactory()
     {
         $factory = [];
@@ -46,13 +43,12 @@ class FactoryDenormalizerTest extends TestCase
             new FakeCallsDenormalizer()
         );
 
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Could not denormalize the given factory.');
+
         $denormalizer->denormalize($fixture, $flagParser, $factory);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Could not denormalize the given factory.
-     */
     public function testCannotDenormalizeFactoryWithMultipleNames()
     {
         $factory = [
@@ -66,13 +62,12 @@ class FactoryDenormalizerTest extends TestCase
             new FakeCallsDenormalizer()
         );
 
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Could not denormalize the given factory.');
+
         $denormalizer->denormalize($fixture, $flagParser, $factory);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Could not denormalize the given factory.
-     */
     public function testCannotDenormalizeFactoryWithNoFactoryName()
     {
         $factory = [
@@ -84,6 +79,9 @@ class FactoryDenormalizerTest extends TestCase
         $denormalizer = new FactoryDenormalizer(
             new FakeCallsDenormalizer()
         );
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Could not denormalize the given factory.');
 
         $denormalizer->denormalize($fixture, $flagParser, $factory);
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\Property\FakePropertyDenormalizer;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -171,10 +172,6 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $constructorDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid property name: 0.
-     */
     public function testCannotProceedWithInvalidProperty()
     {
         $unparsedSpecs = [
@@ -187,13 +184,12 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
             new FakeCallsDenormalizer()
         );
 
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid property name: 0.');
+
         $denormalizer->denormalize(new FakeFixture(), new FakeFlagParser(), $unparsedSpecs);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Cannot use the fixture property "__construct" and "__factory" together.
-     */
     public function testCannotDenormalizeAnInvalidFactory()
     {
         $fixture = new FakeFixture();
@@ -228,13 +224,12 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
 
         $denormalizer = new SimpleSpecificationsDenormalizer($constructorDenormalizer, new FakePropertyDenormalizer(), new FakeCallsDenormalizer());
 
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot use the fixture property "__construct" and "__factory" together.');
+
         $denormalizer->denormalize(new FakeFixture(), $flagParser, $specs);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException
-     * @expectedExceptionMessage Could not denormalize the given factory.
-     */
     public function testCannotDenormalizeAFactoryAndAConstructor()
     {
         $fixture = new FakeFixture();
@@ -259,6 +254,9 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $constructorDenormalizer = $constructorDenormalizerProphecy->reveal();
 
         $denormalizer = new SimpleSpecificationsDenormalizer($constructorDenormalizer, new FakePropertyDenormalizer(), new FakeCallsDenormalizer());
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Could not denormalize the given factory.');
 
         $denormalizer->denormalize(new FakeFixture(), $flagParser, $specs);
     }
@@ -438,10 +436,6 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         $callsDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessage Expected method call value to be an array. Got "string" instead.
-     */
     public function testDenormalizeInvalidCalls()
     {
         $specs = [
@@ -451,13 +445,13 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         ];
 
         $denormalizer = new SimpleSpecificationsDenormalizer(new FakeConstructorDenormalizer(), new FakePropertyDenormalizer(), new FakeCallsDenormalizer());
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected method call value to be an array. Got "string" instead.');
+
         $denormalizer->denormalize(new FakeFixture(), new FakeFlagParser(), $specs);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessage Expected method name. Got "NULL" instead.
-     */
     public function testDenormalizeCallsWithInvalidMethod()
     {
         $specs = [
@@ -467,13 +461,13 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         ];
 
         $denormalizer = new SimpleSpecificationsDenormalizer(new FakeConstructorDenormalizer(), new FakePropertyDenormalizer(), new FakeCallsDenormalizer());
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected method name. Got "NULL" instead.');
+
         $denormalizer->denormalize(new FakeFixture(), new FakeFlagParser(), $specs);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessage Expected method call value to be an array. Got "NULL" instead.
-     */
     public function testDenormalizeWithInvalidMethodCalls()
     {
         $specs = [
@@ -483,6 +477,10 @@ class SimpleSpecificationsDenormalizerTest extends TestCase
         ];
 
         $denormalizer = new SimpleSpecificationsDenormalizer(new FakeConstructorDenormalizer(), new FakePropertyDenormalizer(), new FakeCallsDenormalizer());
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected method call value to be an array. Got "NULL" instead.');
+
         $denormalizer->denormalize(new FakeFixture(), new FakeFlagParser(), $specs);
     }
 }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Definition\Value\DynamicArrayValue;
 use Nelmio\Alice\Definition\Value\FakeValue;
 use Nelmio\Alice\Definition\Value\UniqueValue;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ValueDenormalizerInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\InvalidScopeException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -115,10 +116,6 @@ class UniqueValueDenormalizerTest extends TestCase
         $this->assertEquals('parsed_value', $result->getElement()->getValue());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\InvalidScopeException
-     * @expectedExceptionMessage Cannot bind a unique value scope to a temporary fixture.
-     */
     public function testThrowsAnExceptionIsATemporaryFixtureWithAUniqueValue()
     {
         $fixture = new SimpleFixture(uniqid('temporary_id'), 'Dummy', SpecificationBagFactory::create());
@@ -135,6 +132,10 @@ class UniqueValueDenormalizerTest extends TestCase
         $decoratedDenormalizer = $decoratedDenormalizerProphecy->reveal();
 
         $denormalizer = new UniqueValueDenormalizer($decoratedDenormalizer);
+
+        $this->expectException(InvalidScopeException::class);
+        $this->expectExceptionMessage('Cannot bind a unique value scope to a temporary fixture.');
+
         $denormalizer->denormalize($fixture, $flags, $value);
     }
 

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/ConfiguratorFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/ConfiguratorFlagParserTest.php
@@ -25,7 +25,7 @@ class ConfiguratorFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new ConfiguratorFlagParser();
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/ExtendFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/ExtendFlagParserTest.php
@@ -25,7 +25,7 @@ class ExtendFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new ExtendFlagParser();
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/OptionalFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/OptionalFlagParserTest.php
@@ -25,7 +25,7 @@ class OptionalFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new OptionalFlagParser();
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/TemplateFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/TemplateFlagParserTest.php
@@ -25,7 +25,7 @@ class TemplateFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new TemplateFlagParser();
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/UniqueFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Chainable/UniqueFlagParserTest.php
@@ -25,7 +25,7 @@ class UniqueFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new UniqueFlagParser();
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/ElementFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/ElementFlagParserTest.php
@@ -25,7 +25,7 @@ class ElementFlagParserTest extends FlagParserTestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new ElementFlagParser(new ElementParser());
     }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\Chainable\FakeChainableFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -35,11 +36,10 @@ class FlagParserRegistryTest extends TestCase
         $this->assertFalse((new ReflectionClass(FlagParserRegistry::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testThrowsAnExceptionIfAnInvalidParserInjected()
     {
+        $this->expectException(\TypeError::class);
+
         new FlagParserRegistry([new \stdClass()]);
     }
 
@@ -78,13 +78,13 @@ class FlagParserRegistryTest extends TestCase
         $parser2Prophecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException
-     * @expectedExceptionMessage No suitable flag parser found to handle the element "string to parse".
-     */
     public function testThrowsAnExceptionIfNotSuitableParserFound()
     {
         $parser = new FlagParserRegistry([]);
+
+        $this->expectException(FlagParserNotFoundException::class);
+        $this->expectExceptionMessage('No suitable flag parser found to handle the element "string to parse".');
+
         $parser->parse('string to parse');
     }
 }

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/Reference.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/Reference.php
@@ -65,10 +65,6 @@ final class Reference
                     '0',
                     new FlagBag('0'),
                 ],
-                'with an numeric index' => [
-                    0,
-                    new FlagBag('0'),
-                ],
             ],
             'malformed-element' => [
                 'non-empty string with empty flags' => [

--- a/tests/FixtureBuilder/Denormalizer/Parameter/SimpleParameterBagDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Parameter/SimpleParameterBagDenormalizerTest.php
@@ -31,7 +31,7 @@ class SimpleParameterBagDenormalizerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->denormalizer = new SimpleParameterBagDenormalizer();
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
@@ -33,7 +33,7 @@ class FunctionLexerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->lexer = new FunctionLexer(new DummyLexer());
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionTokenizerTest.php
@@ -31,7 +31,7 @@ class FunctionTokenizerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->tokenizer = new FunctionTokenizer();
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
@@ -66,13 +66,13 @@ class GlobalPatternsLexerTest extends TestCase
         $decoratedLexerProphecy->lex(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid token "foo 10x @users" found.
-     */
     public function testThrowsAnExceptionWhenInvalidValue()
     {
         $lexer = new GlobalPatternsLexer(new FakeLexer());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid token "foo 10x @users" found.');
+
         $lexer->lex('foo 10x @users');
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -180,7 +180,7 @@ class LexerIntegrationTest extends TestCase
                 new Token('@', new TokenType(TokenType::STRING_TYPE)),
             ],
         ];
-        yield '[Escape character] with empty reference' => [
+        yield '[Escape character] triple escape with empty reference' => [
             '\\\\\\@',
             [
                 new Token('\\\\', new TokenType(TokenType::ESCAPED_VALUE_TYPE)),
@@ -231,7 +231,7 @@ class LexerIntegrationTest extends TestCase
                 new Token('\%', new TokenType(TokenType::ESCAPED_VALUE_TYPE)),
             ],
         ];
-        yield '[Escaped percent sign]' => [
+        yield '[Escaped percent sign] in string' => [
             'a\%b',
             [
                 new Token('a', new TokenType(TokenType::STRING_TYPE)),
@@ -239,7 +239,7 @@ class LexerIntegrationTest extends TestCase
                 new Token('b', new TokenType(TokenType::STRING_TYPE)),
             ],
         ];
-        yield '[Escaped percent sign]' => [
+        yield '[Escaped percent sign] with number' => [
             '100\%',
             [
                 new Token('100', new TokenType(TokenType::STRING_TYPE)),

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -35,7 +35,7 @@ class LexerIntegrationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->lexer = (new NativeLoader())->getLexer();
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -32,7 +32,7 @@ class ReferenceLexerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->lexer = new ReferenceLexer();
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\LexException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -47,12 +48,11 @@ class ReferenceLexerTest extends TestCase
         $this->assertFalse((new ReflectionClass(ReferenceLexer::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid token "@u->" found.
-     */
     public function testThrowsAnExceptionWhenAnInvalidValueIsGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid token "@u->" found.');
+
         $this->lexer->lex('@u->');
     }
 
@@ -76,12 +76,11 @@ class ReferenceLexerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\LexException
-     * @expectedExceptionMessage Could not lex the value "foo".
-     */
     public function testThrowsAnExceptionIfNoMatchingPatternFound()
     {
+        $this->expectException(LexException::class);
+        $this->expectExceptionMessage('Could not lex the value "foo".');
+
         $this->lexer->lex('foo');
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceLexerTest.php
@@ -116,7 +116,7 @@ class ReferenceLexerTest extends TestCase
             [new Token($value, new TokenType(TokenType::SIMPLE_REFERENCE_TYPE))],
         ];
 
-        yield 'simple reference' => [
+        yield 'simple empty reference' => [
             $value = '@',
             [new Token($value, new TokenType(TokenType::SIMPLE_REFERENCE_TYPE))],
         ];

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
@@ -99,13 +99,13 @@ class SubPatternsLexerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid token "<foo>" found.
-     */
     public function testThrowsAnExceptionWhenAnInvalidValueIsGiven()
     {
         $lexer = new SubPatternsLexer(new FakeLexer());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid token "<foo>" found.');
+
         $lexer->lex('<foo>');
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -44,7 +44,7 @@ class ParserIntegrationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = (new NativeLoader())->getExpressionLanguageParser();
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -154,7 +154,7 @@ class ParserIntegrationTest extends TestCase
             '\\\\@',
             '\\@',
         ];
-        yield '[Escape character] with empty reference' => [
+        yield '[Escape character] triple escape with empty reference' => [
             '\\\\\\@',
             '\\@',
         ];
@@ -186,11 +186,11 @@ class ParserIntegrationTest extends TestCase
             '\%',
             '%',
         ];
-        yield '[Escaped percent sign]' => [
+        yield '[Escaped percent sign] in string' => [
             'a\%b',
             'a%b',
         ];
-        yield '[Escaped percent sign]' => [
+        yield '[Escaped percent sign] with number' => [
             '100\%',
             '100%',
         ];

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/AbstractChainableParserAwareParserTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chai
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -53,14 +54,13 @@ class AbstractChainableParserAwareParserTest extends TestCase
         $this->assertEquals(new ImpartialChainableParserAwareParser(new FakeParser()), $newParser);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE));
         $parser = new ImpartialChainableParserAwareParser();
+
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
 
         $parser->parse($token);
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
@@ -20,6 +20,8 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -49,26 +51,24 @@ class DynamicArrayTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE));
         $parser = new DynamicArrayTokenParser();
 
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: DYNAMIC_ARRAY_TYPE).
-     */
     public function testThrowsAnExceptionIfCouldNotParseToken()
     {
         $token = new Token('', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE));
         $parser = new DynamicArrayTokenParser(new FakeParser());
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: DYNAMIC_ARRAY_TYPE).');
 
         $parser->parse($token);
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/EscapedValueTokenParserTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chai
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -45,15 +46,15 @@ class EscapedValueTokenParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: ESCAPED_VALUE_TYPE).
-     */
     public function testThrowsAnExceptionIfAMalformedTokenIsGiven()
     {
         $token = new Token('', new TokenType(TokenType::ESCAPED_VALUE_TYPE));
 
         $parser = new EscapedValueTokenParser();
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: ESCAPED_VALUE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureListReferenceTokenParserTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -47,27 +48,27 @@ class FixtureListReferenceTokenParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: LIST_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfInvalidTokenIsGiven()
     {
         $token = new Token('', new TokenType(TokenType::LIST_REFERENCE_TYPE));
 
         $parser = new FixtureListReferenceTokenParser();
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: LIST_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: LIST_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfAMalformedTokenIsGiven()
     {
         $token = new Token('', new TokenType(TokenType::LIST_REFERENCE_TYPE));
 
         $parser = new FixtureListReferenceTokenParser();
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: LIST_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -50,26 +51,25 @@ class FixtureMethodReferenceTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
         $parser = new FixtureMethodReferenceTokenParser();
 
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: METHOD_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfCouldNotParseToken()
     {
         $token = new Token('', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
         $parser = new FixtureMethodReferenceTokenParser(new FakeParser());
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: METHOD_REFERENCE_TYPE).');
+
 
         $parser->parse($token);
     }
@@ -92,15 +92,15 @@ class FixtureMethodReferenceTokenParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "@user->getName()->anotherName()" (type: METHOD_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfMethodReferenceIsMalformed()
     {
         $token = new Token('@user->getName()->anotherName()', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
 
         $parser = new FixtureMethodReferenceTokenParser(new FakeParser());
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "@user->getName()->anotherName()" (type: METHOD_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureRangeReferenceTokenParserTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Value\FixtureReferenceValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\ChainableTokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -46,39 +47,38 @@ class FixtureRangeReferenceTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: RANGE_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfPassedTokenIsMalformed()
     {
         $token = new Token('', new TokenType(TokenType::RANGE_REFERENCE_TYPE));
         $parser = new FixtureRangeReferenceTokenParser();
 
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: RANGE_REFERENCE_TYPE).');
+
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "@user{1..10" (type: RANGE_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfPassedTokenIsInvalid()
     {
         $token = new Token('@user{1..10', new TokenType(TokenType::RANGE_REFERENCE_TYPE));
         $parser = new FixtureRangeReferenceTokenParser();
 
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "@user{1..10" (type: RANGE_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: RANGE_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfAMalformedTokenIsGiven()
     {
         $token = new Token('', new TokenType(TokenType::RANGE_REFERENCE_TYPE));
 
         $parser = new FixtureListReferenceTokenParser();
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: RANGE_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
@@ -21,6 +21,8 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -50,34 +52,28 @@ class MethodReferenceTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::DYNAMIC_ARRAY_TYPE));
         $parser = new MethodReferenceTokenParser();
 
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: METHOD_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfCouldNotParseToken()
     {
         $token = new Token('', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
         $parser = new MethodReferenceTokenParser(new FakeParser());
 
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: METHOD_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "@@malformed_user->getUserName(arg1, arg2)" (type: METHOD_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfParsingReferenceGivesAnUnexpectedResult()
     {
         $token = new Token('@@malformed_user->getUserName(arg1, arg2)', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
@@ -93,13 +89,13 @@ class MethodReferenceTokenParserTest extends TestCase
         $decoratedParser = $decoratedParserProphecy->reveal();
 
         $parser = new MethodReferenceTokenParser($decoratedParser);
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "@@malformed_user->getUserName(arg1, arg2)" (type: METHOD_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "@user->getUserName((arg1, arg2)" (type: METHOD_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfParsingFunctionCallGivesAnUnexpectedResult()
     {
         $token = new Token('@user->getUserName((arg1, arg2)', new TokenType(TokenType::METHOD_REFERENCE_TYPE));
@@ -117,6 +113,10 @@ class MethodReferenceTokenParserTest extends TestCase
         $decoratedParser = $decoratedParserProphecy->reveal();
 
         $parser = new MethodReferenceTokenParser($decoratedParser);
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "@user->getUserName((arg1, arg2)" (type: METHOD_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
@@ -19,6 +19,8 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -48,26 +50,24 @@ class OptionalTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::OPTIONAL_TYPE));
         $parser = new OptionalTokenParser();
 
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: OPTIONAL_TYPE).
-     */
     public function testThrowsAnExceptionIfCouldNotParseToken()
     {
         $token = new Token('', new TokenType(TokenType::OPTIONAL_TYPE));
         $parser = new OptionalTokenParser(new FakeParser());
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: OPTIONAL_TYPE).');
 
         $parser->parse($token);
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
@@ -20,6 +20,8 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\FakeParser;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -49,34 +51,28 @@ class PropertyReferenceTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE));
         $parser = new PropertyReferenceTokenParser();
 
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "" (type: PROPERTY_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfCouldNotParseToken()
     {
         $token = new Token('', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE));
         $parser = new PropertyReferenceTokenParser(new FakeParser());
 
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "" (type: PROPERTY_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException
-     * @expectedExceptionMessage Could not parse the token "@@malformed_user->username" (type: PROPERTY_REFERENCE_TYPE).
-     */
     public function testThrowsAnExceptionIfParsingReferenceReturnsUnexpectedResult()
     {
         $token = new Token('@@malformed_user->username', new TokenType(TokenType::PROPERTY_REFERENCE_TYPE));
@@ -87,6 +83,10 @@ class PropertyReferenceTokenParserTest extends TestCase
         $decoratedParser = $decoratedParserProphecy->reveal();
 
         $parser = new PropertyReferenceTokenParser($decoratedParser);
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Could not parse the token "@@malformed_user->username" (type: PROPERTY_REFERENCE_TYPE).');
+
         $parser->parse($token);
     }
 

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -49,14 +50,13 @@ class StringArrayTokenParserTest extends TestCase
         $this->assertFalse($parser->canParse($anotherToken));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.
-     */
     public function testThrowsAnExceptionIfNoDecoratedParserIsFound()
     {
         $token = new Token('', new TokenType(TokenType::STRING_ARRAY_TYPE));
         $parser = new StringArrayTokenParser();
+
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParser\Chainable\AbstractChainableParserAwareParser::parse" to be called only if it has a parser.');
 
         $parser->parse($token);
     }

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
@@ -38,7 +38,7 @@ class TokenParserRegistryTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parsersRefl = (new \ReflectionClass(TokenParserRegistry::class))->getProperty('parsers');
         $this->parsersRefl->setAccessible(true);

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Parser\TokenParserInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserAwareInterface;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
+use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -54,16 +55,11 @@ class TokenParserRegistryTest extends TestCase
         $this->assertFalse((new ReflectionClass(TokenParserRegistry::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testAcceptsOnlyChainableParsers()
     {
-        try {
-            new TokenParserRegistry([new FakeChainableTokenParser()]);
-        } catch (\Throwable $exception) {
-            $this->fails('Did not expect exception to be thrown.');
-        }
+        new TokenParserRegistry([new FakeChainableTokenParser()]);
+
+        $this->expectException(\TypeError::class);
 
         new TokenParserRegistry([new \stdClass()]);
     }
@@ -140,13 +136,13 @@ class TokenParserRegistryTest extends TestCase
         $parser2Prophecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException
-     * @expectedExceptionMessage No suitable token parser found to handle the token "foo" (type: STRING_TYPE).
-     */
     public function testThrowsAnExceptionIfNoSuitableParserIsFound()
     {
         $registry = new TokenParserRegistry([]);
+
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('No suitable token parser found to handle the token "foo" (type: STRING_TYPE).');
+
         $registry->parse(new Token('foo', new TokenType(TokenType::STRING_TYPE)));
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
@@ -28,7 +28,7 @@ class TokenTypeTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $reflClass = new \ReflectionClass(TokenType::class);
         $this->constants = $reflClass->getConstants();

--- a/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/TokenTypeTest.php
@@ -65,12 +65,11 @@ class TokenTypeTest extends TestCase
         $this->assertEquals($type->getValue(), constant(sprintf('%s::%s', TokenType::class, $typeConstant)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected type to be a known token type but got "unknown".
-     */
     public function testThrowsAnExceptionIfAnInvalidTypeIsGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected type to be a known token type but got "unknown".');
+
         new TokenType('unknown');
     }
 

--- a/tests/Generator/Caller/SimpleCallerTest.php
+++ b/tests/Generator/Caller/SimpleCallerTest.php
@@ -32,6 +32,7 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use PHPUnit\Framework\TestCase;
@@ -69,10 +70,6 @@ class SimpleCallerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Caller\SimpleCaller::doCallsOn" to be called only if it has a resolver.
-     */
     public function testThrowsAnExceptionIfDoesNotHaveAResolver()
     {
         $obj = new FakeObject();
@@ -80,6 +77,10 @@ class SimpleCallerTest extends TestCase
         $caller = new SimpleCaller(
             new FakeCallProcessor()
         );
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Caller\SimpleCaller::doCallsOn" to be called only if it has a resolver.');
+
         $caller->doCallsOn($obj, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -50,7 +50,7 @@ class SymfonyPropertyAccessorHydratorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propertyAccessor = new PropertyAccessor();
         $this->hydrator = new SymfonyPropertyAccessorHydrator($this->propertyAccessor);

--- a/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
@@ -81,10 +81,6 @@ class AbstractChainableInstantiatorTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage custom exception
-     */
     public function testIfCannotCreateInstanceAndExceptionThrownIsAnInstantiationExceptionThenItLetsTheExceptionPass()
     {
         $fixture = new DummyFixture('dummy');
@@ -96,6 +92,10 @@ class AbstractChainableInstantiatorTest extends TestCase
         $decoratedInstantiator = $decoratedInstantiatorProphecy->reveal();
 
         $instantiator = new ProphecyChainableInstantiator($decoratedInstantiator);
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('custom exception');
+
         $instantiator->instantiate($fixture, $set, new GenerationContext());
     }
 

--- a/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
@@ -41,7 +41,7 @@ class AbstractChainableInstantiatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new DummyChainableInstantiator();
     }

--- a/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
+use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -130,10 +131,6 @@ class NoCallerMethodCallInstantiatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotInstantiateObject()
     {
         $fixture = new SimpleFixture(
@@ -143,6 +140,9 @@ class NoCallerMethodCallInstantiatorTest extends TestCase
                 new SimpleMethodCall('fake', [10])
             )
         );
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
 
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }

--- a/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoCallerMethodCallInstantiatorTest.php
@@ -40,7 +40,7 @@ class NoCallerMethodCallInstantiatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new NoCallerMethodCallInstantiator();
     }

--- a/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithRequiredParameterInConstructor;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
+use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -90,10 +91,6 @@ class NoMethodCallInstantiatorTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotInstantiateObject()
     {
         $fixture = new SimpleFixture(
@@ -103,6 +100,9 @@ class NoMethodCallInstantiatorTest extends TestCase
                 new SimpleMethodCall('fake', [10])
             )
         );
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
 
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }

--- a/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NoMethodCallInstantiatorTest.php
@@ -38,7 +38,7 @@ class NoMethodCallInstantiatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new NoMethodCallInstantiator();
     }

--- a/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
@@ -41,7 +41,7 @@ class NullConstructorInstantiatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new NullConstructorInstantiator();
     }

--- a/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/NullConstructorInstantiatorTest.php
@@ -74,13 +74,13 @@ class NullConstructorInstantiatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfInstantiatingObjectWithoutArgumentsFails()
     {
         $fixture = new SimpleFixture('dummy', AbstractDummy::class, SpecificationBagFactory::create());
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
@@ -101,43 +101,43 @@ class NullConstructorInstantiatorTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate "dummy", the constructor has mandatory parameters but no parameters have been given.
-     */
     public function testThrowsAnExceptionIfObjectConstructorHasMandatoryParameters()
     {
         $fixture = new SimpleFixture('dummy', DummyWithRequiredParameterInConstructor::class, SpecificationBagFactory::create());
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate "dummy", the constructor has mandatory parameters but no parameters have been given.');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfObjectInstantiationFailsUnderNominalConditions()
     {
         $fixture = new SimpleFixture('dummy', DummyWithExplicitDefaultConstructorThrowingException::class, SpecificationBagFactory::create());
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate "dummy", the constructor of "Nelmio\Alice\Entity\Instantiator\DummyWithPrivateConstructor" is not public.
-     */
     public function testThrowsAnExceptionIfObjectConstructorIsPrivate()
     {
         $fixture = new SimpleFixture('dummy', DummyWithPrivateConstructor::class, SpecificationBagFactory::create());
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate "dummy", the constructor of "Nelmio\Alice\Entity\Instantiator\DummyWithPrivateConstructor" is not public.');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate "dummy", the constructor of "Nelmio\Alice\Entity\Instantiator\DummyWithProtectedConstructor" is not public.
-     */
     public function testThrowsAnExceptionIfObjectConstructorIsProtected()
     {
         $fixture = new SimpleFixture('dummy', DummyWithProtectedConstructor::class, SpecificationBagFactory::create());
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate "dummy", the constructor of "Nelmio\Alice\Entity\Instantiator\DummyWithProtectedConstructor" is not public.');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 }

--- a/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
@@ -43,7 +43,7 @@ class StaticFactoryInstantiatorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new StaticFactoryInstantiator();
     }

--- a/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/StaticFactoryInstantiatorTest.php
@@ -27,6 +27,7 @@ use Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructorAndOptionalParamet
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Instantiator\ChainableInstantiatorInterface;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
+use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -156,10 +157,6 @@ class StaticFactoryInstantiatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotInstantiateObject()
     {
         $fixture = new SimpleFixture(
@@ -173,13 +170,12 @@ class StaticFactoryInstantiatorTest extends TestCase
             )
         );
 
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotFindFactoryMethod()
     {
         $fixture = new SimpleFixture(
@@ -193,13 +189,12 @@ class StaticFactoryInstantiatorTest extends TestCase
             )
         );
 
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotFindFactoryClass()
     {
         $fixture = new SimpleFixture(
@@ -213,13 +208,12 @@ class StaticFactoryInstantiatorTest extends TestCase
             )
         );
 
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Could not instantiate fixture "dummy".
-     */
     public function testThrowsAnExceptionIfCouldNotCallOnTheFactory()
     {
         $fixture = new SimpleFixture(
@@ -234,13 +228,12 @@ class StaticFactoryInstantiatorTest extends TestCase
             )
         );
 
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Could not instantiate fixture "dummy".');
+
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Instantiated fixture was expected to be an instance of "Dummy". Got "Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructorAndOptionalParameters" instead.
-     */
     public function testThrowsAnExceptionIfFixtureClassDoesNotMatchObjectClass()
     {
         $fixture = new SimpleFixture(
@@ -254,18 +247,13 @@ class StaticFactoryInstantiatorTest extends TestCase
                 )
             )
         );
-        $set = $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
 
-        $expected = DummyWithNamedConstructorAndOptionalParameters::namedConstruct(10);
-        $actual = $set->getObjects()->get($fixture)->getInstance();
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Instantiated fixture was expected to be an instance of "Dummy". Got "Nelmio\Alice\Entity\Instantiator\DummyWithNamedConstructorAndOptionalParameters" instead.');
 
-        $this->assertEquals($expected, $actual);
+        $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException
-     * @expectedExceptionMessage Instantiated fixture was expected to be an instance of "Nelmio\Alice\Entity\Instantiator\DummyWithFakeNamedConstructor". Got "null" instead.
-     */
     public function testThrowsAnExceptionIfFactoryDoesNotReturnAnInstance()
     {
         $fixture = new SimpleFixture(
@@ -278,6 +266,9 @@ class StaticFactoryInstantiatorTest extends TestCase
                 )
             )
         );
+
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage('Instantiated fixture was expected to be an instance of "Nelmio\Alice\Entity\Instantiator\DummyWithFakeNamedConstructor". Got "null" instead.');
 
         $this->instantiator->instantiate($fixture, ResolvedFixtureSetFactory::create(), new GenerationContext());
     }

--- a/tests/Generator/Instantiator/InstantiatorRegistryTest.php
+++ b/tests/Generator/Instantiator/InstantiatorRegistryTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
 use Nelmio\Alice\ObjectBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiatorNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -42,11 +43,10 @@ class InstantiatorRegistryTest extends TestCase
         new InstantiatorRegistry([new FakeChainableInstantiator()]);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testThrowExceptionIfInvalidParserIsPassed()
     {
+        $this->expectException(\TypeError::class);
+
         new InstantiatorRegistry([new stdClass()]);
     }
 
@@ -141,10 +141,6 @@ class InstantiatorRegistryTest extends TestCase
         $instantiator2Prophecy->instantiate(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiatorNotFoundException
-     * @expectedExceptionMessage No suitable instantiator found for the fixture "dummy".
-     */
     public function testThrowExceptionIfNoSuitableParserIsFound()
     {
         $fixture = new DummyFixture('dummy');
@@ -152,6 +148,10 @@ class InstantiatorRegistryTest extends TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $registry = new InstantiatorRegistry([]);
+
+        $this->expectException(InstantiatorNotFoundException::class);
+        $this->expectExceptionMessage('No suitable instantiator found for the fixture "dummy".');
+
         $registry->instantiate($fixture, $set, new GenerationContext());
     }
 }

--- a/tests/Generator/Populator/SimpleHydratorTest.php
+++ b/tests/Generator/Populator/SimpleHydratorTest.php
@@ -31,6 +31,7 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use PHPUnit\Framework\TestCase;
@@ -54,13 +55,13 @@ class SimpleHydratorTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Hydrator\SimpleHydrator::hydrate" to be called only if it has a resolver.
-     */
     public function testThrowsAnExceptionIfDoesNotHaveAResolver()
     {
         $hydrator = new SimpleHydrator(new FakePropertyHydrator());
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Hydrator\SimpleHydrator::hydrate" to be called only if it has a resolver.');
+
         $hydrator->hydrate(new FakeObject(), ResolvedFixtureSetFactory::create(), new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Definition\PropertyBag;
 use Nelmio\Alice\Definition\ServiceReference\FixtureReference;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\FixtureBag;
+use Nelmio\Alice\Throwable\Exception\FixtureNotFoundException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -309,10 +310,6 @@ class TemplateFixtureBagResolverTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureNotFoundException
-     * @expectedExceptionMessage Could not find the fixture "user_base".
-     */
     public function testThrowsAnExceptionIfFixtureExtendsANonExistingFixture()
     {
         $unresolvedFixtures = (new FixtureBag())
@@ -334,13 +331,13 @@ class TemplateFixtureBagResolverTest extends TestCase
                 )
             )
         ;
+
+        $this->expectException(FixtureNotFoundException::class);
+        $this->expectExceptionMessage('Could not find the fixture "user_base".');
+
         $this->resolver->resolve($unresolvedFixtures);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Fixture "user0" extends "user_base" but "user_base" is not a template.
-     */
     public function testThrowsAnExceptionIfAFixtureExtendANonTemplateFixture()
     {
         $unresolvedFixtures = (new FixtureBag())
@@ -369,6 +366,10 @@ class TemplateFixtureBagResolverTest extends TestCase
                 )
             )
         ;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fixture "user0" extends "user_base" but "user_base" is not a template.');
+
         $this->resolver->resolve($unresolvedFixtures);
     }
 

--- a/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplateFixtureBagResolverTest.php
@@ -47,7 +47,7 @@ class TemplateFixtureBagResolverTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propRefl = (new ReflectionClass(TemplatingFixture::class))->getProperty('fixture');
         $this->propRefl->setAccessible(true);

--- a/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -82,13 +83,12 @@ class ArrayParameterResolverTest extends TestCase
         })));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Parameter\Chainable\ArrayParameterResolver::resolve" to be called only if it has a resolver.
-     */
     public function testRequiresInjectedResolverToResolverAParameter()
     {
         $resolver = new ArrayParameterResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Parameter\Chainable\ArrayParameterResolver::resolve" to be called only if it has a resolver.');
 
         $resolver->resolve(new Parameter('foo', null), new ParameterBag(), new ParameterBag());
     }

--- a/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 use Nelmio\Alice\Generator\Resolver\ResolvingContext;
 use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\ParameterNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -263,10 +264,6 @@ class StringParameterResolverTest extends TestCase
         $injectedResolverProphecy->resolve(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StringParameterResolver::resolveStringKey" to be called only if it has a resolver.
-     */
     public function testThrowsAnExceptionIfNoResolverInjectedWhenRequired()
     {
         $parameter = new Parameter('foo', '<{bar}>');
@@ -276,6 +273,10 @@ class StringParameterResolverTest extends TestCase
         $resolvedParameters = new ParameterBag();
 
         $resolver = new StringParameterResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Parameter\Chainable\StringParameterResolver::resolveStringKey" to be called only if it has a resolver.');
+
         $resolver->resolve($parameter, $unresolvedParameters, $resolvedParameters);
     }
 }

--- a/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\Generator\Resolver\Parameter\Chainable\FakeChainableParameterRe
 use Nelmio\Alice\Generator\Resolver\ParameterResolverInterface;
 use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -61,12 +62,11 @@ class ParameterResolverRegistryTest extends TestCase
         $this->assertFalse((new ReflectionClass(ParameterResolverRegistry::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessage Expected resolvers to be "Nelmio\Alice\Generator\Resolver\ParameterResolverInterface" objects. Got "stdClass" instead.
-     */
     public function testThrowsAnExceptionIfInvalidResolverIsPassed()
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Expected resolvers to be "Nelmio\Alice\Generator\Resolver\ParameterResolverInterface" objects. Got "stdClass" instead.');
+
         new ParameterResolverRegistry([new \stdClass()]);
     }
 
@@ -105,13 +105,13 @@ class ParameterResolverRegistryTest extends TestCase
         $resolver2Prophecy->resolve(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage No resolver found to resolve parameter "foo".
-     */
     public function testThrowsAnExceptionIfNoSuitableParserIsFound()
     {
         $registry = new ParameterResolverRegistry([]);
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('No resolver found to resolve parameter "foo".');
+
         $registry->resolve(new Parameter('foo', null), new ParameterBag(), new ParameterBag());
     }
 }

--- a/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
+++ b/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
@@ -16,6 +16,8 @@ namespace Nelmio\Alice\Generator\Resolver;
 use Nelmio\Alice\Generator\Resolver\Parameter\SimpleParameterBagResolver;
 use Nelmio\Alice\Loader\NativeLoader;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException;
+use Nelmio\Alice\Throwable\Exception\ParameterNotFoundException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -52,20 +54,19 @@ class ParameterResolverIntegrationTest extends TestCase
 
     /**
      * @dataProvider provideCircularReferences
-     *
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\CircularReferenceException
-     * @expectedExceptionMessageRegExp /^Circular reference detected for the parameter "[^\"]+" while resolving \[.+]\.$/
      */
     public function testThrowExceptionIfCircularReferenceDetected(ParameterBag $unresolvedParameters, ParameterBag $injectedParameters = null)
     {
+        $this->expectException(CircularReferenceException::class);
+        $this->expectExceptionMessageRegExp('/^Circular reference detected for the parameter "[^\"]+" while resolving \[.+]\.$/');
+
         $this->resolver->resolve($unresolvedParameters, $injectedParameters);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\ParameterNotFoundException
-     */
     public function testThrowExceptionWhenResolvingNonExistentParameter()
     {
+        $this->expectException(ParameterNotFoundException::class);
+
         $this->resolver->resolve(
             new ParameterBag([
                 'param1' => '<{inexisting_param}>',

--- a/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
+++ b/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
@@ -32,7 +32,7 @@ class ParameterResolverIntegrationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->resolver = (new NativeLoader())->getParameterResolver();
     }

--- a/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
@@ -41,7 +41,7 @@ class DynamicArrayValueResolverTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $reflClass = new \ReflectionClass(DynamicArrayValueResolver::class);
 

--- a/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/EvaluatedValueResolverTest.php
@@ -86,10 +86,6 @@ class EvaluatedValueResolverTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not evaluate the expression "(function () { throw new \Exception(""); })()".
-     */
     public function testThrowsAnExceptionIfAnErrorOccurredDuringEvaluation()
     {
         $value = new EvaluatedValue('(function () { throw new \\Exception(""); })()');
@@ -97,6 +93,10 @@ class EvaluatedValueResolverTest extends TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new EvaluatedValueResolver();
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not evaluate the expression "(function () { throw new \Exception(""); })()".');
+
         $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
@@ -85,10 +85,6 @@ class FakerFunctionCallValueResolverValueTest extends TestCase
         $this->assertEquals('Hello ', substr($result->getValue(), 0, 6));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown formatter "unknown"
-     */
     public function testThrowsAnExceptionIfTriesToCallAnUndefinedProviderFunction()
     {
         $value = new ResolvedFunctionCallValue('unknown');
@@ -96,6 +92,10 @@ class FakerFunctionCallValueResolverValueTest extends TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new FakerFunctionCallValueResolver(FakerGeneratorFactory::create(), new FakeValueResolver());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown formatter "unknown"');
+
         $resolver->resolve($value, $fixture, $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
@@ -29,6 +29,7 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\NoSuchMethodException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -66,14 +67,14 @@ class FixtureMethodCallReferenceResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureMethodCallReferenceResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $value = new FixtureMethodCallValue(new FakeValue(), new FunctionCallValue('method'));
         $resolver = new FixtureMethodCallReferenceResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureMethodCallReferenceResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -29,6 +29,7 @@ use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\NoSuchPropertyException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -68,14 +69,14 @@ class FixturePropertyReferenceResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixturePropertyReferenceResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $value = new FixturePropertyValue(new FakeValue(), '');
         $resolver = new FixturePropertyReferenceResolver(new FakePropertyAccessor());
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixturePropertyReferenceResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
@@ -195,10 +196,6 @@ class FixturePropertyReferenceResolverTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not resolve value "dummy->publicProperty": PropertyAccessor requires a graph of objects or arrays to operate on, but it found type "string" while trying to traverse path "publicProperty" at property "publicProperty".
-     */
     public function testThrowsAnExceptionIfReferenceResolvedIsNotAnObject()
     {
         $value = new FixturePropertyValue(
@@ -222,6 +219,10 @@ class FixturePropertyReferenceResolverTest extends TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new FixturePropertyReferenceResolver(PropertyAccess::createPropertyAccessor(), $valueResolver);
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not resolve value "dummy->publicProperty": PropertyAccessor requires a graph of objects or arrays to operate on, but it found type "string" while trying to traverse path "publicProperty" at property "publicProperty".');
+
         $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
@@ -29,6 +29,9 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
+use Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator\ObjectGeneratorNotFoundException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\FixtureNotFoundException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -67,13 +70,13 @@ class FixtureReferenceResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\ObjectGenerator\ObjectGeneratorNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureReferenceResolver::resolve" to be called only if it has a generator.
-     */
     public function testCannotResolveValueIfHasNoGenerator()
     {
         $resolver = new FixtureReferenceResolver();
+
+        $this->expectException(ObjectGeneratorNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureReferenceResolver::resolve" to be called only if it has a generator.');
+
         $resolver->resolve(
             new FakeValue(),
             new FakeFixture(),
@@ -83,13 +86,13 @@ class FixtureReferenceResolverTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not resolve value "@foo".
-     */
     public function testCannotResolveReferenceIsTheReferenceIsAValue()
     {
         $resolver = new FixtureReferenceResolver(new FakeObjectGenerator());
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not resolve value "@foo".');
+
         $resolver->resolve(
             new FixtureReferenceValue(new DummyValue('foo')),
             new FakeFixture(),
@@ -223,10 +226,6 @@ class FixtureReferenceResolverTest extends TestCase
         $generatorProphecy->generate(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\FixtureNotFoundException
-     * @expectedExceptionMessage Could not find the fixture "dummy".
-     */
     public function testIfTheReferenceRefersToANonExistentFixtureAndNoInstanceIsAvailableThenThrowsAnException()
     {
         $value = new FixtureReferenceValue('dummy');
@@ -236,6 +235,10 @@ class FixtureReferenceResolverTest extends TestCase
         $context = new GenerationContext();
 
         $resolver = new FixtureReferenceResolver(new FakeObjectGenerator());
+
+        $this->expectException(FixtureNotFoundException::class);
+        $this->expectExceptionMessage('Could not find the fixture "dummy".');
+
         $resolver->resolve($value, $fixture, $set, $scope, $context);
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
@@ -28,6 +28,8 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -64,13 +66,13 @@ class FixtureWildcardReferenceResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureWildcardReferenceResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $resolver = new FixtureWildcardReferenceResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\FixtureWildcardReferenceResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve(new FakeValue(), new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
@@ -180,10 +182,6 @@ class FixtureWildcardReferenceResolverTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not find a fixture or object ID matching the pattern
-     */
     public function testThrowsAnExceptionIfNotMathcingIdFound()
     {
         $value = FixtureMatchReferenceValue::createWildcardReference('dummy');
@@ -193,6 +191,10 @@ class FixtureWildcardReferenceResolverTest extends TestCase
         $context = new GenerationContext();
 
         $resolver = new FixtureWildcardReferenceResolver(new FakeValueResolver());
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not find a fixture or object ID matching the pattern');
+
         $resolver->resolve($value, $fixture, $set, $scope, $context);
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -59,14 +60,14 @@ class ListValueResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\ListValueResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $value = new ListValue([]);
         $resolver = new ListValueResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\ListValueResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/OptionalValueResolverTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use phpmock\functions\FixedValueFunction;
 use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
@@ -58,14 +59,14 @@ class OptionalValueResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\OptionalValueResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $value = new FixturePropertyValue(new FakeValue(), '');
         $resolver = new OptionalValueResolver();
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\OptionalValueResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ParameterValueResolverTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -62,16 +63,16 @@ class ParameterValueResolverTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not find the parameter "foo".
-     */
     public function testThrowsAnExceptionIfTheVariableCannotBeFoundInTheScope()
     {
         $value = new ParameterValue('foo');
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new ParameterValueResolver();
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not find the parameter "foo".');
+
         $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
@@ -47,7 +47,7 @@ class UniqueValueResolverTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $reflClass = new \ReflectionClass(UniqueValueResolver::class);
 

--- a/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -68,12 +69,11 @@ class UniqueValueResolverTest extends TestCase
         $this->assertFalse((new ReflectionClass(UniqueValueResolver::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected limit value to be a strictly positive integer, got "0" instead.
-     */
     public function testThrowsExceptionIfInvalidLimitGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected limit value to be a strictly positive integer, got "0" instead.');
+
         new UniqueValueResolver(new UniqueValuesPool(), null, 0);
     }
 
@@ -100,20 +100,16 @@ class UniqueValueResolverTest extends TestCase
         $this->assertFalse($resolver->canResolve(new FakeValue()));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\UniqueValueResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $resolver = new UniqueValueResolver(new UniqueValuesPool());
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\UniqueValueResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve(new UniqueValue('', ''), new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException
-     * @expectedExceptionMessage Could not generate a unique value after 1 attempts for "uniqid".
-     */
     public function testThrowsExceptionIfLimitReached()
     {
         $value = new UniqueValue('uniqid', '');
@@ -121,6 +117,10 @@ class UniqueValueResolverTest extends TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new UniqueValueResolver(new UniqueValuesPool(), new FakeValueResolver(), 1);
+
+        $this->expectException(UniqueValueGenerationLimitReachedException::class);
+        $this->expectExceptionMessage('Could not generate a unique value after 1 attempts for "uniqid".');
+
         $resolver->resolve($value, $fixture, $set, [], new GenerationContext(), 1);
     }
 

--- a/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
@@ -32,6 +32,8 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\Generator\ValueResolverAwareInterface;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -77,14 +79,14 @@ class UnresolvedFixtureReferenceIdResolverTest extends TestCase
         $decoratedResolverProphecy->canResolve(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\UnresolvedFixtureReferenceIdResolver::resolve" to be called only if it has a resolver.
-     */
     public function testCannotResolveValueIfHasNoResolver()
     {
         $value = new FakeValue();
         $resolver = new UnresolvedFixtureReferenceIdResolver(new FakeChainableValueResolver());
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('Expected method "Nelmio\Alice\Generator\Resolver\Value\Chainable\UnresolvedFixtureReferenceIdResolver::resolve" to be called only if it has a resolver.');
+
         $resolver->resolve($value, new FakeFixture(), ResolvedFixtureSetFactory::create(), [], new GenerationContext());
     }
 
@@ -319,10 +321,6 @@ class UnresolvedFixtureReferenceIdResolverTest extends TestCase
         $decoratedResolverProphecy->resolve(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Expected fixture reference value "@bob" to be resolved into a string. Got "(integer) 200" instead.
-     */
     public function testThrowsAnExceptionIfResolvedIdIsInvalid()
     {
         $idValue = new DummyValue('bob');
@@ -348,6 +346,10 @@ class UnresolvedFixtureReferenceIdResolverTest extends TestCase
         $valueResolver = $valueResolverProphecy->reveal();
 
         $resolver = new UnresolvedFixtureReferenceIdResolver(new FakeChainableValueResolver(), $valueResolver);
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Expected fixture reference value "@bob" to be resolved into a string. Got "(integer) 200" instead.');
+
         $resolver->resolve($value, $dummyFixture, $set, $scope, $context);
     }
 }

--- a/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/VariableValueResolverTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -63,16 +64,16 @@ class VariableValueResolverTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException
-     * @expectedExceptionMessage Could not find a variable "$foo".
-     */
     public function testThrowsAnExceptionIfTheVariableCannotBeFoundInTheScope()
     {
         $value = new VariableValue('foo');
         $set = ResolvedFixtureSetFactory::create();
 
         $resolver = new VariableValueResolver();
+
+        $this->expectException(UnresolvableValueException::class);
+        $this->expectExceptionMessage('Could not find a variable "$foo".');
+
         $resolver->resolve($value, new FakeFixture(), $set, [], new GenerationContext());
     }
 }

--- a/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\Generator\ResolvedValueWithFixtureSet;
 use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ObjectBag;
+use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -43,11 +44,10 @@ class ValueResolverRegistryTest extends TestCase
         new ValueResolverRegistry([new FakeChainableValueResolver()]);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testThrowExceptionIfInvalidParserIsPassed()
     {
+        $this->expectException(\TypeError::class);
+
         new ValueResolverRegistry([new stdClass()]);
     }
 
@@ -99,10 +99,6 @@ class ValueResolverRegistryTest extends TestCase
         $instantiator2Prophecy->resolve(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException
-     * @expectedExceptionMessage No resolver found to resolve value "foo".
-     */
     public function testThrowExceptionIfNoSuitableParserIsFound()
     {
         $fixture = new DummyFixture('dummy');
@@ -110,6 +106,10 @@ class ValueResolverRegistryTest extends TestCase
         $set = ResolvedFixtureSetFactory::create();
 
         $registry = new ValueResolverRegistry([]);
+
+        $this->expectException(ResolverNotFoundException::class);
+        $this->expectExceptionMessage('No resolver found to resolve value "foo".');
+
         $registry->resolve(new DummyValue('foo'), $fixture, $set, [], new GenerationContext());
     }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -1525,15 +1525,6 @@ class LoaderIntegrationTest extends TestCase
             new FixtureEntity\Instantiator\DummyWithOptionalParameterInConstructor(),
         ];
 
-        yield 'with default constructor and optional parameters without parameters - use constructor function' => [
-            [
-                FixtureEntity\Instantiator\DummyWithOptionalParameterInConstructor::class => [
-                    'dummy' => [],
-                ],
-            ],
-            new FixtureEntity\Instantiator\DummyWithOptionalParameterInConstructor(),
-        ];
-
         yield 'with default constructor and optional parameters with parameters - use constructor function' => [
             [
                 FixtureEntity\Instantiator\DummyWithOptionalParameterInConstructor::class => [
@@ -2654,30 +2645,6 @@ class LoaderIntegrationTest extends TestCase
             ],
         ];
 
-        yield 'array value' => [
-            [
-                stdClass::class => [
-                    'dummy' => [
-                        'foo' => 'bar',
-                    ],
-                    'another_dummy' => [
-                        'dummies' => ['@dummy', '@dummy', '@dummy'],
-                    ],
-                ],
-            ],
-            [
-                'parameters' => [],
-                'objects' => [
-                    'dummy' => $dummy = StdClassFactory::create([
-                        'foo' => 'bar',
-                    ]),
-                    'another_dummy' => StdClassFactory::create([
-                        'dummies' => [$dummy, $dummy, $dummy]
-                    ]),
-                ],
-            ],
-        ];
-
         yield 'dynamic array value with wildcard' => [
             [
                 stdClass::class => [
@@ -2950,50 +2917,6 @@ class LoaderIntegrationTest extends TestCase
                         'foo' => 'bar_baz',
                         'identity_foo' => 'bar baz',
                     ]),
-                ],
-            ],
-        ];
-
-        yield '[self reference] alone' => [
-            [
-                stdClass::class => [
-                    'dummy' => [
-                        'itself' => '@self',
-                    ],
-                ],
-            ],
-            [
-                'parameters' => [],
-                'objects' => [
-                    'dummy' => (function () {
-                        $dummy = new stdClass();
-                        $dummy->itself = $dummy;
-
-                        return $dummy;
-                    })(),
-                ],
-            ],
-        ];
-
-        yield '[self reference] property' => [
-            [
-                stdClass::class => [
-                    'dummy' => [
-                        'foo' => 'bar',
-                        'itself' => '@self',
-                    ],
-                ],
-            ],
-            [
-                'parameters' => [],
-                'objects' => [
-                    'dummy' => (function () {
-                        $dummy = new stdClass();
-                        $dummy->foo = 'bar';
-                        $dummy->itself = $dummy;
-
-                        return $dummy;
-                    })(),
                 ],
             ],
         ];
@@ -3663,26 +3586,6 @@ class LoaderIntegrationTest extends TestCase
                 'parameters' => [],
                 'objects' => [
                     'dummy' => FixtureEntity\Caller\Dummy::create('Fake Title', 2),
-                ],
-            ],
-        ];
-
-        yield '[current] in method calls' => [
-            [
-                FixtureEntity\Caller\Dummy::class => [
-                    'dummy_{1..2}' => [
-                        '__calls' => [
-                            ['setTitle' => ['Fake Title <current()>']],
-                            ['addFoo' => []],
-                        ]
-                    ]
-                ]
-            ],
-            [
-                'parameters' => [],
-                'objects' => [
-                    'dummy_1' => FixtureEntity\Caller\Dummy::create('Fake Title 1', 1),
-                    'dummy_2' => FixtureEntity\Caller\Dummy::create('Fake Title 2', 1),
                 ],
             ],
         ];

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -56,7 +56,7 @@ class LoaderIntegrationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->loader = new IsolatedLoader();
         $this->nonIsolatedLoader = new NativeLoader();

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -22,10 +22,12 @@ use Nelmio\Alice\FilesLoaderInterface;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ObjectSet;
 use Nelmio\Alice\ParameterBag;
+use Nelmio\Alice\Throwable\Exception\FixtureNotFoundException;
 use Nelmio\Alice\Throwable\Exception\Generator\DebugUnexpectedValueException;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException;
 use Nelmio\Alice\Throwable\Exception\NoValueForCurrentException;
+use Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use Nelmio\Alice\User;
 use Nelmio\Alice\UserDetail;
@@ -146,30 +148,27 @@ class LoaderIntegrationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The file "unknown.yml" could not be found.
-     */
     public function testLoadInexistingFile()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "unknown.yml" could not be found.');
+
         $this->loader->loadFile('unknown.yml');
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException
-     * @expectedExceptionMessageRegExp /^No suitable parser found for the file ".*?plain_file"\.$/
-     */
     public function testLoadUnsupportedFileFormat()
     {
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessageRegExp('/^No suitable parser found for the file ".*?plain_file"\.$/');
+
         $this->loader->loadFile(self::PARSER_FILES_DIR.'/unsupported/plain_file');
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^The file ".*?no_return.php" must return a PHP array\.$/
-     */
     public function testLoadPhpFileWhichDoesNotReturnAnything()
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^The file ".*?no_return.php" must return a PHP array\.$/');
+
         $this->loader->loadFile(self::PARSER_FILES_DIR.'/php/no_return.php');
     }
 
@@ -249,12 +248,11 @@ class LoaderIntegrationTest extends TestCase
         $this->assertEquals($expected, $objects['dummy']);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Cannot use the fixture property "__construct" and "__factory" together.
-     */
     public function testCannotUseBothConstructAndFactoryAtTheSameTime()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot use the fixture property "__construct" and "__factory" together.');
+
         $this->loader->loadData([
             stdClass::class => [
                 'dummy' => [
@@ -1259,10 +1257,6 @@ class LoaderIntegrationTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\FixtureNotFoundException
-     * @expectedExceptionMessage Could not find the fixture "unknown".
-     */
     public function testThrowsAnExceptionIfInheritFromAnNonExistingFixture()
     {
         $data = [
@@ -1270,13 +1264,13 @@ class LoaderIntegrationTest extends TestCase
                 'dummy (extends unknown)' => [],
             ],
         ];
+
+        $this->expectException(FixtureNotFoundException::class);
+        $this->expectExceptionMessage('Could not find the fixture "unknown".');
+
         $this->loader->loadData($data);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Fixture "dummy" extends "another_dummy" but "another_dummy" is not a template.
-     */
     public function testThrowsAnExceptionIfInheritFromAnInexistingTemplate()
     {
         $data = [
@@ -1285,6 +1279,10 @@ class LoaderIntegrationTest extends TestCase
                 'dummy (extends another_dummy)' => [],
             ],
         ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fixture "dummy" extends "another_dummy" but "another_dummy" is not a template.');
+
         $this->loader->loadData($data);
     }
 

--- a/tests/Loader/NativeLoaderTest.php
+++ b/tests/Loader/NativeLoaderTest.php
@@ -20,23 +20,23 @@ use PHPUnit\Framework\TestCase;
  */
 class NativeLoaderTest extends TestCase
 {
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Unknown method "foo".
-     */
     public function testThrowsAnExceptionIfCallUnknownMethod()
     {
         $loader = new NativeLoader();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Unknown method "foo".');
+
         $loader->foo();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Unknown method "createFoo".
-     */
     public function testThrowsAnExceptionIfCallUnknownGetMethod()
     {
         $loader = new NativeLoader();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Unknown method "createFoo".');
+
         $loader->getFoo();
     }
 

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -32,7 +32,7 @@ class ObjectBagTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propRefl = (new \ReflectionClass(ObjectBag::class))->getProperty('objects');
         $this->propRefl->setAccessible(true);

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice;
 use Nelmio\Alice\Definition\Object\CompleteObject;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Entity\StdClassFactory;
+use Nelmio\Alice\Throwable\Exception\ObjectNotFoundException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -78,12 +79,11 @@ class ObjectBagTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Reference key mismatch, the keys "foo" and "bar" refers to the same fixture but the keys are different.
-     */
     public function testThrowsAnExceptionIfAReferenceMismatchIsFound()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reference key mismatch, the keys "foo" and "bar" refers to the same fixture but the keys are different.');
+
         new ObjectBag([
             'foo' => new CompleteObject(new SimpleObject('bar', new stdClass())),
         ]);
@@ -124,12 +124,11 @@ class ObjectBagTest extends TestCase
         $this->assertFalse($bag->has($inexistingReference));
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\ObjectNotFoundException
-     * @expectedExceptionMessage Could not find the object "foo" of the class "Dummy".
-     */
     public function testThrowsExceptionWhenTryingToGetInexistingObject()
     {
+        $this->expectException(ObjectNotFoundException::class);
+        $this->expectExceptionMessage('Could not find the object "foo" of the class "Dummy".');
+
         $bag = new ObjectBag();
         $bag->get($this->createFixture('foo', 'Dummy'));
     }

--- a/tests/ParameterBagTest.php
+++ b/tests/ParameterBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice;
 
+use Nelmio\Alice\Throwable\Exception\ParameterNotFoundException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,12 +42,11 @@ class ParameterBagTest extends TestCase
         $this->assertBagSize(2, $bag);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\ParameterNotFoundException
-     * @expectedExceptionMessage Could not find the parameter "foo".
-     */
     public function testThrowsAnExceptionWhenATryingToGetAnInexistingParameter()
     {
+        $this->expectException(ParameterNotFoundException::class);
+        $this->expectExceptionMessage('Could not find the parameter "foo".');
+
         $bag = new ParameterBag();
         $bag->get('foo');
     }

--- a/tests/Parser/Chainable/JsonParserTest.php
+++ b/tests/Parser/Chainable/JsonParserTest.php
@@ -35,7 +35,7 @@ class JsonParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -45,7 +45,7 @@ class JsonParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$dir = null;
 
@@ -55,7 +55,7 @@ class JsonParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new JsonParser();
     }

--- a/tests/Parser/Chainable/JsonParserTest.php
+++ b/tests/Parser/Chainable/JsonParserTest.php
@@ -15,6 +15,7 @@ namespace Nelmio\Alice\Parser\Chainable;
 
 use Nelmio\Alice\Parser\ChainableParserInterface;
 use Nelmio\Alice\Parser\FileListProviderTrait;
+use Nelmio\Alice\Throwable\Exception\Parser\UnparsableFileException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -111,12 +112,11 @@ class JsonParserTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The file "/nowhere.json" could not be found.
-     */
     public function testThrowsAnExceptionIfFileDoesNotExist()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "/nowhere.json" could not be found.');
+
         $this->parser->parse('/nowhere.json');
     }
 
@@ -143,12 +143,11 @@ class JsonParserTest extends TestCase
         $this->assertSame([], $actual);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Parser\UnparsableFileException
-     * @expectedExceptionMessageRegExp /^The file ".+\/invalid\.json" does not contain valid JSON\.$/
-     */
     public function testThrowsAnExceptionIfInvalidJson()
     {
+        $this->expectException(UnparsableFileException::class);
+        $this->expectExceptionMessageRegExp('/^The file ".+\/invalid\.json" does not contain valid JSON\.$/');
+
         $this->parser->parse(self::$dir.'/invalid.json');
     }
 }

--- a/tests/Parser/Chainable/PhpParserTest.php
+++ b/tests/Parser/Chainable/PhpParserTest.php
@@ -111,12 +111,11 @@ class PhpParserTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The file "/nowhere.php" could not be found.
-     */
     public function testThrowsAnExceptionIfFileDoesNotExist()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "/nowhere.php" could not be found.');
+
         $this->parser->parse('/nowhere.php');
     }
 
@@ -143,21 +142,19 @@ class PhpParserTest extends TestCase
         $this->assertSame([], $actual);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^The file ".+\/no_return\.php" must return a PHP array\.$/
-     */
     public function testThrowsAnExceptionIfNoArrayReturnedInParsedFile()
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^The file ".+\/no_return\.php" must return a PHP array\.$/');
+
         $this->parser->parse(self::$dir.'/no_return.php');
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^The file ".+\/wrong_return\.php" must return a PHP array\.$/
-     */
     public function testThrowsAnExceptionIfWrongValueReturnedInParsedFile()
     {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^The file ".+\/wrong_return\.php" must return a PHP array\.$/');
+
         $this->parser->parse(self::$dir.'/wrong_return.php');
     }
 }

--- a/tests/Parser/Chainable/PhpParserTest.php
+++ b/tests/Parser/Chainable/PhpParserTest.php
@@ -35,7 +35,7 @@ class PhpParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -45,7 +45,7 @@ class PhpParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$dir = null;
 
@@ -55,7 +55,7 @@ class PhpParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new PhpParser();
     }

--- a/tests/Parser/Chainable/YamlParserTest.php
+++ b/tests/Parser/Chainable/YamlParserTest.php
@@ -40,7 +40,7 @@ class YamlParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -50,7 +50,7 @@ class YamlParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$dir = null;
 
@@ -60,7 +60,7 @@ class YamlParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $symfonyYamlParserProphecy = $this->prophesize(SymfonyYamlParser::class);
         $symfonyYamlParserProphecy->parse(Argument::cetera())->shouldNotBeCalled();

--- a/tests/Parser/Chainable/YamlParserTest.php
+++ b/tests/Parser/Chainable/YamlParserTest.php
@@ -121,12 +121,11 @@ class YamlParserTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The file "/nowhere.yml" could not be found.
-     */
     public function testThrowExceptionIfFileDoesNotExist()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "/nowhere.yml" could not be found.');
+
         $this->parser->parse('/nowhere.yml');
     }
 

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -31,7 +31,7 @@ class DefaultIncludeProcessorTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         self::$dir = __DIR__.'/../../../fixtures/Parser/files/cache';
     }

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -46,10 +46,6 @@ class DefaultIncludeProcessorTest extends TestCase
         $this->assertFalse((new ReflectionClass(DefaultIncludeProcessor::class))->isCloneable());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find any include statement in the file "dummy.php".
-     */
     public function testThrowsAnExceptionIfNoIncludeStatementFound()
     {
         $parserProphecy = $this->prophesize(ParserInterface::class);
@@ -63,6 +59,9 @@ class DefaultIncludeProcessorTest extends TestCase
         $fileLocator = $fileLocatorProphecy->reveal();
 
         $processor = new DefaultIncludeProcessor($fileLocator);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find any include statement in the file "dummy.php".');
 
         $processor->process($parser, 'dummy.php', []);
     }
@@ -99,10 +98,6 @@ class DefaultIncludeProcessorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^Expected include statement to be either null or an array of files to include\. Got "string" instead in file ".+\/main\.yml"\.$/
-     */
     public function testIfNotNullIncludeStatementMustBeAnArray()
     {
         $mainFile = self::$dir.'/main.yml';   // needs to be a real file to be cached
@@ -120,13 +115,12 @@ class DefaultIncludeProcessorTest extends TestCase
 
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
 
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^Expected include statement to be either null or an array of files to include\. Got "string" instead in file ".+\/main\.yml"\.$/');
+
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }
 
-    /**
-     * @expectedException \TypeError
-     * @expectedExceptionMessageRegExp /^Expected elements of include statement to be file names\. Got "boolean" instead in file ".+\/main\.yml"\.$/
-     */
     public function testIncludedFilesMustBeStrings()
     {
         $mainFile = self::$dir.'/main.yml';   // needs to be a real file to be cached
@@ -146,13 +140,12 @@ class DefaultIncludeProcessorTest extends TestCase
 
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
 
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessageRegExp('/^Expected elements of include statement to be file names\. Got "boolean" instead in file ".+\/main\.yml"\.$/');
+
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^Expected elements of include statement to be file names\. Got empty string instead in file ".+\/main\.yml"\.$/
-     */
     public function testIncludedFilesMustBeNonEmptyStrings()
     {
         $mainFile = self::$dir.'/main.yml';   // needs to be a real file to be cached
@@ -171,6 +164,9 @@ class DefaultIncludeProcessorTest extends TestCase
         $parser = $parserProphecy->reveal();
 
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/^Expected elements of include statement to be file names\. Got empty string instead in file ".+\/main\.yml"\.$/');
 
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }

--- a/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
+++ b/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
@@ -28,7 +28,7 @@ class IncludeDataMergerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->merger = new IncludeDataMerger();
     }

--- a/tests/Parser/ParserRegistryTest.php
+++ b/tests/Parser/ParserRegistryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nelmio\Alice\Parser;
 
 use Nelmio\Alice\ParserInterface;
+use Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
@@ -39,11 +40,10 @@ class ParserRegistryTest extends TestCase
         new ParserRegistry([$parser]);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testThrowsAnExceptionIfInvalidParserIsPassed()
     {
+        $this->expectException(\TypeError::class);
+
         new ParserRegistry([new stdClass()]);
     }
 
@@ -87,13 +87,13 @@ class ParserRegistryTest extends TestCase
         $parser2Prophecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
 
-    /**
-     * @expectedException \Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException
-     * @expectedExceptionMessage No suitable parser found for the file "dummy.php".
-     */
     public function testThrowsAnExceptionIfNoSuitableParserIsFound()
     {
         $registry = new ParserRegistry([]);
+
+        $this->expectException(ParserNotFoundException::class);
+        $this->expectExceptionMessage('No suitable parser found for the file "dummy.php".');
+
         $registry->parse('dummy.php');
     }
 }

--- a/tests/Parser/RuntimeCacheParserTest.php
+++ b/tests/Parser/RuntimeCacheParserTest.php
@@ -33,7 +33,7 @@ class RuntimeCacheParserTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    protected function setUp(): void
     {
         self::$dir = __DIR__.'/../../fixtures/Parser/files/cache';
     }

--- a/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
+++ b/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
@@ -87,10 +87,6 @@ class ReflectionPropertyAccessorTest extends TestCase
         $this->assertSame($value, $object->test_get_val());
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot set property "unknown".
-     */
     public function testThrowsAnOriginalExceptionIfSetValueForANonExistentProperty()
     {
         $property = 'unknown';
@@ -108,13 +104,12 @@ class ReflectionPropertyAccessorTest extends TestCase
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
 
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot set property "unknown".');
+
         $accessor->setValue($object, $property, $value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot set property "unknown".
-     */
     public function testThrowsAnOriginalExceptionIfSetValueForANonExistentPropertyOnNonObject()
     {
         $property = 'unknown';
@@ -132,13 +127,12 @@ class ReflectionPropertyAccessorTest extends TestCase
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
 
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot set property "unknown".');
+
         $accessor->setValue($object, $property, $value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot set property "staticVal".
-     */
     public function testThrowsAnOriginalExceptionIfSetValueForANonExistentPropertyIsStatic()
     {
         $property = 'staticVal';
@@ -155,6 +149,9 @@ class ReflectionPropertyAccessorTest extends TestCase
         $decoratedAccessor = $decoratedAccessorProphecy->reveal();
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot set property "staticVal".');
 
         $accessor->setValue($object, $property, $value);
     }
@@ -209,10 +206,6 @@ class ReflectionPropertyAccessorTest extends TestCase
         $this->assertEquals($value, $actual);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot read property "foo".
-     */
     public function testThrowsAnOriginalExceptionIfPropertyDoesNotExist()
     {
         $property = 'foo';
@@ -229,13 +222,12 @@ class ReflectionPropertyAccessorTest extends TestCase
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
 
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot read property "foo".');
+
         $accessor->getValue($object, $property);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot read property "foo".
-     */
     public function testThrowsAnOriginalExceptionIfPropertyDoesNotExistOnNonObject()
     {
         $property = 'foo';
@@ -252,13 +244,12 @@ class ReflectionPropertyAccessorTest extends TestCase
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
 
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot read property "foo".');
+
         $accessor->getValue($object, $property);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot read property "staticVal".
-     */
     public function testThrowsAnOriginalExceptionIfPropertyIsStatic()
     {
         $property = 'staticVal';
@@ -274,6 +265,9 @@ class ReflectionPropertyAccessorTest extends TestCase
         $decoratedAccessor = $decoratedAccessorProphecy->reveal();
 
         $accessor = new ReflectionPropertyAccessor($decoratedAccessor);
+
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot read property "staticVal".');
 
         $accessor->getValue($object, $property);
     }

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -27,6 +27,7 @@ use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionClass;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -97,15 +98,15 @@ class StdPropertyAccessorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessage Cannot read property "foo" from stdClass.
-     */
     public function testThrowsAnExceptionIfPropertyNotFoundOnStdClass()
     {
         $object = new \stdClass();
 
         $accessor = new StdPropertyAccessor(new FakePropertyAccessor());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $this->expectExceptionMessage('Cannot read property "foo" from stdClass.');
+
         $accessor->getValue($object, 'foo');
     }
 


### PR DESCRIPTION
PHPUnit 7 is unmaintained and does not officially support PHP 7.4.
Given that the testsuite still needs to run on PHPUnit 7 for the tests on PHP 7.1, I kept it compatible with both PHPunit 7 and PHPUnit 8.

Here is the summary of changes:

- added `void` return types on hook methods (this is compatible with PHPUnit 7, as child classes are allowed to add a return type when overriding methods)
- migrate from `@expectedException` to `expectException()` as the annotation-based expectations are deprecated in PHPUnit 8
- remove broken data provider est case due to tests typehinting the argument as string (PHPUnit 8 runs in strict mode, so the integer was not casted to string implicitly making it the same case than the previous one)
- fix invalid data providers (PHPUnit 8 reports them instead of silently ignoring duplicate keys like older versions which were using `iterator_to_array`), which allowed discovering some non-executed cases