### PR TITLE
Add support for sebastian/comparator 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.2",
         "fakerphp/faker": "^1.10",
         "myclabs/deep-copy": "^1.10",
-        "sebastian/comparator": "^6.0 || ^7.0",
+        "sebastian/comparator": "^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php84": "^1.31",
         "symfony/property-access": "^7.4 || ^8.0",
         "symfony/yaml": "^7.4 || ^8.0"
@@ -32,7 +32,7 @@
         "bamarni/composer-bin-plugin": "^1.8.1",
         "phpspec/prophecy": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^11 || ^12.5",
+        "phpunit/phpunit": "^11 || ^12.5 || ^13",
         "symfony/config": "^7.4 || ^8.0",
         "symfony/dependency-injection": "^7.4 || ^8.0",
         "symfony/finder": "^7.4 || ^8.0",


### PR DESCRIPTION
This allows being compatible with projects using phpunit 13.

Note that I increased the phpunit range to actually have CI jobs installing those newer `sebastian/comparator` version (as each major version of PHPUnit is tied to a single major version of `sebastian/comparator`)

Closes #1355