### PR TITLE
fix returned empty arguments when args are passed via func_get_args ()

### DIFF
--- a/fixtures/Entity/DummyWithNoArgumentConstructor.php
+++ b/fixtures/Entity/DummyWithNoArgumentConstructor.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity;
+
+class DummyWithNoArgumentConstructor
+{
+    /**
+     * @var array
+     */
+    private $args;
+
+    public function __construct()
+    {
+        $this->args = func_get_args();
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+}

--- a/src/Generator/NamedArgumentsResolver.php
+++ b/src/Generator/NamedArgumentsResolver.php
@@ -23,6 +23,10 @@ class NamedArgumentsResolver
             return $arguments;
         }
 
+        if (0 === count($method->getParameters())) {
+            return $arguments;
+        }
+
         $sortedArguments = [];
         $buffer = [];
 

--- a/tests/Generator/NamedArgumentsResolverTest.php
+++ b/tests/Generator/NamedArgumentsResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator;
 
+use Nelmio\Alice\Entity\DummyWithNoArgumentConstructor;
 use Nelmio\Alice\Entity\DummyWithMethods;
 use Nelmio\Alice\Entity\EmptyDummy;
 use PHPUnit\Framework\TestCase;
@@ -299,6 +300,19 @@ class NamedArgumentsResolverTest extends TestCase
             [
                 'bar1' => 'hello',
                 'bar2' => null,
+            ],
+        ];
+
+        yield 'with arguments passed to a constructor that does not expect arguments' => [
+            DummyWithNoArgumentConstructor::class,
+            '__construct',
+            [
+                'foo',
+                'bar',
+            ],
+            [
+                'foo',
+                'bar',
             ],
         ];
     }


### PR DESCRIPTION
- add fix #1046
- add non-regression test
