### PR TITLE
Fix deprecations

### DIFF
--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizer.php
@@ -37,7 +37,7 @@ final class SimpleValueDenormalizer implements ValueDenormalizerInterface
         $this->parser = $parser;
     }
 
-    public function denormalize(FixtureInterface $scope, ?FlagBag $flags = null, $value)
+    public function denormalize(FixtureInterface $scope, ?FlagBag $flags, $value)
     {
         if (is_string($value)) {
             return $this->parseValue($this->parser, $value);

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizer.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizer.php
@@ -44,7 +44,7 @@ final class UniqueValueDenormalizer implements ValueDenormalizerInterface
      * @param  mixed                 $value
      * @throws InvalidScopeException
      */
-    public function denormalize(FixtureInterface $scope, ?FlagBag $flags = null, $value)
+    public function denormalize(FixtureInterface $scope, ?FlagBag $flags, $value)
     {
         $value = $this->denormalizer->denormalize($scope, $flags, $value);
 

--- a/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/ValueDenormalizerInterface.php
+++ b/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/ValueDenormalizerInterface.php
@@ -30,5 +30,5 @@ interface ValueDenormalizerInterface
      *
      * @return ValueInterface|mixed
      */
-    public function denormalize(FixtureInterface $scope, ?FlagBag $flags = null, $value);
+    public function denormalize(FixtureInterface $scope, ?FlagBag $flags, $value);
 }

--- a/src/Generator/Resolver/Parameter/Chainable/StringParameterResolver.php
+++ b/src/Generator/Resolver/Parameter/Chainable/StringParameterResolver.php
@@ -89,7 +89,7 @@ final class StringParameterResolver implements ChainableParameterResolverInterfa
      * @param string    $key       Key of the parameter that need to be resolved to resolve $parameter
      */
     private function resolveStringKey(
-        ?ParameterResolverInterface $resolver = null,
+        ?ParameterResolverInterface $resolver,
         Parameter $parameter,
         string $key,
         ParameterBag $unresolvedParameters,


### PR DESCRIPTION
This PR fixes the below deprecations:

```
Deprecated: Optional parameter $resolver declared before required parameter $context is implicitly treated as a required parameter in /srv/api/vendor/nelmio/alice/src/Generator/Resolver/Parameter/Chainable/StringParameterResolver.php on line 91

Deprecated: Optional parameter $flags declared before required parameter $value is implicitly treated as a required parameter in /srv/api/vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/UniqueValueDenormalizer.php on line 47

Deprecated: Optional parameter $flags declared before required parameter $value is implicitly treated as a required parameter in /srv/api/vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/ValueDenormalizerInterface.php on line 33

Deprecated: Optional parameter $flags declared before required parameter $value is implicitly treated as a required parameter in /srv/api/vendor/nelmio/alice/src/FixtureBuilder/Denormalizer/Fixture/SpecificationBagDenormalizer/Value/SimpleValueDenormalizer.php on line 40
```


note: This can't be a BC break as the parameter is required (see the PHP deprecation message, and also [POC ](https://3v4l.org/hQGE7) )