### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NelmioAliceExtension.php
@@ -17,9 +17,9 @@ use Faker\Provider\Base as BaseFakerProvider;
 use InvalidArgumentException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @private


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component. As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1.
As this bundle does not rely on the extra feature, it can use the base class from DI directly.