### PR TITLE
Add support for sebastian/comparator 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "fakerphp/faker": "^1.10",
         "myclabs/deep-copy": "^1.10",
-        "sebastian/comparator": "^3.0 || ^4.0",
+        "sebastian/comparator": "^3.0 || ^4.0 || ^5.0",
         "symfony/property-access": "^5.4 || ^6.0",
         "symfony/yaml": "^5.4 || ^6.0"
     },


### PR DESCRIPTION
With phpunit/phpunit 10.0 release, sebastian/comparator was updated to 5.0.0.  
To migrate project with this new version, alice package should support this new version.