### PR TITLE
Add support for enum in symfony property accessor hydrator

### DIFF
--- a/fixtures/Entity/DummyWithEnum.php
+++ b/fixtures/Entity/DummyWithEnum.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity;
+
+use Nelmio\Alice\Entity\Enum\DummyEnum;
+
+class DummyWithEnum
+{
+    private DummyEnum $dummyEnum;
+
+    public function setDummyEnum(DummyEnum $dummyEnum): void
+    {
+        $this->dummyEnum = $dummyEnum;
+    }
+
+    public function getDummyEnum(): DummyEnum
+    {
+        return $this->dummyEnum;
+    }
+}

--- a/fixtures/Entity/Enum/DummyEnum.php
+++ b/fixtures/Entity/Enum/DummyEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Alice package.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Nelmio\Alice\Entity\Enum;
+
+enum DummyEnum: string
+{
+    case Case1 = 'case1';
+    case Case2 = 'case2';
+}

--- a/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
+++ b/src/Generator/Hydrator/Property/SymfonyPropertyAccessorHydrator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nelmio\Alice\Generator\Hydrator\Property;
 
+use function enum_exists;
 use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Generator\GenerationContext;
@@ -24,6 +25,10 @@ use Nelmio\Alice\Throwable\Exception\Generator\Hydrator\HydrationExceptionFactor
 use Nelmio\Alice\Throwable\Exception\Generator\Hydrator\InaccessiblePropertyException;
 use Nelmio\Alice\Throwable\Exception\Generator\Hydrator\InvalidArgumentException;
 use Nelmio\Alice\Throwable\Exception\Generator\Hydrator\NoSuchPropertyException;
+use ReflectionEnum;
+use ReflectionException;
+use ReflectionProperty;
+use ReflectionType;
 use Symfony\Component\PropertyAccess\Exception\AccessException as SymfonyAccessException;
 use Symfony\Component\PropertyAccess\Exception\ExceptionInterface as SymfonyPropertyAccessException;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
@@ -62,6 +67,14 @@ final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
         } catch (SymfonyAccessException $exception) {
             throw HydrationExceptionFactory::createForInaccessibleProperty($object, $property, 0, $exception);
         } catch (SymfonyInvalidArgumentException $exception) {
+            // as a fallback check if the property might be an enum
+            if (
+                null !== ($enumType = self::getEnumType($instance, $property))
+                && null !== $newProperty = self::castValueToEnum($enumType, $property)
+            ) {
+                return $this->hydrate($object, $newProperty, $context);
+            }
+
             throw HydrationExceptionFactory::createForInvalidProperty($object, $property, 0, $exception);
         } catch (SymfonyPropertyAccessException $exception) {
             throw HydrationExceptionFactory::create($object, $property, 0, $exception);
@@ -70,5 +83,38 @@ final class SymfonyPropertyAccessorHydrator implements PropertyHydratorInterface
         }
 
         return new SimpleObject($object->getId(), $instance);
+    }
+
+    private static function getEnumType($instance, Property $property): ?ReflectionType
+    {
+        try {
+            $enumType = (new ReflectionProperty($instance, $property->getName()))->getType();
+        } catch (ReflectionException) {
+            // property might not exist
+            return null;
+        }
+
+        if (null === $enumType) {
+            // might not have a type
+            return null;
+        }
+
+        if (!enum_exists($enumType->getName())) {
+            // might not be an enum
+            return null;
+        }
+
+        return $enumType;
+    }
+
+    private static function castValueToEnum(ReflectionType $enumType, Property $property): ?Property
+    {
+        foreach ((new ReflectionEnum($enumType->getName()))->getCases() as $reflectionCase) {
+            if ($property->getValue() === $reflectionCase->getValue()->value ?? $reflectionCase->getValue()->name) {
+                return $property->withValue($reflectionCase->getValue());
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -17,6 +17,8 @@ use Nelmio\Alice\Definition\Object\SimpleObject;
 use Nelmio\Alice\Definition\Property;
 use Nelmio\Alice\Dummy as NelmioDummy;
 use Nelmio\Alice\Entity\DummyWithDate;
+use Nelmio\Alice\Entity\DummyWithEnum;
+use Nelmio\Alice\Entity\Enum\DummyEnum;
 use Nelmio\Alice\Entity\Hydrator\Dummy;
 use Nelmio\Alice\Generator\GenerationContext;
 use Nelmio\Alice\Generator\Hydrator\PropertyHydratorInterface;
@@ -49,7 +51,7 @@ class SymfonyPropertyAccessorHydratorTest extends TestCase
      * @var PropertyAccessorInterface
      */
     private $propertyAccessor;
-    
+
     protected function setUp(): void
     {
         $this->propertyAccessor = new PropertyAccessor();
@@ -141,6 +143,35 @@ class SymfonyPropertyAccessorHydratorTest extends TestCase
         } catch (InvalidArgumentException $exception) {
             static::assertEquals(
                 'Invalid value given for the property "immutableDateTime" of the object "dummy" (class: Nelmio\Alice\Entity\DummyWithDate).',
+                $exception->getMessage()
+            );
+            static::assertEquals(0, $exception->getCode());
+            static::assertNotNull($exception->getPrevious());
+        }
+    }
+
+    public function testReturnsHydratedObjectWithEnum(): void
+    {
+        $object = new SimpleObject('dummy', new DummyWithEnum());
+        $property = new Property('dummyEnum', 'case1');
+
+        $result = $this->hydrator->hydrate($object, $property, new GenerationContext());
+
+        static::assertEquals(DummyEnum::Case1, $result->getInstance()->getDummyEnum());
+    }
+
+    public function testThrowsInvalidArgumentExceptionIfEnumCaseIsNotFound(): void
+    {
+        try {
+            $object = new SimpleObject('dummy', new DummyWithEnum());
+            $property = new Property('dummyEnum', 'case3');
+
+            $this->hydrator->hydrate($object, $property, new GenerationContext());
+
+            static::fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            static::assertEquals(
+                'Invalid value given for the property "dummyEnum" of the object "dummy" (class: Nelmio\Alice\Entity\DummyWithEnum).',
                 $exception->getMessage()
             );
             static::assertEquals(0, $exception->getCode());


### PR DESCRIPTION
We're using enums for some properties, and for the fixtures to work we had to do a workaround because it was trying to set a string.

The workaround was basically to convert the enum value to an enum (which we assume is correct, else it should fail)
```php
    public function setDummyEnum(DummyEnum|string $dummyEnum): void
    {
        if (is_string($dummyEnum)) {
            // alice fixture
            $dummyEnum = DummyEnum::from($dummyEnum);
        }

        $this->dummyEnum = $dummyEnum;
    }
```

Today I thought enough was enough, we needed a better solution since they were becoming more and more.

I'm not sure if that's where the fix should go, but that's where the exception was happening, so it was a good starting place.

Tested in a big project with no issues.