### PR TITLE
Add WordPress third-party lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ For more information, refer to [the documentation](#table-of-contents).
 
 -  [Zenify/DoctrineFixtures](https://github.com/Zenify/DoctrineFixtures)
 
+### WordPress
+
+- [rmp-up/wp-fixtures](https://github.com/rmp-up/wp-fixtures)
+
 ### Zend Framework 2:
 
 - [ma-si/aist-alice-fixtures](https://github.com/ma-si/aist-alice-fixtures)


### PR DESCRIPTION
WordPress entities work a bit different than common ones.
Sometimes the constructor, getter/setter already access the database,
fields are internally used but missing or some properties are fetched from DB on the fly.
The rmp-up/wp-fixtures enhances the NativeLoader
to bypass such obstacles and allows creating native WP entities.

* Maintained and enhancing for two years already
* Using alice for quiet a time now
* Finally works with native WordPress entities since v0.8