### PR TITLE
Missing autowire parameter

### DIFF
--- a/doc/customizing-data-generation.md
+++ b/doc/customizing-data-generation.md
@@ -193,13 +193,14 @@ the `NativeLoader::createFakerGenerator()` method.
  
 If you are using Symfony, custom Faker providers are registered by adding the
 tag `nelmio_alice.faker.provider` to the services. Note that this is automatically
-done if your service extends `Faker\Provider\Base` and have `autoconfigure` enabled:
+done if your service extends `Faker\Provider\Base` and have `autoconfigure` and `autowire` enabled:
 
 ```yaml
 # config/services.yaml
 
 services:
     _defaults:
+        autowire: true
         autoconfigure: true
 
     App\Faker\Provider\JobProvider: ~
@@ -213,6 +214,8 @@ or:
 
 services:
     App\Faker\Provider\JobProvider:
+        arguments:
+            - '@Faker\Generator'
         tags: [ { name: nelmio_alice.faker.provider } ]
 ```
 


### PR DESCRIPTION
With the given configuration, Symfony is not able to instantiate the custom provider as it requires a Generator to be injected.
The Generator objects comes from the constructor of `Faker\Provider\Base`.

This PR makes it clear that `autowire` should be enabled or that the `Faker\Generator` service should be passed as constructor argument.