### PR TITLE
Fix link to hautelook/alice-bundle repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For more information, refer to [the documentation](#table-of-contents).
 
 ### Symfony
 
-- [hautelook/AliceBundle](https://github.com/hautelook/AliceBundle)
+- [hautelook/AliceBundle](https://github.com/theofidry/AliceBundle)
 - [h4cc/AliceFixturesBundle](https://github.com/h4cc/AliceFixturesBundle)
 - [knplabs/rad-fixtures-load](https://github.com/KnpLabs/rad-fixtures-load)
 


### PR DESCRIPTION
The hautelook repository has been removed, a fork is maintained at https://github.com/theofidry/AliceBundle.