### PR TITLE
shift monthly schedule later in the night

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     push:
         branches: [ master, main ]
     schedule:
-        - cron: '0 0 1 * *'
+        - cron: '45 4 1 * *'
 
 jobs:
     tests:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -5,7 +5,7 @@ on:
     push:
         branches: [ master, main ]
     schedule:
-        - cron: '0 0 1 * *'
+        - cron: '45 4 1 * *'
 
 jobs:
     php-cs-fixer:


### PR DESCRIPTION
Follow-up of:

- #1140

Unless you want the result at midnight, we can change the schedule to a different time.

This is [suggested by GitHub](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule):

> Note: The `schedule` event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour.

[Source](https://github.com/orgs/community/discussions/52477#discussioncomment-5580518)