### PR TITLE
Fix parsing of numeric, boolean and null values for function arguments

### DIFF
--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -143,32 +143,30 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         switch (true) {
             case $value === 'true':
                 return true;
+
             case $value === 'false':
                 return false;
+
             case $value === 'null':
                 return null;
-            case ctype_digit($value):
+
+            case preg_match('/^([-+])?([0-9]+)$/', $value, $matches):
                 $castedValue = (int) $value;
 
-                if (0 === $value[0]) {
-                    return octdec($value);
-                } elseif ($value === (string) $castedValue) {
+                if ('0' === $matches[2][0]) {
+                    return '-' === $matches[1] ? -octdec($matches[2]) : octdec($matches[2]);
+                }
+
+                if ($value === (string) $castedValue || ('+' === $matches[1] && $matches[2] === (string) $castedValue)) {
                     return $castedValue;
                 }
 
                 return $value;
-            case $value[0] === '-' && ctype_digit(substr($value, 1)):
-                $castedValue = (int) $value;
 
-                if (0 === $value[0]) {
-                    return -octdec($value);
-                } elseif ($value === (string) $castedValue) {
-                    return $castedValue;
-                }
-
-                return $value;
+            case is_numeric($value):
             case preg_match('/^[-+]?[0-9]*(\.[0-9]+)?$/', $value):
                 return (float) $value;
+
             default:
                 return $parser->parse($value);
         }

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -113,7 +113,6 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         }
 
         $argumentEscaper = $this->argumentEscaper;
-
         $escapedString = preg_replace_callback(
             '/\'(.*?)\'|"(.*?)"/',
             function (array $matches) use ($argumentEscaper): string {
@@ -129,13 +128,49 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
         );
 
         $arguments = [];
-        preg_match_all('/\[[^[]+\]|[^,\s]+/', $escapedString, $argumentsList);
-        foreach ($argumentsList[0] as $index => $argument) {
-            $argument = $parser->parse($argument);
 
-            $arguments[$index] = $argument;
+        preg_match_all('/\[[^[]+\]|[^,\s]+/', $escapedString, $argumentsList);
+
+        foreach ($argumentsList[0] as $index => $argument) {
+            $arguments[$index] = $this->parseArgument($parser, $argument);
         }
 
         return $arguments;
+    }
+
+    private function parseArgument(ParserInterface $parser, string $value)
+    {
+        switch (true) {
+            case $value === 'true':
+                return true;
+            case $value === 'false':
+                return false;
+            case $value === 'null':
+                return null;
+            case ctype_digit($value):
+                $castedValue = (int) $value;
+
+                if (0 === $value[0]) {
+                    return octdec($value);
+                } elseif ($value === (string) $castedValue) {
+                    return $castedValue;
+                }
+
+                return $value;
+            case $value[0] === '-' && ctype_digit(substr($value, 1)):
+                $castedValue = (int) $value;
+
+                if (0 === $value[0]) {
+                    return -octdec($value);
+                } elseif ($value === (string) $castedValue) {
+                    return $castedValue;
+                }
+
+                return $value;
+            case preg_match('/^[-+]?[0-9]*(\.[0-9]+)?$/', $value):
+                return (float) $value;
+            default:
+                return $parser->parse($value);
+        }
     }
 }

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -457,9 +457,27 @@ class LexerIntegrationTest extends TestCase
             ],
         ];
         yield '[Function] nominal with string arguments which contains quotes' => [
-            '<function(\'foo\', "bar")>',
+            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20")>',
             [
-                new Token('<aliceTokenizedFunction(FUNCTION_START__function__\'foo\', "bar"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
+        yield '[Function] nominal with boolean arguments' => [
+            '<function(true, false)>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__true, falseIDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
+        yield '[Function] nominal with null arguments' => [
+            '<function(null)>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__nullIDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+            ],
+        ];
+        yield '[Function] nominal with numeric arguments' => [
+            '<function(10, 10.20, +10, -10, +10.20, -10.20)>',
+            [
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__10, 10.20, +10, -10, +10.20, -10.20IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
         yield '[Function] nominal with array argument which contains string elements in quotes' => [

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/LexerIntegrationTest.php
@@ -457,9 +457,9 @@ class LexerIntegrationTest extends TestCase
             ],
         ];
         yield '[Function] nominal with string arguments which contains quotes' => [
-            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20")>',
+            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20", "012", "+012", "-012")>',
             [
-                new Token('<aliceTokenizedFunction(FUNCTION_START__function__\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20", "012", "+012", "-012"IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
         yield '[Function] nominal with boolean arguments' => [
@@ -475,9 +475,9 @@ class LexerIntegrationTest extends TestCase
             ],
         ];
         yield '[Function] nominal with numeric arguments' => [
-            '<function(10, 10.20, +10, -10, +10.20, -10.20)>',
+            '<function(10, 10.20, +10, -10, +10.20, -10.20, 012, +012, -012)>',
             [
-                new Token('<aliceTokenizedFunction(FUNCTION_START__function__10, 10.20, +10, -10, +10.20, -10.20IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
+                new Token('<aliceTokenizedFunction(FUNCTION_START__function__10, 10.20, +10, -10, +10.20, -10.20, 012, +012, -012IDENTITY_OR_FUNCTION_END)>', new TokenType(TokenType::FUNCTION_TYPE)),
             ],
         ];
         yield '[Function] nominal with array argument which contains string elements in quotes' => [

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -38,12 +38,11 @@ use PHPUnit\Framework\TestCase;
  */
 class ParserIntegrationTest extends TestCase
 {
-    /** @var ParserInterface */
+    /**
+     * @var ParserInterface
+     */
     protected $parser;
 
-    /**
-     * @inheritdoc
-     */
     protected function setUp(): void
     {
         $this->parser = (new NativeLoader())->getExpressionLanguageParser();
@@ -378,12 +377,52 @@ class ParserIntegrationTest extends TestCase
             ),
         ];
         yield '[Function] nominal with string arguments which contains quotes' => [
-            '<function(\'foo\', "bar")>',
+            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20")>',
             new FunctionCallValue(
                 'function',
                 [
                     'foo',
                     'bar',
+                    'true',
+                    'false',
+                    'null',
+                    '10',
+                    '10.20',
+                    '+10',
+                    '-10',
+                    '+10.20',
+                    '-10.20',
+                ]
+            ),
+        ];
+        yield '[Function] nominal with boolean arguments' => [
+            '<function(true, false)>',
+            new FunctionCallValue(
+                'function',
+                [
+                    true,
+                    false,
+                ]
+            ),
+        ];
+        yield '[Function] nominal with null arguments' => [
+            '<function(null)>',
+            new FunctionCallValue(
+                'function',
+                [null]
+            ),
+        ];
+        yield '[Function] nominal with numeric arguments' => [
+            '<function(10, 10.20, +10, -10, +10.20, -10.20)>',
+            new FunctionCallValue(
+                'function',
+                [
+                    10,
+                    10.20,
+                    10,
+                    -10,
+                    10.20,
+                    -10.20,
                 ]
             ),
         ];

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -377,7 +377,7 @@ class ParserIntegrationTest extends TestCase
             ),
         ];
         yield '[Function] nominal with string arguments which contains quotes' => [
-            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20")>',
+            '<function(\'foo\', "bar", "true", "false", "null", "10", "10.20", "+10", "-10", "+10.20", "-10.20", "012", "+012", "-012")>',
             new FunctionCallValue(
                 'function',
                 [
@@ -392,6 +392,9 @@ class ParserIntegrationTest extends TestCase
                     '-10',
                     '+10.20',
                     '-10.20',
+                    '012',
+                    '+012',
+                    '-012',
                 ]
             ),
         ];
@@ -413,7 +416,7 @@ class ParserIntegrationTest extends TestCase
             ),
         ];
         yield '[Function] nominal with numeric arguments' => [
-            '<function(10, 10.20, +10, -10, +10.20, -10.20)>',
+            '<function(10, 10.20, +10, -10, +10.20, -10.20, 012, +012, -012)>',
             new FunctionCallValue(
                 'function',
                 [
@@ -423,6 +426,9 @@ class ParserIntegrationTest extends TestCase
                     -10,
                     10.20,
                     -10.20,
+                    10,
+                    10,
+                    -10,
                 ]
             ),
         ];


### PR DESCRIPTION
Fixes #1029 by implementing the parsing of `numeric`, `boolean` and `null` values I don't really like that I have to parse two times the value, both in the lexer and in the parser, but as the `Token` class accepts only a `string` as value of the token I don't see any other way around this without widening the typehint. However, as far as I see quite a lot of things are marked as `@internal` so BC should not be a problem if we decide to go that way