### PR TITLE
Add support for sebastian/comparator 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.1",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
-        "sebastian/comparator": "^3.0",
+        "sebastian/comparator": "^3.0 || ^4.0",
         "symfony/property-access": "^2.8 || ^3.4 || ^4.0 || ^5.0",
         "symfony/yaml": "^2.8 || ^3.4 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
The CI always uses version 3 for now, because of the PHPUnit version being used (using sebastian/comparator 4 would require allowing the testsuite to run with PHPUnit 9, which is more work).
Given that the *only* change in sebastian/comparator 4 is the minimum PHP requirement (there are also some tooling changes in the git history, but that's only for contributors), I consider that this is fine as a way to fix #1017 