### PR TITLE
Add support for newlines in `identity()`

### DIFF
--- a/fixtures/Integration/identity_newlines.yml
+++ b/fixtures/Integration/identity_newlines.yml
@@ -1,0 +1,78 @@
+stdClass:
+    dummy:
+        newlinesReplacedWithSpaces: >
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-01',
+                )
+            )>
+
+
+        newlinesReplacedWithSpacesNoNewlineAtEnd: >-
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-02',
+                )
+            )>
+
+
+        newlinesReplacedWithSpacesAllNewlinesFromEnd: >+
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-03',
+                )
+            )>
+
+
+        newlinesKept: |
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-04',
+                )
+            )>
+
+
+        newlinesKeptNoNewlineAtEnd: |-
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-05',
+                )
+            )>
+
+
+        newlinesKeptAllNewlinesFromEnd: |+
+
+            <(
+                new DateTime(
+                    '2022'
+
+                    .'-01'
+
+                    .'-06',
+                )
+            )>

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/SimpleParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/SimpleParser.php
@@ -58,6 +58,18 @@ final class SimpleParser implements ParserInterface
             $parsedTokens = $this->parseToken($parsedTokens, $this->tokenParser, $token);
         }
 
+        if (count($parsedTokens) > 1) {
+            $first = reset($parsedTokens);
+            if (is_string($first) && trim($first) === '') {
+                array_shift($parsedTokens);
+            }
+
+            $last = end($parsedTokens);
+            if (is_string($last) && trim($last) === '') {
+                array_pop($parsedTokens);
+            }
+        }
+
         return (1 === count($parsedTokens))
             ? $parsedTokens[0]
             : new ListValue($parsedTokens)

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/FunctionTokenParser.php
@@ -34,7 +34,7 @@ final class FunctionTokenParser implements ChainableTokenParserInterface, Parser
     use IsAServiceTrait;
 
     /** @private */
-    const REGEX = '/^<(?<function>(.|\r?\n)+?)\((?<arguments>.*)\)>$/';
+    const REGEX = '/^\s*<(?<function>(.|\r?\n)+?)\((?<arguments>.*)\)>\s*$/s';
 
     /**
      * @var ArgumentEscaper

--- a/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
+++ b/src/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParser.php
@@ -69,7 +69,7 @@ final class IdentityTokenParser implements ChainableTokenParserInterface, Parser
     public function parse(Token $token)
     {
         $value = $this->tokenizer->detokenize($token->getValue());
-        $realValue = preg_replace('/^<\((.*)\)>$/', '<identity($1)>', $value);
+        $realValue = preg_replace('/^<\((.*)\)>$/s', '<identity($1)>', $value);
 
         return $this->decoratedTokenParser->parse(
             new Token($realValue, new TokenType(TokenType::FUNCTION_TYPE))

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/ParserIntegrationTest.php
@@ -746,14 +746,11 @@ class ParserIntegrationTest extends TestCase
         ];
         yield '[Optional] complete with superfluous space' => [
             '80%?  Y :  Z  ',
-            new ListValue([
-                new OptionalValue(
-                    '80',
-                    'Y',
-                    'Z'
-                ),
-                '  ',
-            ]),
+            new OptionalValue(
+                '80',
+                'Y',
+                'Z'
+            ),
         ];
         yield '[Optional] complete with negative number' => [
             '-50%? Y: Z',

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/SimpleParserTest.php
@@ -83,6 +83,35 @@ class SimpleParserTest extends TestCase
         $tokenParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(2);
     }
 
+    public function testIfTheLexProcessReturnsATokensSurroundedWithSpacesTheTrimsTheSpaces(): void
+    {
+        $value = 'foo';
+
+        $lexerProphecy = $this->prophesize(LexerInterface::class);
+        $lexerProphecy->lex($value)->willReturn([
+            $token1 = new Token("\n", new TokenType(TokenType::STRING_TYPE)),
+            $token2 = new Token('foo', new TokenType(TokenType::VARIABLE_TYPE)),
+            $token3 = new Token("\n", new TokenType(TokenType::STRING_TYPE)),
+        ]);
+        /** @var LexerInterface $lexer */
+        $lexer = $lexerProphecy->reveal();
+
+        $tokenParserProphecy = $this->prophesize(TokenParserInterface::class);
+        $tokenParserProphecy->parse($token1)->willReturn("\n");
+        $tokenParserProphecy->parse($token2)->willReturn('parsed_foo');
+        $tokenParserProphecy->parse($token3)->willReturn("\n");
+        /** @var TokenParserInterface $tokenParser */
+        $tokenParser = $tokenParserProphecy->reveal();
+
+        $parser = new SimpleParser($lexer, $tokenParser);
+        $parsedValue = $parser->parse($value);
+
+        static::assertEquals(
+            'parsed_foo',
+            $parsedValue
+        );
+    }
+
     public function testIfTheLexProcessReturnsMultipleTokensThenTheValueReturnedWillBeAListValue(): void
     {
         $value = 'foo';

--- a/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
+++ b/tests/FixtureBuilder/ExpressionLanguage/Parser/TokenParser/Chainable/IdentityTokenParserTest.php
@@ -69,4 +69,26 @@ class IdentityTokenParserTest extends TestCase
 
         $decoratedParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
     }
+
+    public function testSupportNewlines(): void
+    {
+        $token = new Token("<(new DateTime(\n    '2021-12-29',\n))>", new TokenType(TokenType::IDENTITY_TYPE));
+
+        $decoratedParserProphecy = $this->prophesize(ChainableTokenParserInterface::class);
+        $decoratedParserProphecy
+            ->parse(
+                new Token("<identity(new DateTime(\n    '2021-12-29',\n))>", new TokenType(TokenType::FUNCTION_TYPE))
+            )
+            ->willReturn($expected = 'foo')
+        ;
+        /** @var ChainableTokenParserInterface $decoratedParser */
+        $decoratedParser = $decoratedParserProphecy->reveal();
+
+        $parser = new IdentityTokenParser($decoratedParser);
+        $actual = $parser->parse($token);
+
+        static::assertEquals($expected, $actual);
+
+        $decoratedParserProphecy->parse(Argument::any())->shouldHaveBeenCalledTimes(1);
+    }
 }

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Loader;
 
+use DateTime;
 use DateTimeInterface;
 use InvalidArgumentException;
 use LogicException;
@@ -1548,6 +1549,26 @@ class LoaderIntegrationTest extends TestCase
 
         static::assertNotSame($dummy1, $dummy2);
         static::assertSame($dummy2, $dummy1->sibling);
+    }
+
+    public function testNewlinesInIdentity(): void
+    {
+        $objects = $this->loader->loadFile(self::FIXTURES_FILES_DIR.'/identity_newlines.yml')->getObjects();
+
+        $expected = new stdClass();
+        $expected->newlinesReplacedWithSpaces = new DateTime('2022-01-01');
+        $expected->newlinesReplacedWithSpacesNoNewlineAtEnd = new DateTime('2022-01-02');
+        $expected->newlinesReplacedWithSpacesAllNewlinesFromEnd = new DateTime('2022-01-03');
+        $expected->newlinesKept = new DateTime('2022-01-04');
+        $expected->newlinesKeptNoNewlineAtEnd = new DateTime('2022-01-05');
+        $expected->newlinesKeptAllNewlinesFromEnd = new DateTime('2022-01-06');
+
+        static::assertEquals(
+            [
+                'dummy' => $expected,
+            ],
+            $objects
+        );
     }
 
     public function provideFixturesToInstantiate()


### PR DESCRIPTION
This PR allows writing complex `<identity()>` expressions in a more readable way, e.g.:

```yaml
Foo:
  foo:
    __construct: <(new Some(new Very(new Complex(new Expression(), new With(), new Many(), new Arguments())))>
```

can become

```yaml
Foo:
  foo:
    __construct: |
      <(new Some(
        new Very(
          new Complex(
            new Expression(),
          ),
          new With(),
          new Many(),
          new Arguments(),
        ),
      ))>
```

I focused on `<identity()>`. Are there other kind of values I overlooked that would conflict with this? Or that could benefit from newlines support as well?