### PR TITLE
Silence deprecation warning on `ObjectBag::getIterator` method

### DIFF
--- a/src/ObjectBag.php
+++ b/src/ObjectBag.php
@@ -123,7 +123,8 @@ final class ObjectBag implements IteratorAggregate, Countable
     {
         return count($this->objects);
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->objects);


### PR DESCRIPTION
On PHP 8.1.7, Sentry captures the following deprecation error with the latest `nelmio/alice` version:

> Deprecated: Return type of Nelmio\Alice\ObjectBag::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice