### PR TITLE
cs: Revert the static closure changes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,6 +45,7 @@ $config = new FidryConfig(
 $config->addRules([
     'php_unit_method_casing' => ['case' => 'camel_case'],
     'phpdoc_no_empty_return' => false,
+    'static_lambda' => false,
 ]);
 
 $config->setFinder($finder);

--- a/src/PropertyAccess/ReflectionPropertyAccessor.php
+++ b/src/PropertyAccess/ReflectionPropertyAccessor.php
@@ -55,7 +55,7 @@ final class ReflectionPropertyAccessor implements PropertyAccessorInterface
             }
 
             $setPropertyClosure = Closure::bind(
-                static function ($object) use ($propertyPath, $value): void {
+                function ($object) use ($propertyPath, $value): void {
                     $object->{$propertyPath} = $value;
                 },
                 $objectOrArray,
@@ -83,7 +83,7 @@ final class ReflectionPropertyAccessor implements PropertyAccessorInterface
             }
 
             $getPropertyClosure = Closure::bind(
-                static fn ($object) => $object->{$propertyPath},
+                fn ($object) => $object->{$propertyPath},
                 $objectOrArray,
                 $objectOrArray,
             );

--- a/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/Chainable/ChainableDenormalizerTest.php
@@ -102,7 +102,7 @@ abstract class ChainableDenormalizerTest extends TestCase
         $decoratedDenormalizerProphecy
             ->denormalize(Argument::cetera())
             ->will(
-                static fn ($args) => $args[0]->with(FixtureFactory::create($args[2], '')),
+                fn ($args) => $args[0]->with(FixtureFactory::create($args[2], '')),
             );
 
         return $decoratedDenormalizerProphecy->reveal();

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Arguments/SimpleArgumentsDenormalizerTest.php
@@ -55,7 +55,7 @@ class SimpleArgumentsDenormalizerTest extends TestCase
 
         $valueDenormalizerProphecy = $this->prophesize(ValueDenormalizerInterface::class);
         $valueDenormalizerProphecy->denormalize(Argument::cetera())->will(
-            static fn ($args) => $args[2],
+            fn ($args) => $args[2],
         );
         /** @var ValueDenormalizerInterface $valueDenormalizer */
         $valueDenormalizer = $valueDenormalizerProphecy->reveal();
@@ -81,7 +81,7 @@ class SimpleArgumentsDenormalizerTest extends TestCase
         $flagParserProphecy
             ->parse(Argument::any())
             ->will(
-                static function ($args) {
+                function ($args) {
                     preg_match('/(?<val>.+?)\s\(.+\)/', $args[0], $matches);
 
                     return new FlagBag($matches['val']);
@@ -92,7 +92,7 @@ class SimpleArgumentsDenormalizerTest extends TestCase
 
         $valueDenormalizerProphecy = $this->prophesize(ValueDenormalizerInterface::class);
         $valueDenormalizerProphecy->denormalize(Argument::cetera())->will(
-            static fn ($args) => $args[2],
+            fn ($args) => $args[2],
         );
         /** @var ValueDenormalizerInterface $valueDenormalizer */
         $valueDenormalizer = $valueDenormalizerProphecy->reveal();

--- a/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
+++ b/tests/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Calls/CallsWithFlagsDenormalizerTest.php
@@ -133,7 +133,7 @@ class CallsWithFlagsDenormalizerTest extends TestCase
         /** @var CallsDenormalizerInterface $callsDenormalizer */
         $callsDenormalizer = $callsDenormalizerProphecy->reveal();
 
-        $returnMethodUnchanged = static fn (array $args) => $args[0];
+        $returnMethodUnchanged = fn (array $args) => $args[0];
 
         $dummyFlagMethodHandlerProphecy = $this->prophesize(MethodFlagHandler::class);
         $dummyFlagMethodHandlerProphecy

--- a/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
+++ b/tests/Generator/Resolver/Parameter/Chainable/RecursiveParameterResolverTest.php
@@ -288,7 +288,7 @@ class RecursiveParameterResolverTest extends TestCase
         $decoratedResolverProphecy
             ->resolve(Argument::cetera())
             ->will(
-                static function ($args) {
+                function ($args) {
                     $hash = spl_object_hash($args[0]);
 
                     return new ParameterBag(['foo' => uniqid($hash)]);

--- a/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
+++ b/tests/Generator/Resolver/Value/Chainable/FixtureMethodCallReferenceResolverTest.php
@@ -150,7 +150,7 @@ class FixtureMethodCallReferenceResolverTest extends TestCase
             $error = new Error();
             $dummyProphecy = $this->prophesize(DummyWithGetter::class);
             $dummyProphecy->getFoo()->will(
-                static function () use ($error): void {
+                function () use ($error): void {
                     throw $error;
                 },
             );

--- a/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
+++ b/tests/PropertyAccess/ReflectionPropertyAccessorTest.php
@@ -160,7 +160,7 @@ class ReflectionPropertyAccessorTest extends TestCase
         $decoratedAccessorProphecy
             ->setValue($object, $property, $value)
             ->will(
-                static function ($args): void {
+                function ($args): void {
                     $args[0]->{$args[1]} = $args[2];
                 },
             );

--- a/tests/PropertyAccess/StdPropertyAccessorTest.php
+++ b/tests/PropertyAccess/StdPropertyAccessorTest.php
@@ -69,7 +69,7 @@ class StdPropertyAccessorTest extends TestCase
         $decoratedAccessorProphecy
             ->setValue($object, $property, $value)
             ->will(
-                static function ($args): void {
+                function ($args): void {
                     $args[0]->{$args[1]} = $args[2];
                 },
             );
@@ -116,7 +116,7 @@ class StdPropertyAccessorTest extends TestCase
         $decoratedAccessorProphecy
             ->getValue($object, $property)
             ->will(
-                static fn ($args) => $args[0]->{$args[1]},
+                fn ($args) => $args[0]->{$args[1]},
             );
         /** @var PropertyAccessorInterface $decoratedAccessor */
         $decoratedAccessor = $decoratedAccessorProphecy->reveal();


### PR DESCRIPTION
Reverts the `static_lambda` rule introduced in #1150 as this breaks a few things.