### PR TITLE
Restrict Symfony to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "fakerphp/faker": "^1.10",
         "myclabs/deep-copy": "^1.10",
         "sebastian/comparator": "^3.0 || ^4.0",
-        "symfony/property-access": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "symfony/yaml": "^2.8 || ^3.4 || ^4.0 || ^5.0"
+        "symfony/property-access": "^5.3",
+        "symfony/yaml": "^5.3"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.1.0",
@@ -33,7 +33,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^8.5.4 || ^9.3",
         "symfony/phpunit-bridge": "^5.1.3",
-        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
+        "symfony/var-dumper": "^5.3"
     },
     "conflict": {
         "symfony/framework-bundle": "<3.4"


### PR DESCRIPTION
This is a test to try to reproduce the error in https://github.com/liip/LiipTestFixturesBundle/pull/126/checks?check_run_id=2748254786