### PR TITLE
fix nondeterminism in OptionalMethodCallProcessor

### DIFF
--- a/src/Loader/NativeLoader.php
+++ b/src/Loader/NativeLoader.php
@@ -633,7 +633,7 @@ class NativeLoader implements FilesLoaderInterface, FileLoaderInterface, DataLoa
         return new CallProcessorRegistry([
             new ConfiguratorMethodCallProcessor(),
             new MethodCallWithReferenceProcessor(),
-            new OptionalMethodCallProcessor(),
+            new OptionalMethodCallProcessor(null, $this->getFakerGenerator()),
             new SimpleMethodCallProcessor(),
         ]);
     }


### PR DESCRIPTION
An optional method call (`__calls : [ setLocation (80%?): [40.689269, -74.044737] ]`) would be resolved using an external source of randomness, rather than the FakerGenerator instance used by all other value generators, resulting in nondeterministic behavior.

We're making the generator an optional parameter to OptionalMethodCallProcessor and falling back to random_int for backwards-compatibility. This can be made non nullable in a next major release.

(Also see OptionalValueResolver, this is handled in the same way there https://github.com/nelmio/alice/blob/a7e15b08a64d4f6fb64b4c3b58bd6a710f71050e/src/Generator/Resolver/Value/Chainable/OptionalValueResolver.php#L101-L103)

Fixes gh-1230