### PR TITLE
EvaluatedValueResolver: to work with arrays

### DIFF
--- a/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
+++ b/src/Generator/Resolver/Value/Chainable/EvaluatedValueResolver.php
@@ -105,6 +105,6 @@ final class EvaluatedValueResolver implements ChainableValueResolverInterface
      */
     private function replacePlaceholders(string $expression): string
     {
-        return preg_replace('/(@(?<id>[^ @\-]+))/', '\$_instances[\'$2\']', $expression);
+        return preg_replace('/(@(?<id>[^ @\-,\]]+))/', '\$_instances[\'$2\']', $expression);
     }
 }


### PR DESCRIPTION
'<(new SomeObject([@entity1,@entity2]))>'
For now processing of such syntax is broken. Let's give it a chanse.