### PR TITLE
Fix class order, when merging data

### DIFF
--- a/src/Parser/IncludeProcessor/IncludeDataMerger.php
+++ b/src/Parser/IncludeProcessor/IncludeDataMerger.php
@@ -28,18 +28,21 @@ final class IncludeDataMerger
      */
     public function mergeInclude(array $data, array $includeData): array
     {
-        foreach ($data as $class => $fixtures) {
+        foreach ($includeData as $class => $fixtures) {
             // $class is either a FQCN or 'parameters'
-            $includeData[$class] = (
-                array_key_exists($class, $includeData)
-                    && is_array($includeData[$class])
-                    && is_array($fixtures)
-            )
-                ? array_merge($includeData[$class], $fixtures)
-                : $fixtures
-            ;
+            if (array_key_exists($class, $data)) {
+                if (is_array($data[$class]) && is_array($fixtures)) {
+                    foreach ($fixtures as $key => $fixture) {
+                        if (!array_key_exists($key, $data[$class])) {
+                            $data[$class][$key] = $fixture;
+                        }
+                    }
+                }
+            } else {
+                $data[$class] = $fixtures;
+            }
         }
 
-        return $includeData;
+        return $data;
     }
 }

--- a/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
+++ b/tests/Parser/IncludeProcessor/DefaultIncludeProcessorTest.php
@@ -33,7 +33,7 @@ class DefaultIncludeProcessorTest extends TestCase
 
     private static $dir;
 
-    
+
     protected function setUp(): void
     {
         self::$dir = __DIR__.'/../../../fixtures/Parser/files/cache';
@@ -206,10 +206,10 @@ class DefaultIncludeProcessorTest extends TestCase
         ];
         $expected = [
             'Nelmio\Alice\Model\User' => [
-                'user_file1' => [],
-                'user_file3' => [],
-                'user_file2' => [],
                 'user_main' => [],
+                'user_file2' => [],
+                'user_file3' => [],
+                'user_file1' => [],
             ],
         ];
 

--- a/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
+++ b/tests/Parser/IncludeProcessor/IncludeDataMergerTest.php
@@ -25,56 +25,79 @@ class IncludeDataMergerTest extends TestCase
      */
     private $merger;
 
-    
+
     protected function setUp(): void
     {
         $this->merger = new IncludeDataMerger();
     }
 
-    public function testMergesNonArrayData(): void
+    /**
+     * @return \Generator
+     */
+    public function provideDataForTestMergesNonArrayData(): \Generator
     {
         $data = [
-            'parameters' => 'foo',
+            'parameters' => 'foo1',
         ];
         $include = [
-            'parameters' => 'bar',
+            'parameters' => 'bar1',
         ];
         $expected = [
-            'parameters' => 'foo',
+            'parameters' => 'foo1',
         ];
 
-        $actual = $this->merger->mergeInclude($data, $include);
-        static::assertSame($expected, $actual);
-
+        yield [
+            $data,
+            $include,
+            $expected
+        ];
 
         $data = [
             'parameters' => [
-                'foo',
+                'foo2',
             ],
         ];
         $include = [
-            'parameters' => 'bar',
+            'parameters' => 'bar2',
         ];
         $expected = [
             'parameters' => [
-                'foo',
+                'foo2',
             ],
         ];
 
-        $actual = $this->merger->mergeInclude($data, $include);
-        static::assertSame($expected, $actual);
-
+        yield [
+            $data,
+            $include,
+            $expected
+        ];
 
         $data = [
-            'parameters' => 'foo',
+            'parameters' => 'foo3',
         ];
         $include = [
-            'parameters' => ['bar'],
+            'parameters' => ['bar3'],
         ];
         $expected = [
-            'parameters' => 'foo',
+            'parameters' => 'foo3',
         ];
 
+        yield [
+            $data,
+            $include,
+            $expected
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataForTestMergesNonArrayData
+     *
+     * @param array $data
+     * @param array $include
+     * @param array $expected
+     */
+    public function testMergesNonArrayData(array $data, array $include, array $expected): void
+    {
         $actual = $this->merger->mergeInclude($data, $include);
         static::assertSame($expected, $actual);
     }
@@ -96,8 +119,8 @@ class IncludeDataMergerTest extends TestCase
         $expected = [
             'parameters' => [
                 'foo' => 'oof',
-                'white' => 'rabbit',
                 'bar' => 'rab',
+                'white' => 'rabbit',
             ],
         ];
 
@@ -138,11 +161,11 @@ class IncludeDataMergerTest extends TestCase
         ];
         $expected = [
             'Nelmio\Alice\Model\User' => [
-                'user0' => [
-                    'fullname' => 'Bob',
-                ],
                 'user1' => [
                     'fullname' => 'Alice',
+                ],
+                'user0' => [
+                    'fullname' => 'Bob',
                 ],
             ],
             'Nelmio\Alice\Model\Group' => [
@@ -203,15 +226,15 @@ class IncludeDataMergerTest extends TestCase
         $expected = [
             'parameters' => [
                 'foo' => 'oof',
-                'white' => 'rabbit',
                 'bar' => 'rab',
+                'white' => 'rabbit',
             ],
             'Nelmio\Alice\Model\User' => [
-                'user0' => [
-                    'fullname' => 'Bob',
-                ],
                 'user1' => [
                     'fullname' => 'Alice',
+                ],
+                'user0' => [
+                    'fullname' => 'Bob',
                 ],
             ],
             'Nelmio\Alice\Model\Group' => [

--- a/tests/Parser/RuntimeCacheParserTest.php
+++ b/tests/Parser/RuntimeCacheParserTest.php
@@ -34,7 +34,7 @@ class RuntimeCacheParserTest extends TestCase
 
     private static $dir;
 
-    
+
     protected function setUp(): void
     {
         self::$dir = __DIR__.'/../../fixtures/Parser/files/cache';
@@ -184,16 +184,16 @@ class RuntimeCacheParserTest extends TestCase
         ];
         $expected = [
             'Nelmio\Alice\Model\User' => [
-                'user_file1' => [],
-                'user_file3' => [],
-                'user_file2' => [],
                 'user_main' => [],
+                'user_file2' => [],
+                'user_file3' => [],
+                'user_file1' => [],
             ],
         ];
         $expectedFile2 = [
             'Nelmio\Alice\Model\User' => [
-                'user_file3' => [],
                 'user_file2' => [],
+                'user_file3' => [],
             ],
         ];
 


### PR DESCRIPTION
I noticed that ```IncludeDataMerger``` class merges data in wrong way.

For example if I have 3 files as follow:
- file1.yaml
  + Class1a
  + Class1b
- file2.yaml
  + Class2a
  + Class2b
- file3.yaml
  + Class3a
  + Class3b

I noticed that ```mergeInclude()``` method from mentioned class would make following list of objects:
- Class3a
- Class3b
- Class2a
- Class2b
- Class1a
- Class1b

which is wrong and unacceptable for me.

In my case I need to have possibility to make an ordered list:
- create users at first
- create other objects, which relay on the users (user ids)

I fixed ```IncludeDataMerger``` class and related unit tests.