### PR TITLE
Fix reference range wildcard order

### DIFF
--- a/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizer.php
@@ -28,6 +28,7 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\FixtureInterface;
 use Nelmio\Alice\IsAServiceTrait;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserExceptionFactory;
+use Nelmio\Alice\Throwable\Exception\FixtureNotFoundExceptionFactory;
 use Nelmio\Alice\Throwable\Exception\LogicExceptionFactory;
 
 final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormalizerInterface, FlagParserAwareInterface
@@ -51,17 +52,17 @@ final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormaliz
         $this->specsDenormalizer = $specsDenormalizer;
         $this->flagParser = $parser;
     }
-    
+
     public function withFlagParser(FlagParserInterface $parser): self
     {
         return new self($this->specsDenormalizer, $parser);
     }
-    
+
     public function canDenormalize(string $name, array &$matches = []): bool
     {
         return 1 === preg_match(self::REGEX, $name, $matches);
     }
-    
+
     public function denormalize(
         FixtureBag $builtFixtures,
         string $className,
@@ -126,6 +127,10 @@ final class ReferenceRangeNameDenormalizer implements ChainableFixtureDenormaliz
             },
             ARRAY_FILTER_USE_KEY
         );
+
+        if (count($matchedFixtures) === 0) {
+            throw FixtureNotFoundExceptionFactory::createWildcard($referencedName);
+        }
 
         return $matchedFixtures;
     }

--- a/src/Throwable/Exception/FixtureNotFoundExceptionFactory.php
+++ b/src/Throwable/Exception/FixtureNotFoundExceptionFactory.php
@@ -28,6 +28,16 @@ final class FixtureNotFoundExceptionFactory
         );
     }
 
+    public static function createWildcard(string $wildcard): FixtureNotFoundException
+    {
+        return new FixtureNotFoundException(
+            sprintf(
+                'Could not find fixtures matching wildcard "%s*".',
+                $wildcard
+            )
+        );
+    }
+
     private function __construct()
     {
     }

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
@@ -29,7 +29,6 @@ use Nelmio\Alice\FixtureBuilder\Denormalizer\Fixture\SpecificationsDenormalizerI
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParser\DummyFlagParser;
 use Nelmio\Alice\FixtureBuilder\Denormalizer\FlagParserInterface;
 use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\FlagParser\FlagParserNotFoundException;
-use Nelmio\Alice\Throwable\Exception\FixtureBuilder\Denormalizer\UnexpectedValueException;
 use Nelmio\Alice\Throwable\Exception\FixtureNotFoundException;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -221,7 +220,7 @@ class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
         $specsDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(2);
     }
 
-    public function testWildcardWithNoMatchesThrowsUnexpectedValueException(): void
+    public function testWildcardWithNoMatchesThrowsFixtureNotFoundException(): void
     {
         $fixtures = (new FixtureBag());
         $className = 'Nelmio\Alice\Entity\User';

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ReferenceRangeNameDenormalizerTest.php
@@ -39,7 +39,7 @@ use ReflectionClass;
 class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
 {
     use ProphecyTrait;
-    
+
     protected function setUp(): void
     {
         $this->denormalizer = new ReferenceRangeNameDenormalizer(
@@ -130,6 +130,93 @@ class ReferenceRangeNameDenormalizerTest extends ChainableDenormalizerTest
 
         $flagParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
         $specsDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testWildcardIsProperlyParsed(): void
+    {
+        $userDetails1 = new TemplatingFixture(
+            new SimpleFixtureWithFlags(
+                new SimpleFixture(
+                    'userDetails1',
+                    'Nelmio\Alice\Entity\UserDetails',
+                    new SpecificationBag(null, new PropertyBag(), new MethodCallBag())
+                ),
+                new FlagBag('userDetails1')
+            )
+        );
+
+        $userDetails2 = new TemplatingFixture(
+            new SimpleFixtureWithFlags(
+                new SimpleFixture(
+                    'userDetails2',
+                    'Nelmio\Alice\Entity\UserDetails',
+                    new SpecificationBag(null, new PropertyBag(), new MethodCallBag())
+                ),
+                new FlagBag('userDetails2')
+            )
+        );
+
+        $fixtures = (new FixtureBag())->with($userDetails1)->with($userDetails2);
+        $className = 'Nelmio\Alice\Entity\User';
+        $reference = 'user_{@userDetails*} (extends timestamp)';
+        $fixtureName1 = 'user_userDetails1';
+        $fixtureName2 = 'user_userDetails2';
+        $specs = [];
+        $flags = new FlagBag('');
+        $parsedFlags = (new FlagBag('user_{@userDetails}'))->withFlag(new ExtendFlag(new FixtureReference('timestamp')));
+        $fixtureFlags1 = (new FlagBag('user_userDetails1'))->withFlag(new ExtendFlag(new FixtureReference('timestamp')));
+        $fixtureFlags2 = (new FlagBag('user_userDetails2'))->withFlag(new ExtendFlag(new FixtureReference('timestamp')));
+
+        $flagParserProphecy = $this->prophesize(FlagParserInterface::class);
+        $flagParserProphecy
+            ->parse($reference)
+            ->willReturn($parsedFlags)
+        ;
+        /** @var FlagParserInterface $flagParser */
+        $flagParser = $flagParserProphecy->reveal();
+
+        $specsDenormalizerProphecy = $this->prophesize(SpecificationsDenormalizerInterface::class);
+        $expectedSpecs = new SpecificationBag(null, new PropertyBag(), new MethodCallBag());
+        $specsDenormalizerProphecy
+            ->denormalize(Argument::type(SimpleFixture::class), $flagParser, $specs)
+            ->willReturn($expectedSpecs)
+        ;
+        /** @var SpecificationsDenormalizerInterface $specsDenormalizer */
+        $specsDenormalizer = $specsDenormalizerProphecy->reveal();
+
+        $denormalizer = (new ReferenceRangeNameDenormalizer($specsDenormalizer))->withFlagParser($flagParser);
+        $actual = $denormalizer->denormalize($fixtures, $className, $reference, $specs, $flags);
+
+        $expected = $fixtures->with(
+            new TemplatingFixture(
+                new SimpleFixtureWithFlags(
+                    new SimpleFixture(
+                        $fixtureName1,
+                        $className,
+                        $expectedSpecs,
+                        $userDetails1
+                    ),
+                    $fixtureFlags1
+                )
+            )
+        )->with(
+            new TemplatingFixture(
+                new SimpleFixtureWithFlags(
+                    new SimpleFixture(
+                        $fixtureName2,
+                        $className,
+                        $expectedSpecs,
+                        $userDetails2
+                    ),
+                    $fixtureFlags2
+                )
+            )
+        );
+
+        static::assertEquals($expected, $actual);
+
+        $flagParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
+        $specsDenormalizerProphecy->denormalize(Argument::cetera())->shouldHaveBeenCalledTimes(2);
     }
 
     /**


### PR DESCRIPTION
I decided to go with solution 1 in #1080 as it seems much more simple and fits nicely with the existing architecture, as opposed to adding in a extra denormalization step to break up wildcard references.

Before this change, wildcard references which are processed before their dependencies are ignored and not created. This change ensures that at least one reference is found that matches the wildcard (and forces a retry if none exist). 

This causes a potential BC break in two cases:
1. You were relying on defined fixtures not being created because they are processed too early. This is likely not what you intended as you have specified the fixture, you probably want it to be created. With this change, it will now be created. 
    ```yaml
    Nelmio\Alice\Entity\User:
        # This will potentially be skipped before because userDetails1 & userDetails2 may not be created yet
        user_{@userDetails*}:
            details: <current()>

    Nelmio\Alice\Entity\UserDetails:
        userDetails1: ~
        userDetails2: ~
    ````
2. You have multiple fixtures which match the wildcard, but don't want some to be matched. This is arguably an incorrect fixture definition, you should ensure that your wildcard only matches the fixtures you want it to match.
    ```yaml
    Nelmio\Alice\Entity\User:
        # This will potentially be called with userDetails_files now, depending on the order of execution
        user_{@userDetails*}:
            details: <current()>

    Nelmio\Alice\Entity\UserDetails:
        userDetails1: ~
        userDetails2: ~

    Nelmio\Alice\Entity\UserDetailsFiles:
        userDetails_files: ~
    ````

I added two tests:
1. Happy path, when referenced fixtures already exist and can be retrieved from the FixtureBag
2. When referenced fixtures do not exist yet, an exception should be thrown, which will cause the [FixtureBagDenormalizer to retry the fixture later](https://github.com/nelmio/alice/blob/f174420601c1115e1a16cdee8320b1c7176ae2d2/src/FixtureBuilder/Denormalizer/Fixture/SimpleFixtureBagDenormalizer.php#L92).

Closes: #1080 