### PR TITLE
Set allow-plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,9 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        },
         "bin-dir": "bin",
         "sort-packages": true
     }


### PR DESCRIPTION
This new configuration has been introduced with Composer 2.2: https://github.com/composer/composer/releases/tag/2.2.0-RC1