### PR TITLE
Explicit Error Message For Missing Properties During Hydration

### DIFF
--- a/src/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactory.php
+++ b/src/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactory.php
@@ -84,7 +84,7 @@ final class HydrationExceptionFactory
     ): NoSuchPropertyException {
         return new NoSuchPropertyException(
             sprintf(
-                'Could not hydrate the property "%s" of the object "%s" (class: %s).',
+                'Could not hydrate the property "%s" of the object "%s", as the property does not exist (class: %s).',
                 $property->getName(),
                 $object->getId(),
                 get_class($object->getInstance()),

--- a/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
+++ b/tests/Generator/Hydrator/Property/SymfonyPropertyAccessorHydratorTest.php
@@ -124,7 +124,7 @@ class SymfonyPropertyAccessorHydratorTest extends TestCase
             self::fail('Expected exception to be thrown.');
         } catch (NoSuchPropertyException $exception) {
             self::assertEquals(
-                'Could not hydrate the property "foo" of the object "dummy" (class: Nelmio\Alice\Dummy).',
+                'Could not hydrate the property "foo" of the object "dummy", as the property does not exist (class: Nelmio\Alice\Dummy).',
                 $exception->getMessage(),
             );
             self::assertEquals(0, $exception->getCode());

--- a/tests/Loader/LoaderIntegrationTest.php
+++ b/tests/Loader/LoaderIntegrationTest.php
@@ -2266,7 +2266,7 @@ class LoaderIntegrationTest extends TestCase
                     ],
                 ],
             ],
-            'An error occurred while generating the fixture "dummy" (Nelmio\Alice\Entity\Hydrator\SnakeCaseDummy): Could not hydrate the property "setter_property" of the object "dummy" (class: Nelmio\Alice\Entity\Hydrator\SnakeCaseDummy).',
+            'An error occurred while generating the fixture "dummy" (Nelmio\Alice\Entity\Hydrator\SnakeCaseDummy): Could not hydrate the property "setter_property" of the object "dummy", as the property does not exist (class: Nelmio\Alice\Entity\Hydrator\SnakeCaseDummy).',
             GenerationThrowable::class,
         ];
 

--- a/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactoryTest.php
+++ b/tests/Throwable/Exception/Generator/Hydrator/HydrationExceptionFactoryTest.php
@@ -99,7 +99,7 @@ class HydrationExceptionFactoryTest extends TestCase
 
         $exception = HydrationExceptionFactory::createForCouldNotHydrateObjectWithProperty($object, $property);
         self::assertEquals(
-            'Could not hydrate the property "foo" of the object "dummy" (class: stdClass).',
+            'Could not hydrate the property "foo" of the object "dummy", as the property does not exist (class: stdClass).',
             $exception->getMessage(),
         );
         self::assertEquals(0, $exception->getCode());
@@ -110,7 +110,7 @@ class HydrationExceptionFactoryTest extends TestCase
 
         $exception = HydrationExceptionFactory::createForCouldNotHydrateObjectWithProperty($object, $property, $code, $previous);
         self::assertEquals(
-            'Could not hydrate the property "foo" of the object "dummy" (class: stdClass).',
+            'Could not hydrate the property "foo" of the object "dummy", as the property does not exist (class: stdClass).',
             $exception->getMessage(),
         );
         self::assertEquals($code, $exception->getCode());


### PR DESCRIPTION
Before:
<img width="1652" alt="image" src="https://github.com/user-attachments/assets/1be9a51f-17f3-4755-a374-ac8131a520d6">
After:
<img width="1651" alt="image" src="https://github.com/user-attachments/assets/78cc5c5d-c716-48ac-84c8-1fc53ee5e99a">
