### PR TITLE
Fix method name on exception

### DIFF
--- a/src/Generator/Caller/CallProcessorRegistry.php
+++ b/src/Generator/Caller/CallProcessorRegistry.php
@@ -56,6 +56,6 @@ final class CallProcessorRegistry implements CallProcessorInterface
             }
         }
 
-        throw CallProcessorExceptionFactory::createForNoParserFoundForElement($methodCall);
+        throw CallProcessorExceptionFactory::createForNoProcessorFoundForMethodCall($methodCall);
     }
 }


### PR DESCRIPTION
Hey, I misconfigured my alice files so I ran into this error where the CallProcessorExceptionFactory called a non-existent method.