### PR TITLE
Maintenance PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 /bin/
 /composer.lock
 /dist/
-/fixtures/Bridge/Symfony/Application/cache/
+/fixtures/Bridge/Symfony/Application/var/
+!/fixtures/Bridge/Symfony/Application/var/.gitkeep
 /vendor/
 /vendor-bin/*/bin/
 /vendor-bin/*/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bin/
 /composer.lock
 /dist/
+/fixtures/Bridge/Symfony/Application/cache/
 /fixtures/Bridge/Symfony/Application/var/
 !/fixtures/Bridge/Symfony/Application/var/.gitkeep
 /vendor/

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -26,7 +26,7 @@ $finder = Finder::create()
     ])
     ->exclude([
         __DIR__.'/fixtures/Parser/files/php',
-        __DIR__.'/Bridge/Symfony/Application/cache',
+        __DIR__.'/Bridge/Symfony/Application/var',
     ])
 ;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,15 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '7.1'
+    - php: '7.3'
       env: COMPOSER_FLAGS='--prefer-lowest'
-    - php: '7.2'
+    - php: '7.4'
       env: COVERAGE='true'
-    - php: '7.2'
+    - php: '7.4'
       env: SYMFONY_VERSION='~3.4.0'
-    - php: '7.2'
+    - php: '7.4'
       env: SYMFONY_VERSION='~4.4.0'
-    - php: '7.2'
+    - php: '7.4'
       env: SYMFONY_VERSION='~5.0.0'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - "$HOME/.composer/cache/files"
 
 php:
-  - '7.1'
-  - '7.2'
   - '7.3'
   - '7.4'
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
 
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "fzaninotto/faker": "^1.6",
         "myclabs/deep-copy": "^1.5.2",
         "sebastian/comparator": "^3.0 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,9 @@
         "bamarni/composer-bin-plugin": "^1.1.0",
         "php-mock/php-mock": "^2.0",
         "phpspec/prophecy": "^1.6",
-        "phpunit/phpunit": "^7.0 || ^8.5",
-        "symfony/phpunit-bridge": "^3.4.5 || ^4.0.5 || ^5.0",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^8.5.4 || ^9.0",
+        "symfony/phpunit-bridge": "^5.0",
         "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
     },
     "conflict": {

--- a/fixtures/Bridge/Symfony/Application/AppKernel.php
+++ b/fixtures/Bridge/Symfony/Application/AppKernel.php
@@ -85,5 +85,4 @@ class AppKernel extends Kernel
     {
         return __DIR__;
     }
-
 }

--- a/fixtures/Bridge/Symfony/Application/AppKernel.php
+++ b/fixtures/Bridge/Symfony/Application/AppKernel.php
@@ -80,4 +80,10 @@ class AppKernel extends Kernel
     {
         $this->config = $resource;
     }
+
+    public function getProjectDir()
+    {
+        return __DIR__;
+    }
+
 }

--- a/fixtures/Definition/Object/ImmutableObject.php
+++ b/fixtures/Definition/Object/ImmutableObject.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Object;
 
-use Nelmio\Alice\ObjectInterface;
 use function Nelmio\Alice\deep_clone;
+use Nelmio\Alice\ObjectInterface;
 
 class ImmutableObject implements ObjectInterface
 {

--- a/fixtures/Entity/DummyWithPrivatePropertyChild.php
+++ b/fixtures/Entity/DummyWithPrivatePropertyChild.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Nelmio\Alice\Entity;
 
 class DummyWithPrivatePropertyChild extends DummyWithPrivateProperty

--- a/fixtures/Symfony/KernelFactory.php
+++ b/fixtures/Symfony/KernelFactory.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Symfony;
 
+use function bin2hex;
 use Nelmio\Alice\Bridge\Symfony\Application\AppKernel;
+use function random_bytes;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class KernelFactory
@@ -28,7 +30,7 @@ class KernelFactory
     ): KernelInterface {
         if (null !== $config) {
             if (false === array_key_exists($config, static::$environments)) {
-                static::$environments[$config] = uniqid();
+                static::$environments[$config] = bin2hex(random_bytes(8));
             }
 
             $environment = static::$environments[$config];

--- a/phpunit_symfony.xml.dist
+++ b/phpunit_symfony.xml.dist
@@ -18,6 +18,14 @@
          enforceTimeLimit="true"
 >
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+    </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <testsuites>
         <testsuite name="Independent tests">
             <directory>tests/Bridge/Symfony</directory>
@@ -29,8 +37,4 @@
             <directory>src/Bridge/Symfony</directory>
         </whitelist>
     </filter>
-
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
-    </php>
 </phpunit>

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('nelmio_alice');
+
         if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
         } else {
@@ -41,7 +42,7 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('en_US')
                     ->info('Default locale for the Faker Generator')
                     ->validate()
-                        ->always($this->createStringValidatorClosure('nelmio_alice.locale'))
+                        ->always($this->createStringValidatorClosure())
                     ->end()
                 ->end()
                 ->scalarNode('seed')

--- a/src/Definition/Value/ArrayValue.php
+++ b/src/Definition/Value/ArrayValue.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
-use Nelmio\Alice\Definition\ValueInterface;
 use function Nelmio\Alice\deep_clone;
+use Nelmio\Alice\Definition\ValueInterface;
 
 final class ArrayValue implements ValueInterface
 {

--- a/src/Definition/Value/DynamicArrayValue.php
+++ b/src/Definition/Value/DynamicArrayValue.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use function Nelmio\Alice\deep_clone;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Throwable\Error\TypeErrorFactory;
-use function Nelmio\Alice\deep_clone;
 
 /**
  * Value object representing an array like "10x @user0". '10' is called "quantifier" and "@user0" is called "element".

--- a/src/Definition/Value/FunctionCallValue.php
+++ b/src/Definition/Value/FunctionCallValue.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
-use Nelmio\Alice\Definition\ValueInterface;
 use function Nelmio\Alice\deep_clone;
+use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * Value object representing '<name()>'.

--- a/src/Definition/Value/ListValue.php
+++ b/src/Definition/Value/ListValue.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
-use Nelmio\Alice\Definition\ValueInterface;
 use function Nelmio\Alice\deep_clone;
+use Nelmio\Alice\Definition\ValueInterface;
 
 /**
  * Value representing a list of values which will be chained. For example '<foo()> <{bar}>' will be composed of a

--- a/src/Definition/Value/ParameterValue.php
+++ b/src/Definition/Value/ParameterValue.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use function Nelmio\Alice\deep_clone;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Throwable\Error\TypeErrorFactory;
-use function Nelmio\Alice\deep_clone;
 
 /**
  * Value object representing '<{param}>'.

--- a/src/Definition/Value/UniqueValue.php
+++ b/src/Definition/Value/UniqueValue.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Definition\Value;
 
+use function Nelmio\Alice\deep_clone;
 use Nelmio\Alice\Definition\ValueInterface;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
-use function Nelmio\Alice\deep_clone;
 
 final class UniqueValue implements ValueInterface
 {

--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
@@ -27,8 +27,8 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserAwareInterface;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
-use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserExceptionFactory;
+use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
 
 final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
 {
@@ -89,7 +89,7 @@ final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormaliz
 
         $referencedName = $matches['name'];
         $allFlag = ($matches['flag'] ?? null) === '*';
-		$idFlags = $this->flagParser->parse($fixtureId);
+        $idFlags = $this->flagParser->parse($fixtureId);
 
         $fixtureIds = $this->buildReferencedValues($builtFixtures, $referencedName, $allFlag);
 

--- a/src/Parser/IncludeProcessor/DefaultIncludeProcessor.php
+++ b/src/Parser/IncludeProcessor/DefaultIncludeProcessor.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Parser\IncludeProcessor;
 
+use function array_reverse;
 use Nelmio\Alice\FileLocatorInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Parser\IncludeProcessorInterface;
 use Nelmio\Alice\ParserInterface;
 use Nelmio\Alice\Throwable\Error\TypeErrorFactory;
 use Nelmio\Alice\Throwable\Exception\InvalidArgumentExceptionFactory;
-use function array_reverse;
 
 final class DefaultIncludeProcessor implements IncludeProcessorInterface
 {

--- a/src/Parser/IncludeProcessor/IncludeDataMerger.php
+++ b/src/Parser/IncludeProcessor/IncludeDataMerger.php
@@ -31,10 +31,10 @@ final class IncludeDataMerger
         foreach ($data as $class => $fixtures) {
             // $class is either a FQCN or 'parameters'
             $includeData[$class] = (
-                    array_key_exists($class, $includeData)
+                array_key_exists($class, $includeData)
                     && is_array($includeData[$class])
                     && is_array($fixtures)
-                )
+            )
                 ? array_merge($includeData[$class], $fixtures)
                 : $fixtures
             ;

--- a/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
@@ -15,8 +15,8 @@ namespace Nelmio\Alice\Bridge\Symfony\DependencyInjection;
 
 use Nelmio\Alice\Symfony\KernelFactory;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @covers \Nelmio\Alice\Bridge\Symfony\DependencyInjection\Configuration
@@ -117,7 +117,7 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.functions_blacklist"\. Expected array, but got string/');
+        $this->expectExceptionMessageMatches('/^Invalid type for path "nelmio_alice.functions_blacklist"\. Expected array, but got string/');
 
         $processor->processConfiguration(
             $configuration,
@@ -171,7 +171,7 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.loading_limit"\. Expected int, but got boolean\./');
+        $this->expectExceptionMessageMatches('/^Invalid type for path "nelmio_alice.loading_limit"\. Expected int, but got boolean\./');
 
         $processor->processConfiguration(
             $configuration,
@@ -207,7 +207,7 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^Invalid type for path "nelmio_alice.max_unique_values_retry"\. Expected int, but got boolean\./');
+        $this->expectExceptionMessageMatches('/^Invalid type for path "nelmio_alice.max_unique_values_retry"\. Expected int, but got boolean\./');
 
         $processor->processConfiguration(
             $configuration,

--- a/tests/Definition/Fixture/FixtureIdTest.php
+++ b/tests/Definition/Fixture/FixtureIdTest.php
@@ -10,14 +10,6 @@
  */
 
 declare(strict_types=1);
-/*
- * This file is part of the Alice package.
- *
- * (c) Nelmio <hello@nelm.io>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Nelmio\Alice\Definition\Fixture;
 

--- a/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
+++ b/tests/Definition/Fixture/SimpleFixtureWithFlagsTest.php
@@ -19,12 +19,15 @@ use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\FixtureInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\SimpleFixtureWithFlags
  */
 class SimpleFixtureWithFlagsTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixtureWithFlags()
     {
         $this->assertTrue(is_a(SimpleFixtureWithFlags::class, FixtureWithFlagsInterface::class, true));

--- a/tests/Definition/Fixture/TemplatingFixtureTest.php
+++ b/tests/Definition/Fixture/TemplatingFixtureTest.php
@@ -21,12 +21,15 @@ use Nelmio\Alice\Definition\ServiceReference\FixtureReference;
 use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\FixtureInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Definition\Fixture\TemplatingFixture
  */
 class TemplatingFixtureTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixture()
     {
         $this->assertTrue(is_a(TemplatingFixture::class, FixtureInterface::class, true));

--- a/tests/Definition/MethodCall/ConfiguratorMethodCallTest.php
+++ b/tests/Definition/MethodCall/ConfiguratorMethodCallTest.php
@@ -18,12 +18,15 @@ use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\MutableReference;
 use Nelmio\Alice\Entity\StdClassFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\ConfiguratorMethodCall
  */
 class ConfiguratorMethodCallTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAMethodCall()
     {
         $this->assertTrue(is_a(ConfiguratorMethodCall::class, MethodCallInterface::class, true));

--- a/tests/Definition/MethodCall/OptionalMethodCallTest.php
+++ b/tests/Definition/MethodCall/OptionalMethodCallTest.php
@@ -19,12 +19,15 @@ use Nelmio\Alice\Definition\ServiceReference\InstantiatedReference;
 use Nelmio\Alice\Definition\ServiceReference\MutableReference;
 use Nelmio\Alice\Entity\StdClassFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Definition\MethodCall\OptionalMethodCall
  */
 class OptionalMethodCallTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAMethodCall()
     {
         $this->assertTrue(is_a(OptionalMethodCall::class, MethodCallInterface::class, true));

--- a/tests/Definition/Object/CompleteObjectTest.php
+++ b/tests/Definition/Object/CompleteObjectTest.php
@@ -10,14 +10,6 @@
  */
 
 declare(strict_types=1);
-/*
- * This file is part of the Alice package.
- *
- * (c) Nelmio <hello@nelm.io>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Nelmio\Alice\Definition\Object;
 

--- a/tests/Definition/Object/CompleteObjectTest.php
+++ b/tests/Definition/Object/CompleteObjectTest.php
@@ -17,12 +17,15 @@ use Nelmio\Alice\Definition\Value\FakeObject;
 use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\ObjectInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Definition\Object\CompleteObject
  */
 class CompleteObjectTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnObject()
     {
         $this->assertTrue(is_a(CompleteObject::class, ObjectInterface::class, true));

--- a/tests/Definition/Object/SimpleObjectTest.php
+++ b/tests/Definition/Object/SimpleObjectTest.php
@@ -92,7 +92,7 @@ class SimpleObjectTest extends TestCase
     public function testThrowsAnErrorIfInstanceIsNotAnObject($instance)
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^Expected instance argument to be an object. Got ".+?" instead\.$/');
+        $this->expectExceptionMessageMatches('/^Expected instance argument to be an object. Got ".+?" instead\.$/');
 
         new SimpleObject('user0', $instance);
     }

--- a/tests/FileLocator/DefaultFileLocatorTest.php
+++ b/tests/FileLocator/DefaultFileLocatorTest.php
@@ -79,7 +79,7 @@ class DefaultFileLocatorTest extends TestCase
     public function testThrowsExceptionIfTheFileDoesNotExists()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessageRegExp('/^The file "(.+?)foobar.xml" does not exist\.$/');
+        $this->expectExceptionMessageMatches('/^The file "(.+?)foobar.xml" does not exist\.$/');
 
         $this->locator->locate('foobar.xml', __DIR__);
     }
@@ -87,7 +87,7 @@ class DefaultFileLocatorTest extends TestCase
     public function testLocatingFileThrowsExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {
         $this->expectException(FileNotFoundException::class);
-        $this->expectExceptionMessageRegExp('/^The file "(.+?)foobar.xml" does not exist\.$/');
+        $this->expectExceptionMessageMatches('/^The file "(.+?)foobar.xml" does not exist\.$/');
 
         $this->locator->locate(__DIR__.'/Fixtures/foobar.xml');
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
@@ -21,9 +21,11 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\FixtureFactory;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\ReferenceProviderTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 abstract class ChainableDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
     use ReferenceProviderTrait;
 
     /**

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
@@ -30,6 +30,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\DummyFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -37,6 +38,8 @@ use ReflectionClass;
  */
 class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
 {
+    use ProphecyTrait;
+
     /**
      * @inheritdoc
      */

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/SimpleDenormalizerTest.php
@@ -30,6 +30,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\DummyFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -37,6 +38,8 @@ use ReflectionClass;
  */
 class SimpleDenormalizerTest extends ChainableDenormalizerTest
 {
+    use ProphecyTrait;
+
     /**
      * @inheritdoc
      */

--- a/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/FixtureDenormalizerRegistryTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\DenormalizerNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use TypeError;
 
 /**
@@ -32,6 +33,8 @@ use TypeError;
  */
 class FixtureDenormalizerRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \ReflectionProperty
      */

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizerTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class SimpleFixtureBagDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixtureBagDenormalizer()
     {
         $this->assertTrue(is_a(SimpleFixtureBagDenormalizer::class, FixtureBagDenormalizerInterface::class, true));

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class SimpleArgumentsDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(SimpleArgumentsDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
@@ -39,7 +39,7 @@ class CallsWithFlagsDenormalizerTest extends TestCase
     public function testCannotAcceptInvalidMethodHandlers()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/must be an instance of Nelmio\\\\Alice\\\\FixtureBuilder\\\\Denormalizer\\\\Fixture\\\\SpecificationBagDenormalizer\\\\Calls\\\\MethodFlagHandler, instance of stdClass given/');
+        $this->expectExceptionMessageMatches('/must be an instance of Nelmio\\\\Alice\\\\FixtureBuilder\\\\Denormalizer\\\\Fixture\\\\SpecificationBagDenormalizer\\\\Calls\\\\MethodFlagHandler, instance of stdClass given/');
 
         new CallsWithFlagsDenormalizer(
             new FakeCallsDenormalizer(),

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -31,6 +32,8 @@ use stdClass;
  */
 class CallsWithFlagsDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(CallsWithFlagsDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/FunctionDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/FunctionDenormalizerTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class FunctionDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(FunctionDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/ConstructorDenormalizerTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class ConstructorDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(ConstructorDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/FactoryDenormalizerTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -28,6 +29,8 @@ use ReflectionClass;
  */
 class FactoryDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(FactoryDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LLegacyConstructorDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Constructor/LLegacyConstructorDenormalizerTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\FakeFlagParser;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class LLegacyConstructorDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(LegacyConstructorDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Property/SimplePropertyDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Property/SimplePropertyDenormalizerTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\ValueDenormalizerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class SimplePropertyDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(SimplePropertyDenormalizer::class))->isCloneable());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/SimpleSpecificationsDenormalizerTest.php
@@ -29,12 +29,15 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalizer\SimpleSpecificationsDenormalizer
  */
 class SimpleSpecificationsDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         clone new SimpleSpecificationsDenormalizer(new FakeConstructorDenormalizer(), new FakePropertyDenormalizer(), new FakeCallsDenormalizer());

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizerTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\Throwable\DenormalizationThrowable;
 use Nelmio\Alice\Throwable\Exception\RootParseException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class SimpleValueDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAValueDenormalizer()
     {
         $this->assertTrue(is_a(SimpleValueDenormalizer::class, ValueDenormalizerInterface::class, true));

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizerTest.php
@@ -27,6 +27,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationBagDenormalize
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\InvalidScopeException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -34,6 +35,8 @@ use ReflectionClass;
  */
 class UniqueValueDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAValueDenormalizer()
     {
         $this->assertTrue(is_a(UniqueValueDenormalizer::class, ValueDenormalizerInterface::class, true));

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/ElementFlagParserTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/ElementFlagParserTest.php
@@ -16,12 +16,15 @@ namespace Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser;
 use Nelmio\Alice\Definition\Flag\ElementFlag;
 use Nelmio\Alice\Definition\FlagBag;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\ElementFlagParser
  */
 class ElementFlagParserTest extends FlagParserTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @inheritdoc
      */

--- a/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
+++ b/tests/FixtureBuilder/Denormalizer/FlagParser/FlagParserRegistryTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class FlagParserRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFlagParser()
     {
         $this->assertTrue(is_a(FlagParserRegistry::class, FlagParserInterface::class, true));

--- a/tests/FixtureBuilder/Denormalizer/SimpleDenormalizerTestTest.php
+++ b/tests/FixtureBuilder/Denormalizer/SimpleDenormalizerTestTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\FixtureBuilder\DenormalizerInterface;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class SimpleDenormalizerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsADenormalizer()
     {
         $this->assertTrue(is_a(SimpleDenormalizer::class, DenormalizerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/EmptyValueLexerTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class EmptyValueLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALexer()
     {
         $this->assertTrue(is_a(EmptyValueLexer::class, LexerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/FunctionLexerTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class FunctionLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var FunctionLexer
      */

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/GlobalPatternsLexerTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class GlobalPatternsLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALexer()
     {
         $this->assertTrue(is_a(GlobalPatternsLexer::class, LexerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/ReferenceEscaperLexerTest.php
@@ -16,6 +16,7 @@ namespace Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Lexer;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\LexerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -23,6 +24,8 @@ use ReflectionClass;
  */
 class ReferenceEscaperLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALexer()
     {
         $this->assertTrue(is_a(ReferenceEscaperLexer::class, LexerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/StringThenReferenceLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/StringThenReferenceLexerTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class StringThenReferenceLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALexer()
     {
         $this->assertTrue(is_a(StringThenReferenceLexer::class, LexerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Lexer/SubPatternsLexerTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class SubPatternsLexerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALexer()
     {
         $this->assertTrue(is_a(SubPatternsLexer::class, LexerInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/FunctionFixtureReferenceParserTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class FunctionFixtureReferenceParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParser()
     {
         $this->assertTrue(is_a(FunctionFixtureReferenceParser::class, ParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class SimpleParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParser()
     {
         $this->assertTrue(is_a(SimpleParser::class, ParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/StringMergerParserTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Value\ListValue;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\ParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class StringMergerParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParser()
     {
         $this->assertTrue(is_a(StringMergerParser::class, ParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/DynamicArrayTokenParserTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseExce
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -31,6 +32,8 @@ use ReflectionClass;
  */
 class DynamicArrayTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(DynamicArrayTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FixtureMethodReferenceTokenParserTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseException;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -31,6 +32,8 @@ use ReflectionClass;
  */
 class FixtureMethodReferenceTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(FixtureMethodReferenceTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\Token;
 use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -25,6 +26,8 @@ use ReflectionClass;
  */
 class IdentityTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(IdentityTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/MethodReferenceTokenParserTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseExce
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class MethodReferenceTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(MethodReferenceTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/OptionalTokenParserTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseExce
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class OptionalTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(OptionalTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/PropertyReferenceTokenParserTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseExce
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -31,6 +32,8 @@ use ReflectionClass;
  */
 class PropertyReferenceTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(PropertyReferenceTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/StringArrayTokenParserTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParseExce
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class StringArrayTokenParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableTokenParser()
     {
         $this->assertTrue(is_a(StringArrayTokenParser::class, ChainableTokenParserInterface::class, true));

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/TokenParserRegistryTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\FixtureBuilder\ExpressionLanguage\TokenType;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\ExpressionLanguage\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -31,6 +32,8 @@ use ReflectionClass;
  */
 class TokenParserRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \ReflectionProperty
      */

--- a/tests/FixtureBuilder/SimpleBuilderTest.php
+++ b/tests/FixtureBuilder/SimpleBuilderTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class SimpleBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixtureBuilder()
     {
         $this->assertTrue(is_a(SimpleBuilder::class, FixtureBuilderInterface::class, true));

--- a/tests/Generator/Caller/SimpleCallerTest.php
+++ b/tests/Generator/Caller/SimpleCallerTest.php
@@ -37,6 +37,7 @@ use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -45,6 +46,8 @@ use stdClass;
  */
 class SimpleCallerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsNotClonable()
     {
         $this->assertFalse((new ReflectionClass(SimpleCaller::class))->isCloneable());

--- a/tests/Generator/DoublePassGeneratorTest.php
+++ b/tests/Generator/DoublePassGeneratorTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class DoublePassGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAGenerator()
     {
         $this->assertTrue(is_a(DoublePassGenerator::class, GeneratorInterface::class, true));

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -27,6 +27,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Hydrator\NoSuchPropertyException;
 use Nelmio\Alice\Throwable\Exception\Symfony\PropertyAccess\RootException as GenericPropertyAccessException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -37,6 +38,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class SymfonyPropertyAccessorHydratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var SymfonyPropertyAccessorHydrator
      */

--- a/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
+++ b/tests/Generator/Instantiator/Chainable/AbstractChainableInstantiatorTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiationException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionClass;
  */
 class AbstractChainableInstantiatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var AbstractChainableInstantiator
      */

--- a/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
+++ b/tests/Generator/Instantiator/ExistingInstanceInstantiatorTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\Generator\ValueResolverAwareInterface;
 use Nelmio\Alice\ObjectBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class ExistingInstanceInstantiatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnInstantiator()
     {
         $this->assertTrue(is_a(ExistingInstanceInstantiator::class, InstantiatorInterface::class, true));

--- a/tests/Generator/Instantiator/InstantiatorRegistryTest.php
+++ b/tests/Generator/Instantiator/InstantiatorRegistryTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Instantiator\InstantiatorNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -33,6 +34,8 @@ use stdClass;
  */
 class InstantiatorRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnInstantiator()
     {
         $this->assertTrue(is_a(InstantiatorRegistry::class, InstantiatorInterface::class, true));

--- a/tests/Generator/Instantiator/InstantiatorResolverTest.php
+++ b/tests/Generator/Instantiator/InstantiatorResolverTest.php
@@ -32,6 +32,7 @@ use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -39,6 +40,8 @@ use ReflectionClass;
  */
 class InstantiatorResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnInstantiator()
     {
         $this->assertTrue(is_a(InstantiatorResolver::class, InstantiatorInterface::class, true));

--- a/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
@@ -123,9 +123,9 @@ class CompleteObjectGeneratorTest extends TestCase
                 'dummy',
                 'Dummy',
                 SpecificationBagFactory::create(
-                        null,
-                        (new PropertyBag())->with(new Property('foo', 'bar'))
-                    )
+                    null,
+                    (new PropertyBag())->with(new Property('foo', 'bar'))
+                )
             );
 
             $context = new GenerationContext();
@@ -146,10 +146,10 @@ class CompleteObjectGeneratorTest extends TestCase
 
             $expected = (new ObjectBag())->with(
                 new CompleteObject(
-                        new CompleteObject(
+                    new CompleteObject(
                             new SimpleObject('dummy', new \stdClass())
                         )
-                    )
+                )
             );
 
             return [
@@ -165,9 +165,9 @@ class CompleteObjectGeneratorTest extends TestCase
                 'dummy',
                 'Dummy',
                 SpecificationBagFactory::create(
-                        null,
-                        (new PropertyBag())->with(new Property('foo', 'bar'))
-                    )
+                    null,
+                    (new PropertyBag())->with(new Property('foo', 'bar'))
+                )
             );
 
             $context = new GenerationContext();
@@ -187,8 +187,8 @@ class CompleteObjectGeneratorTest extends TestCase
 
             $expected = (new ObjectBag())->with(
                 new CompleteObject(
-                        new SimpleObject('dummy', new \stdClass())
-                    )
+                    new SimpleObject('dummy', new \stdClass())
+                )
             );
 
             return [
@@ -204,9 +204,9 @@ class CompleteObjectGeneratorTest extends TestCase
                 'dummy',
                 'Dummy',
                 SpecificationBagFactory::create(
-                        null,
-                        (new PropertyBag())->with(new Property('foo', 'bar'))
-                    )
+                    null,
+                    (new PropertyBag())->with(new Property('foo', 'bar'))
+                )
             );
 
             $context = new GenerationContext();
@@ -226,8 +226,8 @@ class CompleteObjectGeneratorTest extends TestCase
 
             $expected = (new ObjectBag())->with(
                 new CompleteObject(
-                        new SimpleObject('dummy', new \stdClass())
-                    )
+                    new SimpleObject('dummy', new \stdClass())
+                )
             );
 
             return [
@@ -261,8 +261,8 @@ class CompleteObjectGeneratorTest extends TestCase
 
             $expected = (new ObjectBag())->with(
                 new CompleteObject(
-                        new SimpleObject('dummy', new \stdClass())
-                    )
+                    new SimpleObject('dummy', new \stdClass())
+                )
             );
 
             return [
@@ -278,9 +278,9 @@ class CompleteObjectGeneratorTest extends TestCase
                 'dummy',
                 'Dummy',
                 SpecificationBagFactory::create(
-                        null,
-                        (new PropertyBag())->with(new Property('foo', 'bar'))
-                    )
+                    null,
+                    (new PropertyBag())->with(new Property('foo', 'bar'))
+                )
             );
 
             $context = new GenerationContext();

--- a/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/CompleteObjectGeneratorTest.php
@@ -29,6 +29,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSetFactory;
 use Nelmio\Alice\ObjectBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -36,6 +37,8 @@ use ReflectionClass;
  */
 class CompleteObjectGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnObjectGenerator()
     {
         $this->assertTrue(is_a(CompleteObjectGenerator::class, ObjectGeneratorInterface::class, true));
@@ -147,8 +150,8 @@ class CompleteObjectGeneratorTest extends TestCase
             $expected = (new ObjectBag())->with(
                 new CompleteObject(
                     new CompleteObject(
-                            new SimpleObject('dummy', new \stdClass())
-                        )
+                        new SimpleObject('dummy', new \stdClass())
+                    )
                 )
             );
 

--- a/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
+++ b/tests/Generator/ObjectGenerator/SimpleObjectGeneratorTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\ObjectBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionClass;
  */
 class SimpleObjectGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnObjectGenerator()
     {
         $this->assertTrue(is_a(SimpleObjectGenerator::class, ObjectGeneratorInterface::class, true));

--- a/tests/Generator/Populator/SimpleHydratorTest.php
+++ b/tests/Generator/Populator/SimpleHydratorTest.php
@@ -36,12 +36,15 @@ use Nelmio\Alice\Throwable\Exception\RootResolutionException;
 use Nelmio\Alice\Throwable\GenerationThrowable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Generator\Hydrator\SimpleHydrator
  */
 class SimpleHydratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAnHydrator()
     {
         $this->assertTrue(is_a(SimpleHydrator::class, HydratorInterface::class, true));

--- a/tests/Generator/Resolver/Fixture/TemplatingFixtureBagTest.php
+++ b/tests/Generator/Resolver/Fixture/TemplatingFixtureBagTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Resolver\Fixture;
 
+use function Nelmio\Alice\deep_clone;
 use Nelmio\Alice\Definition\FakeMethodCall;
 use Nelmio\Alice\Definition\Fixture\DummyFixture;
 use Nelmio\Alice\Definition\Fixture\MutableFixture;
@@ -25,7 +26,6 @@ use Nelmio\Alice\Definition\SpecificationBagFactory;
 use Nelmio\Alice\FixtureBag;
 use Nelmio\Alice\Throwable\Exception\FixtureNotFoundException;
 use PHPUnit\Framework\TestCase;
-use function Nelmio\Alice\deep_clone;
 
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\Fixture\TemplatingFixtureBag

--- a/tests/Generator/Resolver/FixtureSet/RemoveConflictingObjectsResolverTest.php
+++ b/tests/Generator/Resolver/FixtureSet/RemoveConflictingObjectsResolverTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\Generator\ResolvedFixtureSet;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class RemoveConflictingObjectsResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixtureResolver()
     {
         $this->assertTrue(is_a(RemoveConflictingObjectsResolver::class, FixtureSetResolverInterface::class, true));

--- a/tests/Generator/Resolver/FixtureSet/SimpleFixtureSetResolverTest.php
+++ b/tests/Generator/Resolver/FixtureSet/SimpleFixtureSetResolverTest.php
@@ -24,6 +24,7 @@ use Nelmio\Alice\Generator\Resolver\ParameterBagResolverInterface;
 use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -31,6 +32,8 @@ use ReflectionClass;
  */
 class SimpleFixtureSetResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAFixtureResolver()
     {
         $this->assertTrue(is_a(SimpleFixtureSetResolver::class, FixtureSetResolverInterface::class, true));

--- a/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/ArrayParameterResolverTest.php
@@ -23,6 +23,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class ArrayParameterResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableParameterResolver()
     {
         $this->assertTrue(is_a(ArrayParameterResolver::class, ChainableParameterResolverInterface::class, true));

--- a/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\RecursionLimitReachedException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class RecursiveParameterResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableParameterResolver()
     {
         $this->assertTrue(is_a(RecursiveParameterResolver::class, ChainableParameterResolverInterface::class, true));

--- a/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/StringParameterResolverTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\ParameterNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class StringParameterResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableParameterResolver()
     {
         $this->assertTrue(is_a(StringParameterResolver::class, ChainableParameterResolverInterface::class, true));

--- a/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Parameter/ParameterResolverRegistryTest.php
@@ -22,6 +22,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class ParameterResolverRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParameterResolver()
     {
         $this->assertTrue(is_a(ParameterResolverRegistry::class, ParameterResolverInterface::class, true));

--- a/tests/Generator/Resolver/Parameter/RemoveConflictingParametersParameterBagResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/RemoveConflictingParametersParameterBagResolverTest.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\Generator\Resolver\ParameterBagResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -24,6 +25,8 @@ use ReflectionClass;
  */
 class RemoveConflictingParametersParameterBagResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParameterBagResolver()
     {
         $this->assertTrue(is_a(

--- a/tests/Generator/Resolver/Parameter/SimpleParameterBagResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/SimpleParameterBagResolverTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\Parameter;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class SimpleParameterBagResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParameterBagResolver()
     {
         $this->assertTrue(is_a(SimpleParameterBagResolver::class, ParameterBagResolverInterface::class, true));

--- a/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
+++ b/tests/Generator/Resolver/ParameterResolverIntegrationTest.php
@@ -58,7 +58,7 @@ class ParameterResolverIntegrationTest extends TestCase
     public function testThrowExceptionIfCircularReferenceDetected(ParameterBag $unresolvedParameters, ParameterBag $injectedParameters = null)
     {
         $this->expectException(CircularReferenceException::class);
-        $this->expectExceptionMessageRegExp('/^Circular reference detected for the parameter "[^\"]+" while resolving \[.+]\.$/');
+        $this->expectExceptionMessageMatches('/^Circular reference detected for the parameter "[^\"]+" while resolving \[.+]\.$/');
 
         $this->resolver->resolve($unresolvedParameters, $injectedParameters);
     }

--- a/tests/Generator/Resolver/SimpleResolverTest.php
+++ b/tests/Generator/Resolver/SimpleResolverTest.php
@@ -23,12 +23,15 @@ use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Nelmio\Alice\Generator\Resolver\FixtureSet\SimpleFixtureSetResolver
  */
 class SimpleResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAResolver()
     {
         $this->assertTrue(is_a(SimpleFixtureSetResolver::class, FixtureSetResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
@@ -26,7 +26,6 @@ use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use ReflectionClass;
 
 /**

--- a/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/DynamicArrayValueResolverTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionClass;
  */
 class DynamicArrayValueResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \ReflectionProperty
      */

--- a/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FakerFunctionCallResolverValueTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Generator\Resolver\Value\ChainableValueResolverInterface;
 use Nelmio\Alice\Generator\Resolver\Value\FakeValueResolver;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class FakerFunctionCallValueResolverValueTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FakerFunctionCallValueResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
@@ -33,6 +33,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -40,6 +41,8 @@ use ReflectionClass;
  */
 class FixtureMethodCallReferenceResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FixtureMethodCallReferenceResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixturePropertyReferenceResolverTest.php
@@ -33,6 +33,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -42,6 +43,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class FixturePropertyReferenceResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FixturePropertyReferenceResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureReferenceResolverTest.php
@@ -34,6 +34,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\FixtureNotFoundException
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -41,6 +42,8 @@ use ReflectionClass;
  */
 class FixtureReferenceResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FixtureReferenceResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureWildcardReferenceResolverTest.php
@@ -32,6 +32,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -39,6 +40,8 @@ use ReflectionClass;
  */
 class FixtureWildcardReferenceResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FixtureWildcardReferenceResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FunctionCallArgumentResolverTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionClass;
  */
 class FunctionCallArgumentResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(FunctionCallArgumentResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/ListValueResolverTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -33,6 +34,8 @@ use ReflectionClass;
  */
 class ListValueResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(ListValueResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/PhpFunctionCallValueResolverTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\Generator\ValueResolverInterface;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class PhpFunctionCallValueResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(PhpFunctionCallValueResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/SelfFixtureReferenceResolverTest.php
@@ -30,6 +30,7 @@ use Nelmio\Alice\Generator\ValueResolverAwareInterface;
 use Nelmio\Alice\ObjectBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -37,6 +38,8 @@ use ReflectionClass;
  */
 class SelfFixtureReferenceResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(SelfFixtureReferenceResolver::class, ChainableValueResolverInterface::class, true));

--- a/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UniqueValueResolverTest.php
@@ -28,6 +28,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UniqueValueGenerationLimitReachedException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -35,6 +36,8 @@ use ReflectionClass;
  */
 class UniqueValueResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \ReflectionProperty
      */

--- a/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
@@ -36,6 +36,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundExceptio
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -43,6 +44,8 @@ use ReflectionClass;
  */
 class UnresolvedFixtureReferenceIdResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAChainableResolver()
     {
         $this->assertTrue(is_a(UnresolvedFixtureReferenceIdResolver::class, ChainableValueResolverInterface::class, true));
@@ -289,10 +292,10 @@ class UnresolvedFixtureReferenceIdResolverTest extends TestCase
                 new ResolvedValueWithFixtureSet(
                     'alice',
                     $newSet = ResolvedFixtureSetFactory::create(
-                         null,
-                         $fixtureBag->with(new SimpleFixture('value_resolver_fixture', 'Dummy', SpecificationBagFactory::create())),
-                         $newObjectBag = $objectBag->with(new SimpleObject('value_resolver_fixture', new \stdClass()))
-                     )
+                        null,
+                        $fixtureBag->with(new SimpleFixture('value_resolver_fixture', 'Dummy', SpecificationBagFactory::create())),
+                        $newObjectBag = $objectBag->with(new SimpleObject('value_resolver_fixture', new \stdClass()))
+                    )
                 )
             )
         ;

--- a/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/UnresolvedFixtureReferenceIdResolverTest.php
@@ -287,13 +287,13 @@ class UnresolvedFixtureReferenceIdResolverTest extends TestCase
             ->resolve($idValue, $dummyFixture, $set, $scope, $context)
             ->willReturn(
                 new ResolvedValueWithFixtureSet(
-                     'alice',
-                     $newSet = ResolvedFixtureSetFactory::create(
+                    'alice',
+                    $newSet = ResolvedFixtureSetFactory::create(
                          null,
                          $fixtureBag->with(new SimpleFixture('value_resolver_fixture', 'Dummy', SpecificationBagFactory::create())),
                          $newObjectBag = $objectBag->with(new SimpleObject('value_resolver_fixture', new \stdClass()))
                      )
-                 )
+                )
             )
         ;
         /** @var ValueResolverInterface $valueResolver */

--- a/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
+++ b/tests/Generator/Resolver/Value/ValueResolverRegistryTest.php
@@ -26,6 +26,7 @@ use Nelmio\Alice\ObjectBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ResolverNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -34,6 +35,8 @@ use stdClass;
  */
 class ValueResolverRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAValueResolver()
     {
         $this->assertTrue(is_a(ValueResolverRegistry::class, ValueResolverInterface::class, true));

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -159,7 +159,7 @@ class LoaderIntegrationTest extends TestCase
     public function testLoadUnsupportedFileFormat()
     {
         $this->expectException(ParserNotFoundException::class);
-        $this->expectExceptionMessageRegExp('/^No suitable parser found for the file ".*?plain_file"\.$/');
+        $this->expectExceptionMessageMatches('/^No suitable parser found for the file ".*?plain_file"\.$/');
 
         $this->loader->loadFile(self::PARSER_FILES_DIR.'/unsupported/plain_file');
     }
@@ -167,7 +167,7 @@ class LoaderIntegrationTest extends TestCase
     public function testLoadPhpFileWhichDoesNotReturnAnything()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^The file ".*?no_return.php" must return a PHP array\.$/');
+        $this->expectExceptionMessageMatches('/^The file ".*?no_return.php" must return a PHP array\.$/');
 
         $this->loader->loadFile(self::PARSER_FILES_DIR.'/php/no_return.php');
     }

--- a/tests/Loader/SimpleDataLoaderTest.php
+++ b/tests/Loader/SimpleDataLoaderTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\GeneratorInterface;
 use Nelmio\Alice\ObjectSetFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -27,6 +28,8 @@ use ReflectionClass;
  */
 class SimpleDataLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsADataLoader()
     {
         $this->assertTrue(is_a(SimpleDataLoader::class, DataLoaderInterface::class, true));

--- a/tests/Loader/SimpleFileLoaderTest.php
+++ b/tests/Loader/SimpleFileLoaderTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\ObjectSetFactory;
 use Nelmio\Alice\ParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class SimpleFileLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(SimpleFileLoader::class, FileLoaderInterface::class, true));

--- a/tests/Loader/SimpleFilesLoaderTest.php
+++ b/tests/Loader/SimpleFilesLoaderTest.php
@@ -21,6 +21,7 @@ use Nelmio\Alice\User;
 use Nelmio\Alice\UserDetail;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -29,6 +30,8 @@ use stdClass;
  */
 class SimpleFilesLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(SimpleFilesLoader::class, FilesLoaderInterface::class, true));

--- a/tests/ObjectBagTest.php
+++ b/tests/ObjectBagTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\Throwable\Exception\ObjectNotFoundException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use stdClass;
 
 /**
@@ -25,6 +26,8 @@ use stdClass;
  */
 class ObjectBagTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var \ReflectionProperty
      */

--- a/tests/Parser/Chainable/JsonParserTest.php
+++ b/tests/Parser/Chainable/JsonParserTest.php
@@ -146,7 +146,7 @@ class JsonParserTest extends TestCase
     public function testThrowsAnExceptionIfInvalidJson()
     {
         $this->expectException(UnparsableFileException::class);
-        $this->expectExceptionMessageRegExp('/^The file ".+\/invalid\.json" does not contain valid JSON\.$/');
+        $this->expectExceptionMessageMatches('/^The file ".+\/invalid\.json" does not contain valid JSON\.$/');
 
         $this->parser->parse(self::$dir.'/invalid.json');
     }

--- a/tests/Parser/Chainable/PhpParserTest.php
+++ b/tests/Parser/Chainable/PhpParserTest.php
@@ -145,7 +145,7 @@ class PhpParserTest extends TestCase
     public function testThrowsAnExceptionIfNoArrayReturnedInParsedFile()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^The file ".+\/no_return\.php" must return a PHP array\.$/');
+        $this->expectExceptionMessageMatches('/^The file ".+\/no_return\.php" must return a PHP array\.$/');
 
         $this->parser->parse(self::$dir.'/no_return.php');
     }
@@ -153,7 +153,7 @@ class PhpParserTest extends TestCase
     public function testThrowsAnExceptionIfWrongValueReturnedInParsedFile()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^The file ".+\/wrong_return\.php" must return a PHP array\.$/');
+        $this->expectExceptionMessageMatches('/^The file ".+\/wrong_return\.php" must return a PHP array\.$/');
 
         $this->parser->parse(self::$dir.'/wrong_return.php');
     }

--- a/tests/Parser/Chainable/YamlParserTest.php
+++ b/tests/Parser/Chainable/YamlParserTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Parser\FileListProviderTrait;
 use Nelmio\Alice\Throwable\Exception\Parser\UnparsableFileException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use Symfony\Component\Yaml\Exception\ParseException as SymfonyParseException;
 use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
@@ -28,6 +29,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlParserTest extends TestCase
 {
+    use ProphecyTrait;
     use FileListProviderTrait;
 
     private static $dir;
@@ -235,7 +237,7 @@ EOF;
 
             $this->fail('Expected exception to be thrown.');
         } catch (UnparsableFileException $exception) {
-            $this->assertRegExp('/^The file ".+\/basic\.yml" does not contain valid YAML\.$/', $exception->getMessage());
+            $this->assertMatchesRegularExpression('/^The file ".+\/basic\.yml" does not contain valid YAML\.$/', $exception->getMessage());
             $this->assertEquals(0, $exception->getCode());
             $this->assertNotNull($exception->getPrevious());
         }
@@ -256,7 +258,7 @@ EOF;
 
             $this->fail('Expected exception to be thrown.');
         } catch (UnparsableFileException $exception) {
-            $this->assertRegExp('/^Could not parse the file ".+\/basic\.yml"\.$/', $exception->getMessage());
+            $this->assertMatchesRegularExpression('/^Could not parse the file ".+\/basic\.yml"\.$/', $exception->getMessage());
             $this->assertEquals(0, $exception->getCode());
             $this->assertNotNull($exception->getPrevious());
         }

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -19,6 +19,7 @@ use Nelmio\Alice\Parser\IncludeProcessorInterface;
 use Nelmio\Alice\ParserInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -26,6 +27,8 @@ use ReflectionClass;
  */
 class DefaultIncludeProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     private static $dir;
 
     /**

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -116,7 +116,7 @@ class DefaultIncludeProcessorTest extends TestCase
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^Expected include statement to be either null or an array of files to include\. Got "string" instead in file ".+\/main\.yml"\.$/');
+        $this->expectExceptionMessageMatches('/^Expected include statement to be either null or an array of files to include\. Got "string" instead in file ".+\/main\.yml"\.$/');
 
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }
@@ -141,7 +141,7 @@ class DefaultIncludeProcessorTest extends TestCase
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageRegExp('/^Expected elements of include statement to be file names\. Got "boolean" instead in file ".+\/main\.yml"\.$/');
+        $this->expectExceptionMessageMatches('/^Expected elements of include statement to be file names\. Got "boolean" instead in file ".+\/main\.yml"\.$/');
 
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }
@@ -166,7 +166,7 @@ class DefaultIncludeProcessorTest extends TestCase
         $processor = new DefaultIncludeProcessor(new DefaultFileLocator());
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/^Expected elements of include statement to be file names\. Got empty string instead in file ".+\/main\.yml"\.$/');
+        $this->expectExceptionMessageMatches('/^Expected elements of include statement to be file names\. Got empty string instead in file ".+\/main\.yml"\.$/');
 
         $processor->process($parser, $mainFile, $parsedMainFileContent);
     }

--- a/tests/Parser/ParserRegistryTest.php
+++ b/tests/Parser/ParserRegistryTest.php
@@ -17,6 +17,7 @@ use Nelmio\Alice\ParserInterface;
 use Nelmio\Alice\Throwable\Exception\Parser\ParserNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -25,6 +26,8 @@ use stdClass;
  */
 class ParserRegistryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAParser()
     {
         $this->assertTrue(is_a(ParserRegistry::class, ParserInterface::class, true));

--- a/tests/Parser/RuntimeCacheParserTest.php
+++ b/tests/Parser/RuntimeCacheParserTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\ParserInterface;
 use Nelmio\Alice\Throwable\Exception\FileLocator\FileNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -28,6 +29,8 @@ use stdClass;
  */
 class RuntimeCacheParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     private static $dir;
 
     /**

--- a/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
+++ b/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Entity\DummyWithPrivatePropertyChild;
 use Nelmio\Alice\Entity\DummyWithPublicProperty;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -27,6 +28,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class ReflectionPropertyAccessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAPropertyAccessor()
     {
         $this->assertTrue(is_a(ReflectionPropertyAccessor::class, PropertyAccessorInterface::class, true));

--- a/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
+++ b/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
@@ -10,14 +10,6 @@
  */
 
 declare(strict_types=1);
-/*
- * This file is part of the Alice package.
- *
- * (c) Nelmio <hello@nelm.io>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Nelmio\Alice\PropertyAccess;
 

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -18,6 +18,7 @@ use Nelmio\Alice\Entity\StdClassFactory;
 use Nelmio\Alice\Symfony\PropertyAccess\FakePropertyAccessor;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -27,6 +28,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class StdPropertyAccessorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAPropertyAccessor()
     {
         $this->assertTrue(is_a(StdPropertyAccessor::class, PropertyAccessorInterface::class, true));

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -10,14 +10,6 @@
  */
 
 declare(strict_types=1);
-/*
- * This file is part of the Alice package.
- *
- * (c) Nelmio <hello@nelm.io>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Nelmio\Alice\PropertyAccess;
 

--- a/vendor-bin/covers-validator/composer.json
+++ b/vendor-bin/covers-validator/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
         "symfony/console": "^3.3",
-        "ockcyp/covers-validator": "^0.6"
+        "ockcyp/covers-validator": "^1.1"
     },
     "config": {
         "bin-dir": "bin",

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "symfony/symfony": "^3.4 || ^4.0",
+        "symfony/symfony": "^3.4 || ^4.0 || ^5.0",
         "theofidry/composer-inheritance-plugin": "^1.0"
     },
     "config": {


### PR DESCRIPTION
- Update Travis and the composer.json to bump and use PHP 7.3 & 7.4 only
- Adapt the Symfony kernel used for fixtures and gitignore to avoid leaving a `var` directory tangling
- Apply PHP-CS-Fixer
- Fix PHPUnit deprecations
  - Migrate to phpspec/prophecy-phpunit
  - Fix the usage of some deprecated assertions
- Bump PHPUnit to 8.5.4 minimum and allow PHPUnit 9.0
- Allow Symfony 5 locally in tests
- Bump the covers validator to 1.1