### PR TITLE
Add Symfony 6.0 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,23 +12,25 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
                     - '8.0'
                     - '8.1'
                 symfony-versions: [false]
                 include:
                     -   description: 'Symfony 4.4'
-                        php: '7.4'
-                        symfony-versions: 4.4.*
-                    -   description: 'Symfony 5.3'
-                        php: '7.4'
-                        symfony-versions: 5.3.*
-                    -   description: 'Symfony 4.4'
                         php: '8.0'
                         symfony-versions: 4.4.*
-                    -   description: 'Symfony 5.3'
+                    -   description: 'Symfony 5.4'
                         php: '8.0'
-                        symfony-versions: 5.3.*
+                        symfony-versions: 5.4.*
+                    -   description: 'Symfony 6.0'
+                        php: '8.0'
+                        symfony-versions: 6.0.*
+                    -   description: 'Symfony 5.4'
+                        php: '8.1'
+                        symfony-versions: 5.4.*
+                    -   description: 'Symfony 6.0'
+                        php: '8.1'
+                        symfony-versions: 6.0.*
 
         name: PHP ${{ matrix.php }} ${{ matrix.description }}
         steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.4'
+                  php-version: '8.0'
 
             - name: Install dependencies
               run: composer install --no-progress --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,24 @@
     ],
 
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "fakerphp/faker": "^1.10",
         "myclabs/deep-copy": "^1.10",
         "sebastian/comparator": "^3.0 || ^4.0",
-        "symfony/property-access": "^4.4 || ^5.2",
-        "symfony/yaml": "^4.4 || ^5.2"
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4.1",
         "phpspec/prophecy": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.3",
-        "symfony/phpunit-bridge": "^5.1.3",
-        "symfony/var-dumper": "^4.4 || ^5.2"
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/finder": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/var-dumper": "^4.4 || ^5.4 || ^6.0"
     },
     "conflict": {
         "symfony/framework-bundle": "<4.4 || >=5.0.0,<5.2.0"

--- a/fixtures/Bridge/Symfony/Application/AppKernel.php
+++ b/fixtures/Bridge/Symfony/Application/AppKernel.php
@@ -33,7 +33,7 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
     
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
@@ -52,11 +52,15 @@ class AppKernel extends Kernel
             public function process(ContainerBuilder $container): void
             {
                 foreach ($container->getDefinitions() as $id => $definition) {
-                    $definition->setPublic(true);
+                    if (str_starts_with($id, 'nelmio_alice.')) {
+                        $definition->setPublic(true);
+                    }
                 }
 
                 foreach ($container->getAliases() as $id => $definition) {
-                    $definition->setPublic(true);
+                    if (str_starts_with($id, 'nelmio_alice.')) {
+                        $definition->setPublic(true);
+                    }
                 }
             }
         }, PassConfig::TYPE_OPTIMIZE);
@@ -67,7 +71,7 @@ class AppKernel extends Kernel
         $this->config = $resource;
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }

--- a/fixtures/Symfony/PropertyAccess/FakePropertyAccessor.php
+++ b/fixtures/Symfony/PropertyAccess/FakePropertyAccessor.php
@@ -25,17 +25,17 @@ class FakePropertyAccessor implements PropertyAccessorInterface
         $this->__call(__METHOD__, func_get_args());
     }
     
-    public function getValue($objectOrArray, $propertyPath): void
+    public function getValue($objectOrArray, $propertyPath): mixed
     {
         $this->__call(__METHOD__, func_get_args());
     }
     
-    public function isWritable($objectOrArray, $propertyPath): void
+    public function isWritable($objectOrArray, $propertyPath): bool
     {
         $this->__call(__METHOD__, func_get_args());
     }
     
-    public function isReadable($objectOrArray, $propertyPath): void
+    public function isReadable($objectOrArray, $propertyPath): bool
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
          executionOrder="random">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <listeners>

--- a/phpunit_symfony.xml.dist
+++ b/phpunit_symfony.xml.dist
@@ -19,7 +19,7 @@
 >
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
 
     <listeners>

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -23,18 +23,12 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('nelmio_alice');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('nelmio_alice');
-        }
-
-        $rootNode
+        $treeBuilder
+            ->getRootNode()
             ->children()
                 ->scalarNode('locale')
                     ->defaultValue('en_US')

--- a/src/PropertyAccess/ReflectionPropertyAccessor.php
+++ b/src/PropertyAccess/ReflectionPropertyAccessor.php
@@ -66,7 +66,7 @@ final class ReflectionPropertyAccessor implements PropertyAccessorInterface
         }
     }
     
-    public function getValue($objectOrArray, $propertyPath)
+    public function getValue($objectOrArray, $propertyPath): mixed
     {
         try {
             return $this->decoratedPropertyAccessor->getValue($objectOrArray, $propertyPath);
@@ -94,12 +94,12 @@ final class ReflectionPropertyAccessor implements PropertyAccessorInterface
         }
     }
     
-    public function isWritable($objectOrArray, $propertyPath)
+    public function isWritable($objectOrArray, $propertyPath): bool
     {
         return $this->decoratedPropertyAccessor->isWritable($objectOrArray, $propertyPath) || $this->propertyExists($objectOrArray, $propertyPath);
     }
     
-    public function isReadable($objectOrArray, $propertyPath)
+    public function isReadable($objectOrArray, $propertyPath): bool
     {
         return $this->decoratedPropertyAccessor->isReadable($objectOrArray, $propertyPath) || $this->propertyExists($objectOrArray, $propertyPath);
     }

--- a/src/PropertyAccess/StdPropertyAccessor.php
+++ b/src/PropertyAccess/StdPropertyAccessor.php
@@ -43,7 +43,7 @@ final class StdPropertyAccessor implements PropertyAccessorInterface
         $this->decoratedPropertyAccessor->setValue($objectOrArray, $propertyPath, $value);
     }
     
-    public function getValue($objectOrArray, $propertyPath)
+    public function getValue($objectOrArray, $propertyPath): mixed
     {
         if (false === $objectOrArray instanceof stdClass) {
             return $this->decoratedPropertyAccessor->getValue($objectOrArray, $propertyPath);
@@ -56,7 +56,7 @@ final class StdPropertyAccessor implements PropertyAccessorInterface
         return $objectOrArray->$propertyPath;
     }
     
-    public function isWritable($objectOrArray, $propertyPath)
+    public function isWritable($objectOrArray, $propertyPath): bool
     {
         return ($objectOrArray instanceof stdClass)
             ? true
@@ -64,7 +64,7 @@ final class StdPropertyAccessor implements PropertyAccessorInterface
         ;
     }
     
-    public function isReadable($objectOrArray, $propertyPath)
+    public function isReadable($objectOrArray, $propertyPath): bool
     {
         return ($objectOrArray instanceof stdClass)
             ? isset($objectOrArray->$propertyPath)


### PR DESCRIPTION
Adds Symfony 6.0 support and fixes tests with Symfony 5.4.

Please note that it requires PHP version bump to 8.0, because `symfony/property-access` since 6.0 has declared return types, and we have to declare them too, and one of them is `mixed` which is supported only since PHP 8.0.